### PR TITLE
FIX: dubios -> dubious

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -259,7 +259,7 @@ impl Config {
              .takes_value(true)
         )
         .arg(Arg::with_name("allow-dubious-hosts")
-             .long("allow-dubios-hosts")
+             .long("allow-dubious-hosts")
              .help("Allow dubious host names in rsycn and HTTPS URIs")
         )
         .arg(Arg::with_name("disable-rsync")

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,6 +260,7 @@ impl Config {
         )
         .arg(Arg::with_name("allow-dubious-hosts")
              .long("allow-dubious-hosts")
+             .aliases(&["allow-dubios-hosts"])
              .help("Allow dubious host names in rsycn and HTTPS URIs")
         )
         .arg(Arg::with_name("disable-rsync")


### PR DESCRIPTION
This PR fixes the following issue:
```
$ routinator --version
Routinator 0.7.0

$ routinator --allow-dubious-hosts --tal-dir=/tmp/tal --rrdp-root-cert=/home/ximon/src/krill/generated_cert/issuer.crt -vvv vrps
error: Found argument '--allow-dubious-hosts' which wasn't expected, or isn't valid in this context
	Did you mean --allow-dubios-hosts?

USAGE:
    routinator --allow-dubios-hosts

For more information try --help
```