### PR TITLE
use explicit dyn in BoxedError to appease compiler

### DIFF
--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -644,7 +644,7 @@ impl<P: Default + Sized, T: Default + Sized> AsMut<[u8]> for Error<P, T> {
 
 //------------ BoxedError ----------------------------------------------------
 
-pub struct BoxedError(Box<AsRef<[u8]> + Send>);
+pub struct BoxedError(Box<dyn AsRef<[u8]> + Send>);
 
 impl BoxedError {
     pub fn write<A: AsyncWrite>(self, a: A) -> WriteAll<A, Self> {


### PR DESCRIPTION
trait objects without an explicit dyn have been deprecated in 1.37