### PR TITLE
Print route6 for IPv6 prefixes RPSL output.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,9 +12,14 @@ Bug Fixes
   instead of logging them since logging isn’t set up yet at that point.
   [(#89)]
 
+* Use `route6:` fields in RPSL output for IPv6 prefixes. ([#96], reported
+  by [@matsm])
+
 Dependencies
 
 [(#89)]: https://github.com/NLnetLabs/routinator/pull/89
+[#96]: https://github.com/NLnetLabs/routinator/pull/96
+[@matsm]: https://github.com/matsm
 
 
 ## 0.3.1 ‘More Intensity’

--- a/src/output.rs
+++ b/src/output.rs
@@ -298,9 +298,11 @@ fn rpsl_origin<W: io::Write>(
 ) -> Result<(), io::Error> {
     let now = Utc::now().to_rfc3339();
     writeln!(output,
-        "\r\nroute: {}/{}\r\norigin: {}\r\n\
+        "\r\n{}: {}/{}\r\norigin: {}\r\n\
         descr: RPKI attestation\r\nmnt-by: NA\r\ncreated: {}\r\n\
         last-modified: {}\r\nsource: ROA-{}-RPKI-ROOT\r\n",
+        if addr.address().is_ipv4() { "route" }
+        else { "route6" },
         addr.address(), addr.address_length(),
         addr.as_id(), now, now, addr.tal_name().to_uppercase()
     )


### PR DESCRIPTION
Fixes #95.