### PR TITLE
Disable apk caching to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG RUN_USER_UID=1012
 ARG RUN_USER_GID=1012
 
 # Install rsync as routinator depends on it
-RUN apk add rsync libgcc
+RUN apk add --no-cache rsync libgcc
 
 RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
     adduser -D -u ${RUN_USER_UID} -G ${RUN_USER} ${RUN_USER}


### PR DESCRIPTION
Avoid storing ~1.4M of /var/cache/apk/ files in the image which are not needed. Pkg installation still works without them.