### PR TITLE
Convert endian of serial in SerialNotify RTR PDU.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,12 @@ New
 
 Bug Fixes
 
+* Converts the endianess of the serial number in the SerialNotify RTR PDU.
+  Reported by Massimiliano Stucchi. [(#60)]
+
 Dependencies
+
+[(#60)]: https://github.com/NLnetLabs/routinator/pull/60
 
 
 ## 0.2.1 ‘Rated R’

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -77,7 +77,7 @@ impl SerialNotify {
     pub fn new(version: u8, session: u16, serial: u32) -> Self {
         SerialNotify {
             header: Header::new(version, Self::PDU, session, Self::LEN),
-            serial
+            serial: serial.to_be(),
         }
     }
 }


### PR DESCRIPTION
This PR adds the endian conversion when creating the SerialNotify RTR PDU so you get the correct serial.

Thanks to Massimiliano Stucchi for finding and reporting this bug!