### PR TITLE
bump rust to 1.35, now with more bubbles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM rust:1.34.1-stretch as build
+FROM rust:1.35.0-stretch as build
 
 RUN apt-get -yq update && \
     apt-get -yq install musl-tools


### PR DESCRIPTION
Keep up with stable rust for docker build after manual validation.