### PR TITLE
Use LF as line ending in RPSL.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,14 +11,17 @@ Bug Fixes
 * Print errors when reading the trust anchor locators to standard error
   instead of logging them since logging isn’t set up yet at that point.
   [(#89)]
-
 * Use `route6:` fields in RPSL output for IPv6 prefixes. ([#96], reported
   by [@matsm])
+* Use LF as line endings in RPSL output. Seems that’s what whois uses in
+  practice, too. ([#97], reported by [@matsm])
+
 
 Dependencies
 
 [(#89)]: https://github.com/NLnetLabs/routinator/pull/89
 [#96]: https://github.com/NLnetLabs/routinator/pull/96
+[#97]: https://github.com/NLnetLabs/routinator/pull/97
 [@matsm]: https://github.com/matsm
 
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -298,9 +298,9 @@ fn rpsl_origin<W: io::Write>(
 ) -> Result<(), io::Error> {
     let now = Utc::now().to_rfc3339();
     writeln!(output,
-        "\r\n{}: {}/{}\r\norigin: {}\r\n\
-        descr: RPKI attestation\r\nmnt-by: NA\r\ncreated: {}\r\n\
-        last-modified: {}\r\nsource: ROA-{}-RPKI-ROOT\r\n",
+        "\n{}: {}/{}\norigin: {}\n\
+        descr: RPKI attestation\nmnt-by: NA\ncreated: {}\n\
+        last-modified: {}\nsource: ROA-{}-RPKI-ROOT\n",
         if addr.address().is_ipv4() { "route" }
         else { "route6" },
         addr.address(), addr.address_length(),


### PR DESCRIPTION
It appears that in practice whois uses Unix line endings (LF) even in the protocol messages itself. This PR changes the RPSL output to use those as well instead of the more proper CRLF endings.