### PR TITLE
routinator.service: restart the daemon on failure

### DIFF
--- a/etc/routinator.service
+++ b/etc/routinator.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 ExecStart=/usr/bin/routinator --config=/etc/routinator/routinator.conf --syslog server
 Type=exec
-RestartSec=0
+Restart=on-failure
 User=routinator
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
RestartSec was a forgotten statement used while debugging: we actually
want the daemon to be restarted on failure.