### PR TITLE
document prometheus monitoring better

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Status](https://ci.appveyor.com/api/projects/status/github/NLnetLabs/routinator?
 Introducing ‘Routinator 3000,’ RPKI relying party software written in Rust.
 If you have any feedback, we would love to hear from you. Don’t hesitate to
 [create an issue on Github](https://github.com/NLnetLabs/routinator/issues/new)
-or post a message on our [RPKI mailing list](https://nlnetlabs.nl/mailman/listinfo/rpki). 
-You can lean more about Routinator and RPKI technology by reading our documentation on 
+or post a message on our [RPKI mailing list](https://nlnetlabs.nl/mailman/listinfo/rpki).
+You can lean more about Routinator and RPKI technology by reading our documentation on
 [Read the Docs](https://rpki.readthedocs.io/).
 
 ## Quick Start
@@ -261,5 +261,19 @@ to refer to your file with local exceptions.
 
 Routinator will re-read that file on every validation run, so you can
 simply update the file whenever your exceptions change.
+
+## Monitoring
+
+Monitoring a Routinator instance is possible by enabling the integrated
+[Prometheus](https://prometheus.io/) exporter using the `listen-http`
+configuration option or command line parameter.
+
+Port [9556](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
+is allocated for this use. A Routinator instance with monitoring on this
+port can be launched so:
+
+```bash
+routinator rtrd -a -l 192.0.2.13:3323 -l [2001:0DB8::13]:3323 --listen-http 192.0.2.13:9556
+```
 
 [SLURM]: https://tools.ietf.org/html/rfc8416

--- a/etc/routinator.conf
+++ b/etc/routinator.conf
@@ -107,6 +107,16 @@ tal-dir = "..."
 # "address:port" with IPv6 address in square brackets.
 #listen-tcp = ["127.0.0.1:3323"]
 
+# Listen addresses for Prometheus HTTP monitoring endpoint.
+#
+# This is an array of strings, each string a socket address of the form
+# "address:port" with IPv6 address in square brackets.
+#
+# Port 9556 is allocated for the routinator exporter.
+# https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+#
+#listen-http = ...
+
 # Log level
 #
 # The maximum log level ("off", "error", "warn", "info", or "debug") for


### PR DESCRIPTION
Documents the allocated default prometheus monitoring port, and introduces listen-http to the example `routinator.conf` configuration file.

Closes #91 