### PR TITLE
Improve Dockerfile and document non-root execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
 
 # Create the repository and TAL directories
 RUN mkdir -p /home/${RUN_USER}/.rpki-cache/repository /home/${RUN_USER}/.rpki-cache/tals && \
-    chown ${RUN_USER_UID}:${RUN_USER_GID} /usr/local/bin/routinator
+    chown -R ${RUN_USER_UID}:${RUN_USER_GID} /usr/local/bin/routinator /home/${RUN_USER}/.rpki-cache
 
 # Due to ARIN TAL distribution terms, we can't do this here.
 # An individual user, however, might want to anyway - after reviewing


### PR DESCRIPTION
In #206 mechanics were introduced to ensure the `routinator` process in official docker container runs as a non-root user. This is consistent with current best practice. 

The changes, however, resulted in a broken container for existing users which don't persist via volume mounting the entire `.rpki-cache` directory but only the `tals` sub-directory thereof as per the README, and included no documentation adjustments to reflect the introduced changes.

This PR corrects the situation and makes miscellaneous additional improvements:
* Ensures the `/home/${RUN_USER}/.rpki-cache` directory is in fact owned by $RUN_USER
* Documents the necessary changes required to successfully launch a container
* Lints the `README.md` markdown
* Introduces container persistence into the documentation (`--restart=unless-stopped`)
* Mentions security can be further enhanced by using gVisor, with which routinator has been tested