### PR TITLE
make arin.tal more instructive to match up with @rfc1036 routinator debian packaging

### DIFF
--- a/tals/arin.tal
+++ b/tals/arin.tal
@@ -4,7 +4,13 @@ This file isn’t ARIN’s TAL but rather a placeholder. Until you replace
 it with the actual TAL you can find at the above URL, Routinator will
 not run.
 
-Please download the TAL in RFC 7730 format and copy it here.
+Please download the TAL in RFC 7730 format after reviewing the usage agreement
+at https://www.arin.net/resources/manage/rpki/tal/ and copy it here.
+
+Example (assumes system-wide routinator installation):
+
+# curl -o /etc/routinator/tals/arin.tal \
+  https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal
 
 Apologies for the inconvenience. Be assured that this procedure isn’t
 our choice.

--- a/tals/arin.tal
+++ b/tals/arin.tal
@@ -7,7 +7,8 @@ not run.
 Please download the TAL in RFC 7730 format after reviewing the usage agreement
 at https://www.arin.net/resources/manage/rpki/tal/ and copy it here.
 
-Example (assumes system-wide routinator installation):
+For a system that stores the TALs in /etc/routinator/tals, this can be
+achieved by running:
 
 # curl -o /etc/routinator/tals/arin.tal \
   https://www.arin.net/resources/manage/rpki/arin-rfc7730.tal


### PR DESCRIPTION
Discussed with @rfc1036 out-of-band, and meets both their stated requirements (to provide a copy-pasteable command that ensures user success) in the Debian package [here](https://salsa.debian.org/md/routinator/tree/master/debian). This eliminates the need to patch the file during packaging while being generic enough for all routinator users.