### PR TITLE
Consolidate ROA information kept and enable csvext in HTTP server. 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,9 +10,6 @@ Breaking Changes
   explicitly specified. This filter can be disabled via the
   `--allow-dubious-hosts` command line and config option for test
   deployments. ([#293])
-* Update to Rust’s new asynchronous IO framework for the RTR and HTTP
-  servers. Repository synchronization and validation remain synchronous
-  atop a thread pool. ([#282])
 * The minimal supported Rust version is now 1.39.0.
 
 New
@@ -31,18 +28,24 @@ New
   to be used when TALs are referenced in output. This way, the output can
   be made to be even more similar to that produced by the RIPE NCC
   Validator. ([#291])
-
+* The _csvext_ output format is now also available via the HTTP server at
+  the `/csvext` path. ([#294])
 
 Bug Fixes
 
 Other Changes
 
+* Update to Rust’s new asynchronous IO framework for the RTR and HTTP
+  servers. Repository synchronization and validation remain synchronous
+  atop a thread pool. ([#282])
 * Changed concurrency strategy for repository update and validation.
   Previously, each trust anchor was updated and validated synchronously.
   Now processing of a CA is deferred if its repository publication point
   hasn’t been updated yet. Processing is then picked up by the next
   available worker thread. This should guarantee that all worker threads
   are busy all the time. ([#284)]
+* Optimized what information to keep for each ROA, bringing maximum memory 
+  consumption down to about a quarter. ([#293])
 
 Dependencies
 
@@ -54,6 +57,7 @@ Dependencies
 [#291]: https://github.com/NLnetLabs/routinator/pull/291
 [#292]: https://github.com/NLnetLabs/routinator/pull/292
 [#293]: https://github.com/NLnetLabs/routinator/pull/293
+[#294]: https://github.com/NLnetLabs/routinator/pull/294
 [@netravnen]: https://github.com/netravnen
 
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -94,6 +94,8 @@ async fn handle_request(
         "/csv" => vrps(origins, req.uri().query(), OutputFormat::Csv),
         "/csvcompat"
             => vrps(origins, req.uri().query(), OutputFormat::CompatCsv),
+        "/csvext"
+            => vrps(origins, req.uri().query(), OutputFormat::ExtendedCsv),
         "/json" => vrps(origins, req.uri().query(), OutputFormat::Json),
         "/metrics" => metrics(origins),
         "/openbgpd" => {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -361,7 +361,7 @@ impl Server {
     /// just runs the server forever.
     /// Runs the command.
     pub fn run(self, mut config: Config) -> Result<(), ExitError> {
-        let mut repo = Repository::new(&config, false, true)?;
+        let mut repo = Repository::new(&config, true)?;
         config.switch_logging(self.detach)?;
 
         let history = OriginsHistory::new(&config);
@@ -396,7 +396,7 @@ impl Server {
                     }
                 };
                 let must_notify = history.update(
-                    report, metrics, &exceptions, false
+                    report, metrics, &exceptions
                 );
                 history.mark_update_done();
                 info!(
@@ -615,14 +615,12 @@ impl Vrps {
     /// and rsync will be enabled during validation to sync any new
     /// publication points.
     fn run(self, config: Config) -> Result<(), ExitError> {
-        let extra_info = self.format.extra_output();
-        let mut repo = Repository::new(&config, extra_info, !self.noupdate)?;
+        let mut repo = Repository::new(&config, !self.noupdate)?;
         config.switch_logging(false)?;
         let (report, mut metrics) = repo.process()?;
         let vrps = AddressOrigins::from_report(
             report,
-            &LocalExceptions::load(&config, extra_info)?,
-            extra_info,
+            &LocalExceptions::load(&config, true)?,
             &mut metrics
         );
         let filters = self.filters.as_ref().map(AsRef::as_ref);
@@ -752,13 +750,12 @@ impl Validate {
 
     /// Outputs whether the given route announcement is valid.
     fn run(self, config: Config) -> Result<(), ExitError> {
-        let mut repo = Repository::new(&config, false, !self.noupdate)?;
+        let mut repo = Repository::new(&config, !self.noupdate)?;
         config.switch_logging(false)?;
         let (report, mut metrics) = repo.process()?;
         let vrps = AddressOrigins::from_report(
             report,
             &LocalExceptions::load(&config, false)?,
-            false,
             &mut metrics
         );
         let validity = RouteValidity::new(self.prefix, self.asn, &vrps);
@@ -821,7 +818,7 @@ impl Update {
     ///
     /// Which turns out is just a shortcut for `vrps` with no output.
     fn run(self, config: Config) -> Result<(), ExitError> {
-        let mut repo = Repository::new(&config, false, true)?;
+        let mut repo = Repository::new(&config, true)?;
         let (_, metrics) = repo.process()?;
         if self.complete && !metrics.rsync_complete() {
             Err(ExitError::IncompleteUpdate)

--- a/src/output.rs
+++ b/src/output.rs
@@ -378,7 +378,7 @@ fn csv_footer<W: io::Write>(
 }
 
 
-//------------ csv -----------------------------------------------------------
+//------------ compat_csv ----------------------------------------------------
 
 fn compat_csv_header<W: io::Write>(
     _vrps: &AddressOrigins,
@@ -437,15 +437,15 @@ fn ext_csv_origin<W: io::Write>(
     _first: bool,
     output: &mut W,
 ) -> Result<(), io::Error> {
-    match addr.cert() {
-        Some(cert) => {
-            match cert.signed_object() {
+    match addr.roa_info() {
+        Some(info) => {
+            match info.uri.as_ref() {
                 Some(uri) => {
                     write!(output, "{}", uri)?;
                 }
                 None => write!(output, "N/A")?
             }
-            let val = cert.validity();
+            let val = info.validity;
             writeln!(output, ",{},{}/{},{},{},{}",
                 addr.as_id(),
                 addr.address(), addr.address_length(),

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -55,9 +55,6 @@ pub struct Repository {
     /// How do we deal with stale objects?
     stale: StalePolicy,
 
-    /// Should we keep extended information about ROAs?
-    extra_output: bool,
-
     /// Number of validation threads.
     validation_threads: usize,
 
@@ -97,7 +94,6 @@ impl Repository {
     /// updating the local cache will not be updated from upstream.
     pub fn new(
         config: &Config,
-        extra_output: bool,
         update: bool
     ) -> Result<Self, Error> {
         if let Err(err) = fs::read_dir(&config.cache_dir) {
@@ -123,7 +119,6 @@ impl Repository {
             tals: Self::load_tals(config)?,
             strict: config.strict,
             stale: config.stale,
-            extra_output,
             validation_threads: config.validation_threads,
             rrdp: rrdp::Cache::new(config, update)?,
             rsync: rsync::Cache::new( config, update)?,


### PR DESCRIPTION
This PR seems to bring memory consumption down to a quarter of what we used to use.

Fixes #269.