### PR TITLE
Debian packaging tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ AS number will be the origin of BGP route announcements for it. \
 Routinator is a RPKI relying party software written in Rust. """
 depends = "$auto, rsync"
 section = "net"
-priority = "extra"
+priority = "optional"
 assets = [
     ["target/release/routinator", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/routinator/", "644"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tls = []
 
 [package.metadata.deb]
 maintainer = "The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"
+license-file = ["LICENSE", "0"]	
 extended-description = """\
 The Resource Public Key Infrastructure provides cryptographically signed \
 statements about the association of Internet routing resources. \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ tls = []
 
 [package.metadata.deb]
 maintainer = "The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"
-license-file = ["LICENSE", "0"]
 extended-description = """\
 The Resource Public Key Infrastructure provides cryptographically signed \
 statements about the association of Internet routing resources. \
@@ -64,8 +63,8 @@ In particular, it allows the holder of an IP address prefix to publish which \
 AS number will be the origin of BGP route announcements for it. \
 Routinator is a RPKI relying party software written in Rust. """
 depends = "$auto, rsync"
-section = "rust"
-priority = "optional"
+section = "net"
+priority = "extra"
 assets = [
     ["target/release/routinator", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/routinator/", "644"],
@@ -75,6 +74,9 @@ assets = [
     ["etc/routinator.conf.system-service", "etc/routinator/routinator.conf", "644"]
 ]
 maintainer-scripts = "debian"
+conf-files = [
+    "etc/routinator/routinator.conf"
+]
 
 [package.metadata.deb.variants.minimal]
 assets = [
@@ -84,5 +86,8 @@ assets = [
     ["doc/routinator.1", "usr/share/man/man1/routinator.1", "644"],
     ["etc/routinator.service.minimal", "lib/systemd/system/routinator.service", "644"],
     ["etc/routinator.conf.system-service", "etc/routinator/routinator.conf", "644"]
+]
+conf-files = [
+    "etc/routinator/routinator.conf"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tls = []
 
 [package.metadata.deb]
 maintainer = "The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"
-license-file = ["LICENSE", "0"]	
+license-file = ["LICENSE", "0"]
 extended-description = """\
 The Resource Public Key Infrastructure provides cryptographically signed \
 statements about the association of Internet routing resources. \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,3 @@ assets = [
     ["etc/routinator.service.minimal", "lib/systemd/system/routinator.service", "644"],
     ["etc/routinator.conf.system-service", "etc/routinator/routinator.conf", "644"]
 ]
-conf-files = [
-    "etc/routinator/routinator.conf"
-]
-


### PR DESCRIPTION
I'm not that familiar with Debian packaging so these changes might be rubbish, but on reading [cargo-deb docs](https://github.com/mmstick/cargo-deb) and [Debian packaging guidelines](https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html) I made the following tweaks:

- Adds conf-files per cargo-deb docs to avoid routinator.conf being overwritten on upgrade.
- Changes section from "rust" to "net" as the implementation language is less descriptive of the tool than that it is a networking tool.
- Removes license-file as cargo-deb docs say it will already use the existing "license" field from Cargo.toml.

@wk: as the original contributor of the cargo-deb metadata in commit e828695a7f83c745f23845df79e1e41c1bb19e85, and @rfc1036 as the maintainer of https://salsa.debian.org/md/routinator/-/tree/master/debian, I'm curious to know what you think of these changes.