### PR TITLE
Properly compare RTR serial numbers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ New
 * Additional Prometheus metric `valid_roas` reporting the number of
   verified ROAs. Additionally, both metrics are now reported separately
   for each TAL. [(#78)]
+* Compare RTR serial numbers according to RFC 1932. [(#81)]
 
 Bug Fixes
 
@@ -29,6 +30,7 @@ Dependencies
 [(#76)]: https://github.com/NLnetLabs/routinator/pull/76
 [(#78)]: https://github.com/NLnetLabs/routinator/pull/78
 [(#80)]: https://github.com/NLnetLabs/routinator/pull/80
+[(#81)]: https://github.com/NLnetLabs/routinator/pull/81
 
 
 ## 0.3.0 ‘It’s More Fun at the Zoo’

--- a/src/rtr/mod.rs
+++ b/src/rtr/mod.rs
@@ -11,10 +11,12 @@
 
 pub use self::net::rtr_listener;
 pub use self::notify::NotifySender;
+pub use self::serial::Serial;
 
 mod pdu;
 mod net;
 mod notify;
 mod query;
 mod send;
+mod serial;
 

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -13,6 +13,7 @@ use tokio::io::{
     AsyncRead, AsyncWrite, ReadExact, WriteAll, read_exact, write_all
 };
 use ::origins::AddressOrigin;
+use super::serial::Serial;
 
 
 //------------ Macro for Common Impls ----------------------------------------
@@ -74,7 +75,7 @@ impl SerialNotify {
     pub const PDU: u8 = 0;
     pub const LEN: u32 = 12;
 
-    pub fn new(version: u8, session: u16, serial: u32) -> Self {
+    pub fn new(version: u8, session: u16, serial: Serial) -> Self {
         SerialNotify {
             header: Header::new(version, Self::PDU, session, Self::LEN),
             serial: serial.to_be(),
@@ -103,7 +104,7 @@ impl SerialQuery {
     pub const PDU: u8 = 1;
     pub const LEN: u32 = 12;
 
-    pub fn new(version: u8, session: u16, serial: u32) -> Self {
+    pub fn new(version: u8, session: u16, serial: Serial) -> Self {
         SerialQuery {
             header: Header::new(version, Self::PDU, session, 12),
             payload: SerialQueryPayload::new(serial),
@@ -118,7 +119,7 @@ impl SerialQuery {
         u16::from_be(self.header.session)
     }
 
-    pub fn serial(&self) -> u32 {
+    pub fn serial(&self) -> Serial {
         self.payload.serial()
     }
 }
@@ -135,14 +136,14 @@ pub struct SerialQueryPayload {
 }
 
 impl SerialQueryPayload {
-    pub fn new(serial: u32) -> Self {
+    pub fn new(serial: Serial) -> Self {
         SerialQueryPayload {
             serial: serial.to_be()
         }
     }
 
-    pub fn serial(&self) -> u32 {
-        u32::from_be(self.serial)
+    pub fn serial(&self) -> Serial {
+        Serial::from_be(self.serial)
     }
 }
 
@@ -402,7 +403,7 @@ impl EndOfData {
     pub fn new(
         version: u8,
         session: u16,
-        serial: u32,
+        serial: Serial,
         refresh: u32,
         retry: u32,
         expire: u32
@@ -453,7 +454,7 @@ pub struct EndOfDataV0 {
 
 #[allow(dead_code)]
 impl EndOfDataV0 {
-    pub fn new(session: u16, serial: u32) -> Self {
+    pub fn new(session: u16, serial: Serial) -> Self {
         EndOfDataV0 {
             header: Header::new(0, 7, session, 12),
             serial: serial.to_be()
@@ -468,8 +469,8 @@ impl EndOfDataV0 {
         u16::from_be(self.header.session)
     }
 
-    pub fn serial(&self) -> u32 {
-        u32::from_be(self.serial)
+    pub fn serial(&self) -> Serial {
+        Serial::from_be(self.serial)
     }
 }
 
@@ -494,7 +495,7 @@ impl EndOfDataV1 {
     pub fn new(
         version: u8,
         session: u16,
-        serial: u32,
+        serial: Serial,
         refresh: u32,
         retry: u32,
         expire: u32
@@ -516,8 +517,8 @@ impl EndOfDataV1 {
         u16::from_be(self.header.session)
     }
 
-    pub fn serial(&self) -> u32 {
-        u32::from_be(self.serial)
+    pub fn serial(&self) -> Serial {
+        Serial::from_be(self.serial)
     }
 
     pub fn refresh(&self) -> u32 {

--- a/src/rtr/query.rs
+++ b/src/rtr/query.rs
@@ -4,6 +4,7 @@ use std::io;
 use futures::{Async, Future, Stream};
 use tokio::io::{AsyncRead, ReadExact};
 use super::{notify, pdu};
+use super::serial::Serial;
 
 
 //------------ Query and Input -----------------------------------------------
@@ -11,7 +12,7 @@ use super::{notify, pdu};
 pub enum Query {
     Serial {
         session: u16,
-        serial: u32,
+        serial: Serial,
     },
     Reset,
     Error(pdu::BoxedError),

--- a/src/rtr/send.rs
+++ b/src/rtr/send.rs
@@ -7,6 +7,7 @@ use tokio::io::{AsyncWrite, WriteAll};
 use crate::config::Config;
 use crate::origins::{AddressOrigins, OriginsDiff};
 use super::pdu;
+use super::serial::Serial;
 
 
 //------------ Sender --------------------------------------------------------
@@ -20,7 +21,7 @@ pub enum Sender<A> {
 }
 
 impl<A: AsyncWrite> Sender<A> {
-    pub fn notify(sock: A, version: u8, session: u16, serial: u32) -> Self {
+    pub fn notify(sock: A, version: u8, session: u16, serial: Serial) -> Self {
         Sender::Notify(
             pdu::SerialNotify::new(version, session, serial).write(sock)
         )
@@ -48,7 +49,7 @@ impl<A: AsyncWrite> Sender<A> {
         sock: A,
         version: u8,
         session: u16,
-        serial: u32,
+        serial: Serial,
         current: Arc<AddressOrigins>,
         timing: Timing,
     ) -> Self {
@@ -113,7 +114,7 @@ impl<A: AsyncWrite, D> Wrapped<A, D> {
         sock: A,
         version: u8,
         session: u16,
-        serial: u32,
+        serial: Serial,
         iter: D,
         timing: Timing,
     ) -> Self {

--- a/src/rtr/serial.rs
+++ b/src/rtr/serial.rs
@@ -1,0 +1,206 @@
+//! Serial numbers.
+//!
+//! This module define a type [`Serial`] that wraps a `u32` to provide
+//! serial number arithmetics.
+//!
+//! [`Serial`]: struct.Serial.html
+
+use std::{cmp, fmt, hash, str};
+
+
+//------------ Serial --------------------------------------------------------
+
+/// A serial number.
+///
+/// Serial numbers are regular integers with a special notion for comparison
+/// in order to be able to deal with roll-over.
+///
+/// Specifically, addition and comparison are defined in [RFC 1982].
+/// Addition, however, is only defined for values up to `2^31 - 1`, so we
+/// decided to not implement the `Add` trait but rather have a dedicated
+/// method `add` so as to not cause surprise panics.
+/// 
+/// Serial numbers only implement a partial ordering. That is, there are
+/// pairs of values that are not equal but there still isn’t one value larger
+/// than the other. Since this is neatly implemented by the `PartialOrd`
+/// trait, the type implements that.
+///
+/// [RFC 1982]: https://tools.ietf.org/html/rfc1982
+#[derive(Clone, Copy, Debug)]
+pub struct Serial(pub u32);
+
+impl Serial {
+    pub fn from_be(value: u32) -> Self {
+        Serial(u32::from_be(value))
+    }
+
+    pub fn to_be(self) -> u32 {
+        self.0.to_be()
+    }
+
+    /// Add `other` to `self`.
+    ///
+    /// Serial numbers only allow values of up to `2^31 - 1` to be added to
+    /// them. Therefore, this method requires `other` to be a `u32` instead
+    /// of a `Serial` to indicate that you cannot simply add two serials
+    /// together. This is also why we don’t implement the `Add` trait.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `other` is greater than `2^31 - 1`.
+    #[allow(should_implement_trait)]
+    pub fn add(self, other: u32) -> Self {
+        assert!(other <= 0x7FFF_FFFF);
+        Serial(self.0.wrapping_add(other))
+    }
+}
+
+
+//--- From and FromStr
+
+impl From<u32> for Serial {
+    fn from(value: u32) -> Serial {
+        Serial(value)
+    }
+}
+
+impl From<Serial> for u32 {
+    fn from(serial: Serial) -> u32 {
+        serial.0
+    }
+}
+
+impl str::FromStr for Serial {
+    type Err = <u32 as str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        <u32 as str::FromStr>::from_str(s).map(Into::into)
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Serial {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+
+//--- PartialEq and Eq
+
+impl PartialEq for Serial {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl PartialEq<u32> for Serial {
+    fn eq(&self, other: &u32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl Eq for Serial { }
+
+
+//--- PartialOrd
+
+impl cmp::PartialOrd for Serial {
+    fn partial_cmp(&self, other: &Serial) -> Option<cmp::Ordering> {
+        if self.0 == other.0 {
+            Some(cmp::Ordering::Equal)
+        }
+        else if self.0 < other.0 {
+            let sub = other.0 - self.0;
+            if sub < 0x8000_0000 {
+                Some(cmp::Ordering::Less)
+            }
+            else if sub > 0x8000_0000 {
+                Some(cmp::Ordering::Greater)
+            }
+            else {
+                None
+            }
+        }
+        else {
+            let sub = self.0 - other.0;
+            if sub < 0x8000_0000 {
+                Some(cmp::Ordering::Greater)
+            }
+            else if sub > 0x8000_0000 {
+                Some(cmp::Ordering::Less)
+            }
+            else {
+                None
+            }
+        }
+    }
+}
+
+
+//--- Hash
+
+impl hash::Hash for Serial {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+
+//============ Testing =======================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn good_addition() {
+        assert_eq!(Serial(0).add(4), Serial(4));
+        assert_eq!(Serial(0xFF00_0000).add(0x0F00_0000),
+                   Serial(((0xFF00_0000u64 + 0x0F00_0000u64)
+                           % 0x1_0000_0000) as u32));
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_addition() {
+        let _ = Serial(0).add(0x8000_0000);
+    }
+
+    #[test]
+    fn comparison() {
+        use std::cmp::Ordering::*;
+
+        assert_eq!(Serial(12), Serial(12));
+        assert_ne!(Serial(12), Serial(112));
+
+        assert_eq!(Serial(12).partial_cmp(&Serial(12)), Some(Equal));
+
+        // s1 is said to be less than s2 if [...]
+        // (i1 < i2 and i2 - i1 < 2^(SERIAL_BITS - 1))
+        assert_eq!(Serial(12).partial_cmp(&Serial(13)), Some(Less));
+        assert_ne!(Serial(12).partial_cmp(&Serial(3_000_000_012)), Some(Less));
+
+        // or (i1 > i2 and i1 - i2 > 2^(SERIAL_BITS - 1))
+        assert_eq!(Serial(3_000_000_012).partial_cmp(&Serial(12)), Some(Less));
+        assert_ne!(Serial(13).partial_cmp(&Serial(12)), Some(Less));
+
+        // s1 is said to be greater than s2 if [...]
+        // (i1 < i2 and i2 - i1 > 2^(SERIAL_BITS - 1))
+        assert_eq!(Serial(12).partial_cmp(&Serial(3_000_000_012)),
+                   Some(Greater));
+        assert_ne!(Serial(12).partial_cmp(&Serial(13)), Some(Greater));
+
+        // (i1 > i2 and i1 - i2 < 2^(SERIAL_BITS - 1))
+        assert_eq!(Serial(13).partial_cmp(&Serial(12)), Some(Greater));
+        assert_ne!(Serial(3_000_000_012).partial_cmp(&Serial(12)),
+                   Some(Greater));
+        
+        // Er, I think that’s what’s left.
+        assert_eq!(Serial(1).partial_cmp(&Serial(0x8000_0001)), None);
+        assert_eq!(Serial(0x8000_0001).partial_cmp(&Serial(1)), None);
+    }
+}
+


### PR DESCRIPTION
Compares serial numbers in RTR messages using the logic prescribed by RFC 1982.

Fixes #38.