### PR TITLE
bump alpine in dockerfile to 3.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.10.1 as build
+FROM alpine:3.10.2 as build
 
 RUN apk add rust cargo
 
@@ -10,7 +10,7 @@ RUN cargo build --target x86_64-alpine-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.10.1
+FROM alpine:3.10.2
 COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Install rsync as routinator depends on it


### PR DESCRIPTION
Bump base image for docker build to latest version of alpine (`3.10.2`)