### PR TITLE
bump alpine to 3.11.3 (rust 1.39) in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.10.3 as build
+FROM alpine:3.11.3 as build
 
 RUN apk add rust cargo
 
@@ -10,7 +10,7 @@ RUN cargo build --target x86_64-alpine-linux-musl --release --locked
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.10.3
+FROM alpine:3.11.3
 COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Build variables for uid and guid of user to run container


### PR DESCRIPTION
Bump alpine to 3.11.3 which brings with it newer Rust. Manually validated.