### PR TITLE
markdown lint documentation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,6 @@
 
 Breaking Changes
 
-
 New
 
 * New output format `csvext` that mimics the output format of the Original
@@ -19,26 +18,21 @@ New
 
 * Log warnings for stale manifests and CRLs.
 
-
 Bug Fixes
 
 * Converts the endianess of the serial number in the SerialNotify RTR PDU.
   Reported by Massimiliano Stucchi. [(#60)]
-
 
 Dependencies
 
 * Docker build updated to Rust 1.32 and Alpine Linux 3.9. Thanks to David
   Monosov. [(#61)]
 
-
 [(#59)]: https://github.com/NLnetLabs/routinator/pull/59
 [(#60)]: https://github.com/NLnetLabs/routinator/pull/60
 [(#61)]: https://github.com/NLnetLabs/routinator/pull/61
 [(#62)]: https://github.com/NLnetLabs/routinator/pull/62
 [(#63)]: https://github.com/NLnetLabs/routinator/pull/63
-
-
 
 ## 0.2.1 ‘Rated R’
 
@@ -61,7 +55,6 @@ Bug Fixes
 [(#49)]: https://github.com/NLnetLabs/routinator/pull/49
 [(#54)]: https://github.com/NLnetLabs/routinator/pull/54
 [(#55)]: https://github.com/NLnetLabs/routinator/pull/55
-
 
 ## 0.2.0 ‘Instant Gezellig’
 
@@ -103,7 +96,6 @@ Performance Improvements
 * Caching of CRL serial numbers for CAs with large manifests leads to
   about half the validation time for the current repository. [(#34)]
 
-
 [(#21)]: https://github.com/NLnetLabs/routinator/pull/21
 [(#23)]: https://github.com/NLnetLabs/routinator/pull/23
 [(#27)]: https://github.com/NLnetLabs/routinator/pull/27
@@ -112,7 +104,6 @@ Performance Improvements
 [(#35)]: https://github.com/NLnetLabs/routinator/pull/35
 [(#41)]: https://github.com/NLnetLabs/routinator/pull/41
 [(#42)]: https://github.com/NLnetLabs/routinator/pull/42
-
 
 ## 0.1.2 ‘And I Cry If I Want To’
 
@@ -124,7 +115,6 @@ Bug Fixes
 
 [17]: https://github.com/NLnetLabs/routinator/issues/17
 
-
 ## 0.1.1 ‘Five-second Rule’
 
 Bug Fixes
@@ -133,8 +123,6 @@ Bug Fixes
 
 [15]: https://github.com/NLnetLabs/routinator/issues/15
 
-
 ## 0.1.0 ‘Godspeed!’
 
 Initial public release.
-

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Status](https://ci.appveyor.com/api/projects/status/github/NLnetLabs/routinator?
 [![](https://img.shields.io/badge/Spotify-∞-green.svg)](https://open.spotify.com/user/alex.band/playlist/1DkYwN4e4tq73LGAeUykA1?si=AXNn9GkpQ4a-q5skG1yiYQ)
 [![](https://img.shields.io/twitter/follow/routinator3000.svg?label=Follow&style=social)](https://twitter.com/routinator3000)
 
-Introducing ‘Routinator 3000,’ RPKI relying party software written in Rust. 
+Introducing ‘Routinator 3000,’ RPKI relying party software written in Rust.
 If you have any feedback, we would love to hear from you. Don’t hesitate to
 [create an issue on Github](https://github.com/NLnetLabs/routinator/issues/new)
 or post a message on our [RPKI mailing list](https://nlnetlabs.nl/mailman/listinfo/rpki).
-
 
 ## Quick Start
 
@@ -33,7 +32,6 @@ If you have an older version of the Routinator, you can update via
 ```bash
 cargo install -f routinator
 ```
-
 
 ## Quick Start with Docker
 
@@ -204,9 +202,7 @@ routinator man
 ```
 
 It is also available online on the
-[NLnetLabs documentation
-site](https://www.nlnetlabs.nl/documentation/rpki/routinator/).
-
+[NLnetLabs documentation site](https://www.nlnetlabs.nl/documentation/rpki/routinator/).
 
 ## Feeding a Router with RPKI-RTR
 
@@ -253,7 +249,6 @@ meaning can be found in the manual page. In addition, a complete sample
 configuration file showing all the default values can be found in the
 repository at [etc/routinator.conf](https://github.com/NLnetLabs/routinator/blob/master/etc/routinator.conf).
 
-
 ## Local Exceptions
 
 If you would like to add exceptions to the validated RPKI data in the
@@ -266,4 +261,3 @@ Routinator will re-read that file on every validation run, so you can
 simply update the file whenever your exceptions change.
 
 [SLURM]: https://tools.ietf.org/html/rfc8416
-


### PR DESCRIPTION
Gently lints a few stray new lines and trailing spaces from `README.md` and `Changelog.md` to increase pedantry quotient. Partially pacifies [markdownlint](https://github.com/markdownlint/markdownlint) where reasonable.