### PR TITLE
Fix spelling in routinator_rrdp_duration metrics definition.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,9 +8,14 @@ New
 
 Bug Fixes
 
+* Fix spelling of `routinator_rrdp_duration` metrics definition. [(#248)]
+
 Other Changes
 
 Dependencies
+
+
+[(#248)]: https://github.com/NLnetLabs/routinator/pull/248
 
 
 ## 0.6.2 ‘Distiller’s Edition’

--- a/src/http.rs
+++ b/src/http.rs
@@ -277,7 +277,7 @@ impl Service {
         unwrap!(writeln!(res, "
             \n\
             # HELP routinator_rrdp_duration duration of rsync in seconds\n\
-            # TYPE routinator_rrdo_duration gauge"
+            # TYPE routinator_rrdp_duration gauge"
         ));
         for metrics in metrics.rrdp() {
             if let Ok(duration) = metrics.duration {


### PR DESCRIPTION
Fixes #247.