### PR TITLE
build dynamic musl routinator with static libssl for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM rust:1.36.0-stretch as build
+FROM alpine:3.10.1 as build
 
-RUN apt-get -yq update && \
-    apt-get -yq install musl-tools
-
-RUN rustup target add x86_64-unknown-linux-musl
+RUN apk add rust cargo openssl-dev
 
 WORKDIR /tmp/routinator
 COPY . .
 
-ENV OPENSSL_STATIC=1 PKG_CONFIG_ALLOW_CROSS=1
-RUN cargo build --target=x86_64-unknown-linux-musl --release --locked
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+ENV OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib OPENSSL_INCLUDE_DIR=/usr/include/openssl
+RUN cargo build --target x86_64-alpine-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
 FROM alpine:3.10.1
-COPY --from=build /tmp/routinator/target/x86_64-unknown-linux-musl/release/routinator /usr/local/bin/
+COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Install rsync as routinator depends on it
 RUN apk add rsync

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,11 @@ extern crate rustc_version;
 use rustc_version::{Version, version};
 
 fn main() {
+    #[cfg(feature="static")]
+    {
+        println!("cargo:rustc-link-lib=static=ssl");
+        println!("cargo:rustc-link-lib=static=crypto");
+    }
     let version = version().expect("Failed to get rustc version.");
     if version < Version::parse("1.34.0").unwrap() {
         eprintln!(


### PR DESCRIPTION
Superset of #196. While #196 builds a dynamic routinator with dynamic libssl that also has a libgcc dependency, resulting in requiring both musl and libgcc, as well as libssl at runtime, this approach results in a static libssl integrated into the routinator library (eliminating the libgcc dependency), which appears to have been the original intent. The binary itself remains dynamic as it utilized the musl provided by alpine out of the box.

This is for reference only; there's no reason to build a static routinator in this scenario as libssl is provided out of the box by alpine.