### PR TITLE
Ignore broken pipe error when outputting VRPs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,10 +10,13 @@ Bug Fixes
 
 * The config file option specific to `rtrd` mode weren’t picked up.
   ([#102], reported by Jay Borkenhagen)
+* Ignore ‘broken pipe’ errors when outputting VRPs to make Routinator play
+  nice with piping output into scripts etc. [(#105)]
 
 Dependencies
 
 [#102]: https://github.com/NLnetLabs/routinator/pull/102
+[(#105)]: https://github.com/NLnetLabs/routinator/pull/105
 
 
 ## 0.3.2 ‘Bitter and Twisted’

--- a/src/output.rs
+++ b/src/output.rs
@@ -61,6 +61,18 @@ impl OutputFormat {
         vrps: &AddressOrigins,
         target: &mut W,
     ) -> Result<(), io::Error> {
+        match self._output(vrps, target) {
+            Ok(()) => Ok(()),
+            Err(ref err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+            Err(err) => Err(err)
+        }
+    }
+
+    fn _output<W: io::Write>(
+        self,
+        vrps: &AddressOrigins,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
         self.output_header(vrps, target)?;
         let mut iter = vrps.iter();
         if let Some(vrp) = iter.next() {


### PR DESCRIPTION
Fixes #101 