### PR TITLE
Fix example config file parameters

### DIFF
--- a/etc/routinator.conf
+++ b/etc/routinator.conf
@@ -105,7 +105,7 @@ tal-dir = "..."
 #
 # This is an array of strings, each string a socket address of the form
 # "address:port" with IPv6 address in square brackets.
-#listen-tcp = ["127.0.0.1:3323"]
+#rtr-listen = ["127.0.0.1:3323"]
 
 # Listen addresses for Prometheus HTTP monitoring endpoint.
 #
@@ -115,7 +115,7 @@ tal-dir = "..."
 # Port 9556 is allocated for the routinator exporter.
 # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 #
-#listen-http = ...
+#http-listen = ...
 
 # Log level
 #


### PR DESCRIPTION
The listen-http name was backwards, and listen-tcp seems to have moved to rtr-listen