### PR TITLE
Filter all VRPs intersecting with resoures from invalid CAs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -697,11 +697,12 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
+ "autocfg",
 ]
 
 [[package]]
@@ -1098,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.9.2-bis"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=more-block-methods#fd2f7aeea688dd3a63ff713f3c70946b887b6add"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=more-block-methods#be21a98f2f7770641310b367c05fa672561be088"
 dependencies = [
  "base64",
  "bcder",
@@ -1229,18 +1230,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1318,9 +1319,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -626,9 +626,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "listenfd"
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if",
  "libc",
@@ -913,9 +913,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.9.2-bis"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#7febb27864ee2884a62216204ae8c90319f81e4c"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=more-block-methods#fd2f7aeea688dd3a63ff713f3c70946b887b6add"
 dependencies = [
  "base64",
  "bcder",
@@ -1294,9 +1294,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -1642,9 +1642,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1681,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1704,15 +1704,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num_cpus        = "1.12.0"
 rand            = "0.7.3"
 reqwest         = { version = "0.10.4", default-features = false, features = ["blocking"] }
 ring            = "0.16.12"
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git" }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "more-block-methods" }
 rpki-rtr        = "0.1.1"
 serde           = { version = "^1.0.95", features = [ "derive" ] }
 serde_json	= "1.0.57"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,10 +6,13 @@ Breaking Changes
 
 * Validation now follows the rules suggested by
   [draft-ietf-sidrops-6486bis]\: Any invalid object mentioned on the
-  manifest will lead to all objects of the CA being rejected. However,
-  unlike suggested by the draft, Routinator currently will not fall back
-  to cached older versions of the CA’s objects that may still be valid.
+  manifest will lead to the issuing CA and all its objects being rejected.
+  However, unlike suggested by the draft, Routinator currently will not fall
+  back to cached older versions of the CA’s objects that may still be valid.
   ([#371])
+* All VRPs overlapping with resources from rejected CAs are filtered. This
+  will avoid situations were routes become RPKI invalid if their VRPs are
+  split over multiple CAs or there are less specific ROAs. ([#377])
 * Parsing of local exception files is now more strict in accordance with
   [RFC 8416]. Any additional member in the JSON objects will lead to an
   error. However, error reporting has been greatly improved and now the
@@ -18,6 +21,8 @@ Breaking Changes
 
 New
 
+* New metrics for the VRPs produced and filtered on the various TALs.
+  ([#377])
 * The feature `rta` enables the new command `rta` for validating Resource
   Tagged Assertions as described in [draft-michaelson-rpki-rta]. This
   feature is not enabled by default and needs to be activated by adding
@@ -29,8 +34,10 @@ Dependencies
 
 Other Changes
 
-[#372]: https://github.com/NLnetLabs/routinator/pull/372
 [#357]: https://github.com/NLnetLabs/routinator/pull/357
+[#371]: https://github.com/NLnetLabs/routinator/pull/371
+[#372]: https://github.com/NLnetLabs/routinator/pull/372
+[#377]: https://github.com/NLnetLabs/routinator/pull/377
 [RFC 8416]: https://tools.ietf.org/html/rfc8416
 [draft-ietf-sidrops-6486bis]: https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/
 [draft-michaelson-rpki-rta]: https://datatracker.ietf.org/doc/html/draft-michaelson-rpki-rta

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -924,20 +924,60 @@ This works in the same way as the options of the same name to the
 .B vrps
 command.
 
-.SH RELAXED VALIDATION
+.SH VALIDATION
+In
+.B vrps
+and
+.B server
+mode, Routinator will produce a set of VRPs from the data published in the
+RPKI repository. It will walk over all certfication authorities (CAs)
+starting with those referred to in the configured TALs.
+.P
+Each CA is checked whether all its published objects are present, correctly
+encoded, and have been signed by the CA. If any of the objects fails this
+check, the entire CA will be rejected. This means that none of its ROAs will
+be added to the VRP set but also that none of its child CAs will be considered
+at all; their published will not be fetched or validated.
+.P
+If a prefix has its ROAs published by different CAs, this will lead to some
+of its VRPs being dropped while others are still added. If the VRP for the
+legitimately announced route is among those having been dropped, the route
+becomes RPKI invalid. This can happen both by operator error or through an
+active attack.
+.P
+In addition, if a VRP for a less specific prefix exists that covers the
+prefix of the dropped VRP, the route will be invalidated by the less specific
+VRP.
+.P
+In order to avoid these situations and instead fall back to an RPKI unknown
+state for such routes, Routinator filters out all VRPs that have prefixes
+overlapping with any of the resources delegated to rejected CAs.
+.P
+We call VRPs filtered because they touch rejected address space
+.IR unsafe .
+Both the resources from rejected CAs and VRPs filtered are being logged at
+log level
+.BR warn .
+In addition, the number of filtered unsafe VRPs are provided in the metrics.
+
+.SH RELAXED DECODING
 The documents defining RPKI include a number of very strict rules
 regarding the formatting of the objects published in the RPKI repository.
 However, because PRKI reuses existing technology, real-world applications
 produce objects that do not follow these strict requirements.
 .PP
 As a consequence, a significant portion of the RPKI repository is actually
-invalid if the rules are followed. We therefore introduce two validation
+invalid if the rules are followed. We therefore introduce two decoding
 modes: strict and relaxed. Strict mode rejects any object that does not
 pass all checks laid out by the relevant RFCs. Relaxed mode ignores a
 number of these checks.
 .PP
-This memo documents the violations we encountered and are dealing with in
-relaxed validation mode.
+Note that none of the violations accepted in relaxed mode endanger the
+integrity or security of the objects. All signatures are always validated
+as strictly as necessary.
+.PP
+This section documents the violations we encountered and are dealing with in
+relaxed decoding mode.
 
 .SS Resource Certificates (RFC 6487)
 
@@ -994,3 +1034,4 @@ Martin Hoffmann extended it for later versions.
 
 .SH BUGS
 Sure.
+

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -953,6 +953,12 @@ In order to avoid these situations and instead fall back to an RPKI unknown
 state for such routes, Routinator filters out all VRPs that have prefixes
 overlapping with any of the resources delegated to rejected CAs.
 .P
+One exception from this rule are CAs that have the full address space
+assigned, i.e., 0.0.0.0/0 and ::/0. Adding these to the filter would wipe out
+all VRPs. These prefixes are used by the RIR trust anchors to avoid having to
+update these often. However, each RIR has its own address space so loosing all
+VRPs should something happen to a trust anchor is unnecessary.
+.P
 We call VRPs filtered because they touch rejected address space
 .IR unsafe .
 Both the resources from rejected CAs and VRPs filtered are being logged at

--- a/src/http.rs
+++ b/src/http.rs
@@ -188,7 +188,46 @@ fn metrics_active(
     for tal in metrics.tals() {
         writeln!(res,
             "routinator_vrps_total{{tal=\"{}\"}} {}",
-            tal.tal.name(), tal.vrps
+            tal.tal.name(), tal.total_valid_vrps
+        ).unwrap();
+    }
+
+    // vrps_unsafe
+    writeln!(res,
+        "\n\
+         # HELP routinator_vrps_unsafe filtered VRPs related to invalid data\n\
+         # TYPE routinator_vrps_unsafe gauge"
+    ).unwrap();
+    for tal in metrics.tals() {
+        writeln!(res,
+            "routinator_vrps_total{{tal=\"{}\"}} {}",
+            tal.tal.name(), tal.unsafe_filtered_vrps
+        ).unwrap();
+    }
+
+    // vrps_slurm
+    writeln!(res,
+        "\n\
+         # HELP routinator_vrps_slurm filtered VRPs due to local exceptions\n\
+         # TYPE routinator_vrps_slurm gauge"
+    ).unwrap();
+    for tal in metrics.tals() {
+        writeln!(res,
+            "routinator_vrps_total{{tal=\"{}\"}} {}",
+            tal.tal.name(), tal.locally_filtered_vrps
+        ).unwrap();
+    }
+
+    // vrps_final
+    writeln!(res,
+        "\n\
+         # HELP routinator_vrps_final final number of  VRPs\n\
+         # TYPE routinator_vrps_final gauge"
+    ).unwrap();
+    for tal in metrics.tals() {
+        writeln!(res,
+            "routinator_vrps_total{{tal=\"{}\"}} {}",
+            tal.tal.name(), tal.final_vrps
         ).unwrap();
     }
 
@@ -487,13 +526,53 @@ fn status_active(
 
     // vrps
     writeln!(res, "vrps: {}",
-        metrics.tals().iter().map(|tal| tal.vrps).sum::<u32>()
+        metrics.tals().iter().map(|tal| tal.total_valid_vrps).sum::<u32>()
     ).unwrap();
 
     // vrps-per-tal
     write!(res, "vrps-per-tal: ").unwrap();
     for tal in metrics.tals() {
-        write!(res, "{}={} ", tal.tal.name(), tal.vrps).unwrap();
+        write!(res, "{}={} ", tal.tal.name(), tal.total_valid_vrps).unwrap();
+    }
+    writeln!(res).unwrap();
+
+    // unsafe-vrps
+    writeln!(res, "unsafe-vrps: {}",
+        metrics.tals().iter().map(|tal| tal.unsafe_filtered_vrps).sum::<u32>()
+    ).unwrap();
+
+    // unsafe-vrps-per-tal
+    write!(res, "unsafe-vrps-per-tal: ").unwrap();
+    for tal in metrics.tals() {
+        write!(res, "{}={} ",
+            tal.tal.name(), tal.unsafe_filtered_vrps
+        ).unwrap();
+    }
+    writeln!(res).unwrap();
+
+    // slurm-vrps
+    writeln!(res, "slurm-vrps: {}",
+        metrics.tals().iter().map(|tal| tal.locally_filtered_vrps).sum::<u32>()
+    ).unwrap();
+
+    // sulrm-vrps-per-tal
+    write!(res, "slurm-vrps-per-tal: ").unwrap();
+    for tal in metrics.tals() {
+        write!(res, "{}={} ",
+            tal.tal.name(), tal.locally_filtered_vrps
+        ).unwrap();
+    }
+    writeln!(res).unwrap();
+
+    // final-vrps
+    writeln!(res, "final-vrps: {}",
+        metrics.tals().iter().map(|tal| tal.final_vrps).sum::<u32>()
+    ).unwrap();
+
+    // final-vrps-per-tal
+    write!(res, "final-vrps-per-tal: ").unwrap();
+    for tal in metrics.tals() {
+        write!(res, "{}={} ", tal.tal.name(), tal.final_vrps).unwrap();
     }
     writeln!(res).unwrap();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -192,28 +192,30 @@ fn metrics_active(
         ).unwrap();
     }
 
-    // vrps_unsafe
+    // vrps_filtered_unsafe
     writeln!(res,
         "\n\
-         # HELP routinator_vrps_unsafe filtered VRPs related to invalid data\n\
-         # TYPE routinator_vrps_unsafe gauge"
+         # HELP routinator_vrps_filtered_unsafe \
+                VRPs filtered overlapping with invalid address space\n\
+         # TYPE routinator_vrps_filtered_unsafe gauge"
     ).unwrap();
     for tal in metrics.tals() {
         writeln!(res,
-            "routinator_vrps_total{{tal=\"{}\"}} {}",
+            "routinator_vrps_filtered_unsafe{{tal=\"{}\"}} {}",
             tal.tal.name(), tal.unsafe_filtered_vrps
         ).unwrap();
     }
 
-    // vrps_slurm
+    // vrps_filtered_locally
     writeln!(res,
         "\n\
-         # HELP routinator_vrps_slurm filtered VRPs due to local exceptions\n\
-         # TYPE routinator_vrps_slurm gauge"
+         # HELP routinator_vrps_filtered_locally \
+                VRPs filtered based on local exceptions\n\
+         # TYPE routinator_vrps_filtered_locally gauge"
     ).unwrap();
     for tal in metrics.tals() {
         writeln!(res,
-            "routinator_vrps_total{{tal=\"{}\"}} {}",
+            "routinator_vrps_filtered_locally{{tal=\"{}\"}} {}",
             tal.tal.name(), tal.locally_filtered_vrps
         ).unwrap();
     }
@@ -536,13 +538,13 @@ fn status_active(
     }
     writeln!(res).unwrap();
 
-    // unsafe-vrps
-    writeln!(res, "unsafe-vrps: {}",
+    // unsafe-filtered-vrps
+    writeln!(res, "unsafe-filtered-vrps: {}",
         metrics.tals().iter().map(|tal| tal.unsafe_filtered_vrps).sum::<u32>()
     ).unwrap();
 
-    // unsafe-vrps-per-tal
-    write!(res, "unsafe-vrps-per-tal: ").unwrap();
+    // unsafe-filtered-vrps-per-tal
+    write!(res, "unsafe-filtered-vrps-per-tal: ").unwrap();
     for tal in metrics.tals() {
         write!(res, "{}={} ",
             tal.tal.name(), tal.unsafe_filtered_vrps
@@ -550,13 +552,13 @@ fn status_active(
     }
     writeln!(res).unwrap();
 
-    // slurm-vrps
-    writeln!(res, "slurm-vrps: {}",
+    // locally-filtered-vrps
+    writeln!(res, "locally-filtered-vrps: {}",
         metrics.tals().iter().map(|tal| tal.locally_filtered_vrps).sum::<u32>()
     ).unwrap();
 
-    // sulrm-vrps-per-tal
-    write!(res, "slurm-vrps-per-tal: ").unwrap();
+    // locally-filtered-vrps-per-tal
+    write!(res, "locally-filtered-vrps-per-tal: ").unwrap();
     for tal in metrics.tals() {
         write!(res, "{}={} ",
             tal.tal.name(), tal.locally_filtered_vrps

--- a/src/http.rs
+++ b/src/http.rs
@@ -233,6 +233,18 @@ fn metrics_active(
         ).unwrap();
     }
 
+    // vrps_added_locally
+    writeln!(res,
+        "\n\
+         # HELP routinator_vrps_added_locally \
+                VRPs added from local exceptions\n\
+         # TYPE routinator_vrps_added_locally gauge"
+    ).unwrap();
+    writeln!(res,
+        "routinator_vrps_added_locally {}",
+        metrics.local_vrps()
+    ).unwrap();
+
     // stale_objects
     writeln!(res,
         "\n\
@@ -565,6 +577,9 @@ fn status_active(
         ).unwrap();
     }
     writeln!(res).unwrap();
+
+    // locally-added-vrps
+    writeln!(res, "locally-added-vrps: {}", metrics.local_vrps()).unwrap();
 
     // final-vrps
     writeln!(res, "final-vrps: {}",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -28,6 +28,9 @@ pub struct Metrics {
 
     /// Number of stale objects.
     stale_count: AtomicU64,
+
+    /// Number of VRPs added from local exceptions.
+    local_vrps: u32,
 }
 
 impl Metrics {
@@ -38,6 +41,7 @@ impl Metrics {
             rsync: Vec::new(),
             rrdp: Vec::new(),
             stale_count: AtomicU64::new(0),
+            local_vrps: 0,
         }
     }
 
@@ -100,6 +104,14 @@ impl Metrics {
             }
         }
         true
+    }
+
+    pub fn local_vrps(&self) -> u32 {
+        self.local_vrps
+    }
+
+    pub fn inc_local_vrps(&mut self) {
+        self.local_vrps += 1
     }
 
     pub fn log(&self) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,8 +106,8 @@ impl Metrics {
         info!("Summary:");
         for tal in &self.tals {
             info!(
-                "{}: {} valid ROAs, {} VRPs.",
-                tal.tal.name(), tal.roas, tal.vrps
+                "{}: {} valid ROAs, {} valid VRPs, {} final VRPs.",
+                tal.tal.name(), tal.roas, tal.total_valid_vrps, tal.final_vrps
             )
         }
     }
@@ -133,11 +133,26 @@ pub struct TalMetrics {
     /// The TAL.
     pub tal: Arc<TalInfo>,
 
-    /// Number of ROAs.
+    /// Number of valid ROAs.
     pub roas: u32,
 
-    /// Number of VRPs.
-    pub vrps: u32,
+    /// Total number of valid VRPs.
+    ///
+    /// This is the total number of VRPs resulting from the validation run
+    /// before any filtering is done. In particular, this number includes
+    /// duplicate VRPs.
+    pub total_valid_vrps: u32,
+
+    /// Number of VRPs filtered due to invalid CAs.
+    pub unsafe_filtered_vrps: u32,
+
+    /// Number of VRPs filtered due to local exceptions.
+    pub locally_filtered_vrps: u32,
+
+    /// Total number of VRPs in the final set.
+    ///
+    /// This is the number of unique valid VRPs minus filtered VRPs.
+    pub final_vrps: u32,
 }
 
 impl TalMetrics {
@@ -145,7 +160,10 @@ impl TalMetrics {
         TalMetrics {
             tal,
             roas: 0,
-            vrps: 0
+            total_valid_vrps: 0,
+            unsafe_filtered_vrps: 0,
+            locally_filtered_vrps: 0,
+            final_vrps: 0,
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -647,17 +647,22 @@ fn summary_header<M: AsRef<Metrics>, W: io::Write>(
     output: &mut W,
 ) -> Result<(), io::Error> {
     let mut roas = 0;
-    let mut vrps = 0;
+    let mut valid_vrps = 0;
+    let mut final_vrps = 0;
     writeln!(output, "Summary at {}", metrics.as_ref().time())?;
     for tal in metrics.as_ref().tals() {
         writeln!(
-            output, "{}: {} verified ROAs, {} VRPs.",
-            tal.tal.name(), tal.roas, tal.vrps
+            output, "{}: {} verified ROAs, {} verified VRPs, {} final VRPs.",
+            tal.tal.name(), tal.roas, tal.total_valid_vrps, tal.final_vrps
         )?;
         roas += tal.roas;
-        vrps += tal.vrps;
+        valid_vrps += tal.total_valid_vrps;
+        final_vrps += tal.final_vrps;
     }
-    writeln!(output, "total: {} verified ROAs, {} VRPs.", roas, vrps)
+    writeln!(output,
+        "total: {} verified ROAs, {} verified VRPs, {} final VRPs.",
+        roas, valid_vrps, final_vrps
+    )
 }
 
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -648,20 +648,25 @@ fn summary_header<M: AsRef<Metrics>, W: io::Write>(
 ) -> Result<(), io::Error> {
     let mut roas = 0;
     let mut valid_vrps = 0;
+    let mut unsafe_vrps = 0;
     let mut final_vrps = 0;
     writeln!(output, "Summary at {}", metrics.as_ref().time())?;
     for tal in metrics.as_ref().tals() {
-        writeln!(
-            output, "{}: {} verified ROAs, {} verified VRPs, {} final VRPs.",
-            tal.tal.name(), tal.roas, tal.total_valid_vrps, tal.final_vrps
+        writeln!(output,
+            "{}: {} verified ROAs, {} verified VRPs, \
+             {} unsafe VRPs, {} final VRPs.",
+            tal.tal.name(), tal.roas, tal.total_valid_vrps,
+            tal.unsafe_filtered_vrps, tal.final_vrps
         )?;
         roas += tal.roas;
         valid_vrps += tal.total_valid_vrps;
+        unsafe_vrps += tal.unsafe_filtered_vrps;
         final_vrps += tal.final_vrps;
     }
     writeln!(output,
-        "total: {} verified ROAs, {} verified VRPs, {} final VRPs.",
-        roas, valid_vrps, final_vrps
+        "total: {} verified ROAs, {} verified VRPs, \
+         {} unsafe VRPs, {} final VRPs.",
+        roas, valid_vrps, unsafe_vrps, final_vrps
     )
 }
 


### PR DESCRIPTION
This PR introduces super-strict filtering of invalid ROAs. It is very much a draft for now awaiting feedback.

It is based on the observation that filtering individual ROAs may lead to legitimate route announcements being dropped because ROAs only contain a single originating AS. As a consequence, a prefix possibly being announced by multiple ASs needs to be authorized via multiple ROAs. If the ROA for the AS currently announcing the prefix gets dropped for whatever reason, the prefix becomes invalid and its route gets dropped.

As an immediate measure, it was proposed to drop all objects published by a CA that has any invalid objects whatsoever. This will make all ROAs published by this CA disappear but also all child CAs. While this will solve the above issue for most practical cases, there is still a possibility that a prefix is delegated to multiple CAs which independently publish ROAs authorising different ASs. If only the ROAs published by one of those CAs is dropped, the result may again be a falsely dropped route. The only way to avoid this is to drop all authorisations (i.e., VRPs) for all address resources delegated to the invalid CA.

However, this is still not quite enough. If the VRP for a legitimate route is dropped because of above filtering and there is a less specific VRP with a max-length not covering the route, then the route suddenly becomes invalid too. To avoid that, we need to filter all VRPs that overlap with any of the resources of invalid CAs.

This is what this PR does: It creates a list of all the resources from all the CAs that had to be dropped because of issues. When creating the final set of VRPs, it filters out all VRPs whose address prefixes overlap with any of these resources, making these resources guaranteed to be RPKI unknown.

There is a new metric `routinator_vrps_unsafe` in Prometheus output or `unsafe-vrps` in status output that counts the VRPs filtered that way. At the time of writing, around 3300 VRPs or 1.9 % were filtered this way.

The question here is, whether this aggressive filtering will improve the overall security of the system. This kind of filtering can – at least in theory – be used by an attacker to actively push their target space to RPKI unknown as an initial step of a route hijack. I _think_ this is relatively difficult to achieve and the risk subsequently is very low, but I’d love to hear opinions – particularly arguments against this filtering strategy.

*  *  *

The PR also introduces new metrics: Fixes #370. Fixes #380.