### PR TITLE
lint with clippy during travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ rust:
   - stable
   - beta
   - 1.30.0  # The minimal Rust version we claim we need.
-
+before_script:
+  # Get clippy-preview if clippy is not available for 1.30.0 not to break
+  - rustup component add clippy || rustup component add clippy-preview
+script:
+  - cargo clippy -- -D warnings
+  - cargo test --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,14 @@
 //!
 //! This crate contains all the moving parts of the Routinator. The
 //! application itself, via `main.rs` is only a very tiny frontend.
-#![allow(unknown_lints)] // Clippy for 1.30.
+
+// Clippy due to multi-versioning
+#![allow(renamed_and_removed_lints)]
+
+// Clippy for 1.30.
+#![allow(unknown_lints)]
+#![allow(needless_pass_by_value)]
+#![allow(map_clone)]
 
 extern crate bytes;
 extern crate chrono;


### PR DESCRIPTION
As one of the emergent implicit goals of this project turned out to be the introduction of rust-lang within the network engineering community, make use of the [rust-clippy](https://github.com/rust-lang/rust-clippy) linter to encourage rust best practices and code correctness.

Initially configured to only produce linter recommendations as part of travis build output, can be modified to fail the build when linter warnings appear after initial linting work is complete to encourage code correctness in PRs and keep contributors honest.