### PR TITLE
bump rust and alpine to latest stable in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM rust:1.35.0-stretch as build
+FROM rust:1.36.0-stretch as build
 
 RUN apt-get -yq update && \
     apt-get -yq install musl-tools
@@ -13,7 +13,7 @@ RUN cargo build --target=x86_64-unknown-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.10.0
+FROM alpine:3.10.1
 COPY --from=build /tmp/routinator/target/x86_64-unknown-linux-musl/release/routinator /usr/local/bin/
 
 # Install rsync as routinator depends on it


### PR DESCRIPTION
Bump rust to new stable (1.36) and alpine to latest point release (3.10.1). 