### PR TITLE
Delay creating of the HTTP client until after a possible fork.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -355,7 +355,7 @@ impl Server {
     /// just runs the server forever.
     /// Runs the command.
     pub fn run(self, mut config: Config) -> Result<(), ExitError> {
-        let repo = Repository::new(&config, false, true)?;
+        let mut repo = Repository::new(&config, false, true)?;
         let idle = IdleWait::new()?; // Create early to fail early.
         config.switch_logging(self.detach)?;
 
@@ -571,7 +571,7 @@ impl Vrps {
     /// publication points.
     fn run(self, config: Config) -> Result<(), ExitError> {
         let extra_info = self.format.extra_output();
-        let repo = Repository::new(&config, extra_info, !self.noupdate)?;
+        let mut repo = Repository::new(&config, extra_info, !self.noupdate)?;
         config.switch_logging(false)?;
         let (report, mut metrics) = repo.process()?;
         let vrps = AddressOrigins::from_report(
@@ -707,7 +707,7 @@ impl Validate {
 
     /// Outputs whether the given route announcement is valid.
     fn run(self, config: Config) -> Result<(), ExitError> {
-        let repo = Repository::new(&config, false, !self.noupdate)?;
+        let mut repo = Repository::new(&config, false, !self.noupdate)?;
         config.switch_logging(false)?;
         let (report, mut metrics) = repo.process()?;
         let vrps = AddressOrigins::from_report(

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -204,12 +204,22 @@ impl Repository {
 
     /// Performs a complete validation run on the repository.
     pub fn process(
-        &self,
+        &mut self,
     ) -> Result<(OriginsReport, Metrics), Error> {
+        self.ignite()?;
         let run = Run::new(self)?;
         let report = run.process()?;
         let metrics = run.into_metrics();
         Ok((report, metrics))
+    }
+
+    /// Starts the caches.
+    ///
+    /// This needs to be done after a possible fork as the caches may use
+    /// their own threads.
+    fn ignite(&mut self) -> Result<(), Error> {
+        self.rsync.as_mut().map_or(Ok(()), rsync::Cache::ignite)?;
+        self.rrdp.as_mut().map_or(Ok(()), rrdp::Cache::ignite)
     }
 }
 

--- a/src/rrdp/cache.rs
+++ b/src/rrdp/cache.rs
@@ -79,6 +79,10 @@ impl Cache {
         }
     }
 
+    pub fn ignite(&mut self) -> Result<(), Error> {
+        self.http.as_mut().map_or(Ok(()), HttpClient::ignite)
+    }
+
     fn cache_dir(config: &Config) -> PathBuf {
         config.cache_dir.join("rrdp")
     }

--- a/src/rsync.rs
+++ b/src/rsync.rs
@@ -58,6 +58,10 @@ impl Cache {
         }
     }
 
+    pub fn ignite(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
     fn cache_dir(config: &Config) -> PathBuf {
         config.cache_dir.join("rsync")
     }


### PR DESCRIPTION
This will make RRDP to actually work in detached server mode (aka `server -d`). Fixes #246.