### PR TITLE
Run ci workflow on branch or PR, not both.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
 jobs:
   test:
     name: test


### PR DESCRIPTION
E.g
![image](https://user-images.githubusercontent.com/3304436/86372649-c4198a80-bc82-11ea-9b48-64fb0f28fd84.png)

See: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662