### PR TITLE
Format time values in RPSL with a stable length.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,10 @@ Bug Fixes
   [(via rpki-rs #78)]
 * The `/rpsl` endpoint of the HTTP server accidentally produced CSV
   output. [(#238)]
+* Produce a formatting of the time elements of RPSL with a stable length.
+  This will result in the RPSL output via the HTTP server to be correct
+  and also decreases the size of the RPSL output by about twenty percent.
+  [(#243)]
 
 Dependencies
 
@@ -40,6 +44,7 @@ Other Changes
 [(via rpki-rs #78)]: https://github.com/NLnetLabs/rpki-rs/pull/78
 [(#229)]: https://github.com/NLnetLabs/routinator/pull/229
 [(#238)]: https://github.com/NLnetLabs/routinator/pull/238
+[(#243)]: https://github.com/NLnetLabs/routinator/pull/243
 
 
 ## 0.6.1 ‘Philosophy Is Tricky’

--- a/src/output.rs
+++ b/src/output.rs
@@ -354,7 +354,7 @@ fn csv_footer<W: io::Write>(
 //------------ ext_csv -------------------------------------------------------
 
 // 2017-08-25 13:12:19
-const TIME_ITEMS: &[Item<'static>] = &[
+const EXT_CSV_TIME_ITEMS: &[Item<'static>] = &[
     Item::Numeric(Numeric::Year, Pad::Zero),
     Item::Literal("-"),
     Item::Numeric(Numeric::Month, Pad::Zero),
@@ -394,10 +394,10 @@ fn ext_csv_origin<W: io::Write>(
                 addr.address(), addr.address_length(),
                 addr.max_length(),
                 val.not_before().format_with_items(
-                    TIME_ITEMS.iter().cloned()
+                    EXT_CSV_TIME_ITEMS.iter().cloned()
                 ),
                 val.not_after().format_with_items(
-                    TIME_ITEMS.iter().cloned()
+                    EXT_CSV_TIME_ITEMS.iter().cloned()
                 ),
             )
         }
@@ -485,6 +485,22 @@ fn openbgpd_footer<W: io::Write>(
 
 //------------ rpsl ----------------------------------------------------------
 
+// 2017-08-25T13:12:19Z
+const RPSL_TIME_ITEMS: &[Item<'static>] = &[
+    Item::Numeric(Numeric::Year, Pad::Zero),
+    Item::Literal("-"),
+    Item::Numeric(Numeric::Month, Pad::Zero),
+    Item::Literal("-"),
+    Item::Numeric(Numeric::Day, Pad::Zero),
+    Item::Literal("T"),
+    Item::Numeric(Numeric::Hour, Pad::Zero),
+    Item::Literal(":"),
+    Item::Numeric(Numeric::Minute, Pad::Zero),
+    Item::Literal(":"),
+    Item::Numeric(Numeric::Second, Pad::Zero),
+    Item::Literal("Z"),
+];
+
 fn rpsl_header<W: io::Write>(
     _vrps: &AddressOrigins,
     _output: &mut W,
@@ -497,7 +513,7 @@ fn rpsl_origin<W: io::Write>(
     _first: bool,
     output: &mut W,
 ) -> Result<(), io::Error> {
-    let now = Utc::now().to_rfc3339();
+    let now = Utc::now().format_with_items(RPSL_TIME_ITEMS.iter().cloned());
     writeln!(output,
         "\n{}: {}/{}\norigin: {}\n\
         descr: RPKI attestation\nmnt-by: NA\ncreated: {}\n\


### PR DESCRIPTION
Fixes the RPSL output via the HTTP endpoint.