### PR TITLE
bump docker alpine to 3.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.10.2 as build
+FROM alpine:3.10.3 as build
 
 RUN apk add rust cargo
 
@@ -10,7 +10,7 @@ RUN cargo build --target x86_64-alpine-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.10.2
+FROM alpine:3.10.3
 COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Build variables for uid and guid of user to run container


### PR DESCRIPTION
Bump the Dockerfile to the latest stable version of Alpine Linux as base. Manually validated.