### PR TITLE
Fix description in prometheus endpoint

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -276,7 +276,7 @@ impl Service {
         // rrdp_duration
         unwrap!(writeln!(res, "
             \n\
-            # HELP routinator_rrdp_duration duration of rsync in seconds\n\
+            # HELP routinator_rrdp_duration duration of rrdp in seconds\n\
             # TYPE routinator_rrdp_duration gauge"
         ));
         for metrics in metrics.rrdp() {


### PR DESCRIPTION
Nitpick: In the prometheus endpoint the description of the RRDP duration words it as rsync duration.