### PR TITLE
Bring TALs in correctly into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apk add rsync
 # Prepare a directory for TALs
 RUN mkdir -p /root/.rpki-cache/tals
 
-VOLUME ["/root/.rpki-cache/tals"]
+# Copy over TALs from source
+COPY --from=build /tmp/routinator/tals/*.tal /root/.rpki-cache/tals/
+
 EXPOSE 3323/tcp
 CMD ["routinator","-r","-l","0.0.0.0:3323"]

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ the dummy arin.tal file that is shipped with Routinator.
 sudo mkdir -p /etc/routinator/tals
 # Fetch the ARIN TAL (after agreeing to the distribution terms as described above)
 sudo wget https://www.arin.net/resources/rpki/arin-rfc7730.tal -P /etc/routinator/tals
-# Launch a detached container named 'routinator' (will listen on 0.0.0.0:3323 and expose that port by default)
-sudo docker run -d --name routinator -v /etc/routinator/tals/arin-rfc7730.tal:/root/.rpki-cache/tals/arin.tal nlnetlabs/routinator
+# Launch a detached container named 'routinator' (will listen on 0.0.0.0:3323 and expose that port)
+sudo docker run -d --name routinator -p 3323:3323 -v /etc/routinator/tals/arin-rfc7730.tal:/root/.rpki-cache/tals/arin.tal nlnetlabs/routinator
 ```
 
 ## RPKI

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ is necessary to first review and agree to the ARIN TAL terms available at
 https://www.arin.net/resources/rpki/tal.html
 
 The ARIN TAL RFC 7730 format file available at that URL will then need to
-be downloaded and placed in a volume mounted into the docker container.
+be downloaded and mounted into the docker container as a replacement for
+the dummy arin.tal file that is shipped with Routinator.
 
 ```bash
 # Create a local directory for the rpki cache
 sudo mkdir -p /etc/routinator/tals
 # Fetch the ARIN TAL (after agreeing to the distribution terms as described above)
 sudo wget https://www.arin.net/resources/rpki/arin-rfc7730.tal -P /etc/routinator/tals
-# Launch detached container (will listen on 0.0.0.0:3323 and expose that port by default)
-sudo docker run -d -v /etc/routinator/tals:/root/.rpki-cache/tals nlnetlabs/routinator
+# Launch a detached container named 'routinator' (will listen on 0.0.0.0:3323 and expose that port by default)
+sudo docker run -d --name routinator -v /etc/routinator/tals/arin-rfc7730.tal:/root/.rpki-cache/tals/arin.tal nlnetlabs/routinator
 ```
 
 ## RPKI


### PR DESCRIPTION
This corrects an omission in NLnetLabs/routinator#23 in regards to how routinator treats an existing TALs directory with only one TAL present (as a result of following ARIN TAL instructions). 

Instead, the TALs are now copied over from source during container build, and the instructions have been updated in a manner to facilitate overloading the shipped `arin.tal` file with the genuine article downloaded by the user from the ARIN website.

This leads to correct behavior in both absence of a correct `arin.tal` (error is displayed), as well as presence of downloaded file - and still allows the user to add TALs by mounting additional files into the tals directory.