### PR TITLE
enable nightly for CI/CD and speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ os:
 rust:
   - stable
   - beta
+  - nightly
   - 1.34.0  # The minimal Rust version we claim we need.
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
 before_script:
   - rustup component add clippy
 script:
   - cargo clippy -- -D warnings
   - cargo test --verbose
+cache: cargo


### PR DESCRIPTION
add rust nightly to CI/CD builds while ignoring any errors, and speed up the build with cargo caching