### PR TITLE
Simplify CSV logic

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -382,14 +382,9 @@ fn ext_csv_origin<W: io::Write>(
 ) -> Result<(), io::Error> {
     match addr.cert() {
         Some(cert) => {
-            match cert.signed_object() {
-                Some(uri) => {
-                    write!(output, "{}", uri)?;
-                }
-                None => write!(output, "N/A")?
-            }
             let val = cert.validity();
-            writeln!(output, ",{},{}/{},{},{},{}",
+            writeln!(output, "{},{},{}/{},{},{},{}",
+                cert.signed_object().map(|x| x.to_string()).unwrap_or("N/A".to_string()),
                 addr.as_id(),
                 addr.address(), addr.address_length(),
                 addr.max_length(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -384,7 +384,7 @@ fn ext_csv_origin<W: io::Write>(
         Some(cert) => {
             let val = cert.validity();
             writeln!(output, "{},{},{}/{},{},{},{}",
-                cert.signed_object().map(|x| x.to_string()).unwrap_or("N/A".to_string()),
+                cert.signed_object().map(std::string::ToString::to_string).unwrap_or_else(|| "N/A".to_string()),
                 addr.as_id(),
                 addr.address(), addr.address_length(),
                 addr.max_length(),

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -169,9 +169,7 @@ impl Repository {
             }
 
             let mut file = match File::open(&path) {
-                Ok(file) => {
-                    file
-                }
+                Ok(file) => file,
                 Err(err) => {
                     error!(
                         "Failed to open TAL {}: {}. \n\


### PR DESCRIPTION
This PR simplifies ther CSV logic a bit by using functionality provided by `Option` rather than matching. It’s a little verbose in one line, but IMO still quite readable.

I also found a little formatting inconsistency in repository.

If you want me to split those two things up, let me know!

Cheers