### PR TITLE
Update minimum Rust version to 1.42.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.39.0, stable, beta, nightly]
+        rust: [1.42.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 Breaking Changes
 
+* The minimal supported Rust version is now 1.42.0.
+
 New
 
 Bug Fixes
@@ -12,6 +14,7 @@ Dependencies
 
 Other Changes
 
+[#357]: https://github.com/NLnetLabs/routinator/pull/357
 
 
 # 0.7.1 ‘Moonlight and Love Songs’

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The official [Rust Platform Support](https://forge.rust-lang.org/platform-suppor
 page provides an overview of the various platforms and support levels.
 
 While some system distributions include Rust as system packages,
-Routinator relies on a relatively new version of Rust, currently 1.39 or
+Routinator relies on a relatively new version of Rust, currently 1.42 or
 newer. We therefore suggest to use the canonical Rust installation via a
 tool called ``rustup``.
 

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,9 @@ use rustc_version::{Version, version};
 
 fn main() {
     let version = version().expect("Failed to get rustc version.");
-    if version < Version::parse("1.39.0").unwrap() {
+    if version < Version::parse("1.42.0").unwrap() {
         eprintln!(
-            "\n\nAt least Rust version 1.39 is required.\n\
+            "\n\nAt least Rust version 1.42 is required.\n\
              Version {} is used for building.\n\
              Build aborted.\n\n",
              version);


### PR DESCRIPTION
One of the dependencies breaks with 1.39. Debian testing is currently shipping 1.42 and Alpine 3.12 has 1.44, so requiring 1.42 should be fine.