### PR TITLE
use alpine as base and build dynamic routinator in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM rust:1.36.0-stretch as build
+FROM alpine:3.10.1 as build
 
-RUN apt-get -yq update && \
-    apt-get -yq install musl-tools
-
-RUN rustup target add x86_64-unknown-linux-musl
+RUN apk add rust cargo openssl-dev
 
 WORKDIR /tmp/routinator
 COPY . .
 
-ENV OPENSSL_STATIC=1 PKG_CONFIG_ALLOW_CROSS=1
-RUN cargo build --target=x86_64-unknown-linux-musl --release --locked
+RUN cargo build --target x86_64-alpine-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
 FROM alpine:3.10.1
-COPY --from=build /tmp/routinator/target/x86_64-unknown-linux-musl/release/routinator /usr/local/bin/
+COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Install rsync as routinator depends on it
-RUN apk add rsync
+RUN apk add rsync libgcc
 
 # Create the repository and TAL directories
 RUN mkdir -p /root/.rpki-cache/repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -- stage 1: build static routinator with musl libc for alpine
 FROM alpine:3.10.1 as build
 
-RUN apk add rust cargo openssl-dev
+RUN apk add rust cargo
 
 WORKDIR /tmp/routinator
 COPY . .


### PR DESCRIPTION
Superset of #196 for a clean dynamic build with alpine as base and runtime, with openssl dependency met.
