### PR TITLE
Downgrade to requiring Rust 1.39.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.40.0, stable, beta, nightly]
+        rust: [1.39.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ Breaking Changes
 * Update to Rust’s new asynchronous IO framework for the RTR and HTTP
   servers. Repository synchronization and validation remain synchronous
   atop a thread pool. ([#282])
-* The minimal supported Rust version is now 1.40.0.
+* The minimal supported Rust version is now 1.39.0.
 
 New
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The official [Rust Platform Support](https://forge.rust-lang.org/platform-suppor
 page provides an overview of the various platforms and support levels.
 
 While some system distributions include Rust as system packages,
-Routinator relies on a relatively new version of Rust, currently 1.40 or
+Routinator relies on a relatively new version of Rust, currently 1.39 or
 newer. We therefore suggest to use the canonical Rust installation via a
 tool called ``rustup``.
 

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,9 @@ use rustc_version::{Version, version};
 
 fn main() {
     let version = version().expect("Failed to get rustc version.");
-    if version < Version::parse("1.40.0").unwrap() {
+    if version < Version::parse("1.39.0").unwrap() {
         eprintln!(
-            "\n\nAt least Rust version 1.40 is required.\n\
+            "\n\nAt least Rust version 1.39 is required.\n\
              Version {} is used for building.\n\
              Build aborted.\n\n",
              version);


### PR DESCRIPTION
This so we can use Alpine 3.11 for Docker builds.