### PR TITLE
Add three new metrics gauges for update times.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tempfile        = "^3.0"
 tokio           = "^0.1"
 tokio-process   = "^0.2"
 toml            = "^0.4"
+unwrap          = "^1.2.1"
 
 [target.'cfg(unix)'.dependencies]
 daemonize	= "^0.3"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@ Breaking Changes
 
 New
 
+* Three new monitoring gauges `last_update_start`, `last_update_done`, and
+  `last_update_duration` that will allow alerting if Routinator stops
+  updating. [(#122)]
+
 Bug Fixes
 
 * The value of the `listen-http` config option wasn’t include in the
@@ -26,6 +30,7 @@ Dependencies
 [(#112)]: https://github.com/NLnetLabs/routinator/pull/112
 [(#120)]: https://github.com/NLnetLabs/routinator/pull/120
 [(#121)]: https://github.com/NLnetLabs/routinator/pull/121
+[(#122)]: https://github.com/NLnetLabs/routinator/pull/122
 
 
 ## 0.3.3 ‘Big Bada Boom’

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate tempfile;
 extern crate tokio;
 extern crate tokio_process;
 extern crate toml;
+#[macro_use] extern crate unwrap;
 
 pub use self::config::Config;
 pub use self::operation::{Error, Operation};

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -325,6 +325,34 @@ impl Response {
             }
         });
 
+        // last_update_state, last_update_done
+        let (start, done, duration) = origins.update_times();
+
+        unwrap!(write!(res,
+            "\n\
+            # HELP last_update_start seconds since last update started\n\
+            # TYPE gauge\n\
+            last_update_start {}\n\
+            \n\
+            # HELP last_update_duration duration in seconds of last update\n\
+            # TYPE gauge\n\
+            last_update_duration {}\n\
+            \n\
+            # HELP last_update_done seconds since last update finished\n\
+            # TYPE gauge\n\
+            last_update_done ",
+            start.elapsed().as_secs(),
+            duration.map(|duration| duration.as_secs()).unwrap_or(0),
+        ));
+        match done {
+            Some(instant) => {
+                unwrap!(writeln!(res, "{}", instant.elapsed().as_secs()));
+            }
+            None => {
+                unwrap!(writeln!(res, "Nan"));
+            }
+        }
+
         Self::from_content(
             sock, "200 OK", "text/plain; version=0.0.4",
             &res


### PR DESCRIPTION
This adds three new gauges to the metrics data:

```
# HELP last_update_start seconds since last update started
# TYPE gauge
last_update_start 20

# HELP last_update_duration duration in seconds of last update
# TYPE gauge
last_update_duration 17

# HELP last_update_done seconds since last update finished
# TYPE gauge
last_update_done 2
```

This will allow alerting for #115.