### PR TITLE
Support setting the HTTP User Agent in the RRDP client

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg, ArgMatches, crate_version};
 #[cfg(unix)] use daemonize::Daemonize;
 use dirs::home_dir;
 use log::{LevelFilter, Log, error};
@@ -45,6 +45,9 @@ const DEFAULT_EXPIRE: u64 = 7200;
 
 /// The default number of VRP diffs to keep.
 const DEFAULT_HISTORY_SIZE: usize = 10;
+
+/// The default RRDP HTTP User Agent header value to send.
+const DEFAULT_RRDP_USER_AGENT: &str = concat!("Routinator/", crate_version!());
 
 
 //------------ Config --------------------------------------------------------  
@@ -145,6 +148,9 @@ pub struct Config {
 
     /// RRDP HTTP proxies.
     pub rrdp_proxies: Vec<String>,
+
+    /// RRDP HTTP User Agent.
+    pub rrdp_user_agent: String,
 
     /// Wether to not cleanup the repository directory after a validation run.
     ///
@@ -987,6 +993,7 @@ impl Config {
                     Vec::new
                 )
             },
+            rrdp_user_agent: DEFAULT_RRDP_USER_AGENT.to_string(),
             dirty_repository: file.take_bool("dirty")?.unwrap_or(false),
             validation_threads: {
                 file.take_small_usize("validation-threads")?
@@ -1143,6 +1150,7 @@ impl Config {
             rrdp_local_addr: None,
             rrdp_root_certs: Vec::new(),
             rrdp_proxies: Vec::new(),
+            rrdp_user_agent: DEFAULT_RRDP_USER_AGENT.to_string(),
             dirty_repository: DEFAULT_DIRTY_REPOSITORY,
             validation_threads: ::num_cpus::get(),
             refresh: Duration::from_secs(DEFAULT_REFRESH),

--- a/src/rrdp/http.rs
+++ b/src/rrdp/http.rs
@@ -94,6 +94,25 @@ impl HttpClient {
         })
     }
 
+    pub fn set_user_agent(&mut self, user_agent: &str) -> Result<Self, Error> {
+        match self.client.as_mut() {
+            Ok(_) => {
+                error!("HTTP client is already initialized.");
+                return Err(Error)
+            },
+            Err(builder) => match builder.take() {
+                Some(builder) => {
+                    builder.user_agent(user_agent);
+                    self
+                },
+                None => {
+                    error!("Previously failed to initialize HTTP client.");
+                    return Err(Error)
+                }
+            }
+        };
+    }
+
     pub fn ignite(&mut self) -> Result<(), Error> {
         let builder = match self.client.as_mut() {
             Ok(_) => return Ok(()),

--- a/src/rrdp/http.rs
+++ b/src/rrdp/http.rs
@@ -6,7 +6,6 @@ use std::{error, fmt, fs, io};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use clap::crate_version;
 use log::{error, info};
 use reqwest::{Certificate, Proxy, StatusCode};
 use reqwest::blocking::{Client, ClientBuilder, Response};
@@ -55,7 +54,7 @@ impl HttpClient {
 
     pub fn new(config: &Config) -> Result<Self, Error> {
         let mut builder = Client::builder();
-        builder = builder.user_agent(concat!("Routinator/", crate_version!()));
+        builder = builder.user_agent(config.rrdp_user_agent.clone());
         match config.rrdp_timeout {
             Some(Some(timeout)) => {
                 builder = builder.timeout(timeout);
@@ -92,25 +91,6 @@ impl HttpClient {
             client: Err(Some(builder)),
             tmp_dir: config.cache_dir.join("tmp"),
         })
-    }
-
-    pub fn set_user_agent(&mut self, user_agent: &str) -> Result<(), Error> {
-        match self.client.as_mut() {
-            Ok(_) => {
-                error!("HTTP client is already initialized.");
-                Err(Error)
-            },
-            Err(builder) => match builder.take() {
-                Some(builder) => {
-                    self.client = Err(Some(builder.user_agent(user_agent)));
-                    Ok(())
-                },
-                None => {
-                    error!("Previously failed to initialize HTTP client.");
-                    Err(Error)
-                }
-            }
-        }
     }
 
     pub fn ignite(&mut self) -> Result<(), Error> {

--- a/src/rrdp/http.rs
+++ b/src/rrdp/http.rs
@@ -94,23 +94,23 @@ impl HttpClient {
         })
     }
 
-    pub fn set_user_agent(&mut self, user_agent: &str) -> Result<Self, Error> {
+    pub fn set_user_agent(&mut self, user_agent: &str) -> Result<(), Error> {
         match self.client.as_mut() {
             Ok(_) => {
                 error!("HTTP client is already initialized.");
-                return Err(Error)
+                Err(Error)
             },
             Err(builder) => match builder.take() {
                 Some(builder) => {
-                    builder.user_agent(user_agent);
-                    self
+                    self.client = Err(Some(builder.user_agent(user_agent)));
+                    Ok(())
                 },
                 None => {
                     error!("Previously failed to initialize HTTP client.");
-                    return Err(Error)
+                    Err(Error)
                 }
             }
-        };
+        }
     }
 
     pub fn ignite(&mut self) -> Result<(), Error> {

--- a/src/rrdp/http.rs
+++ b/src/rrdp/http.rs
@@ -54,7 +54,7 @@ impl HttpClient {
 
     pub fn new(config: &Config) -> Result<Self, Error> {
         let mut builder = Client::builder();
-        builder = builder.user_agent(config.rrdp_user_agent.clone());
+        builder = builder.user_agent(&config.rrdp_user_agent);
         match config.rrdp_timeout {
             Some(Some(timeout)) => {
                 builder = builder.timeout(timeout);


### PR DESCRIPTION
In `lib.rs` it says:

> "In addition, this also lets you use Routinator as a library for your own dedicated RPKI validation needs"

However, derived clients will still advertise themselves as Routinator/x.y.z when making HTTP RRDP requests which will cause confusion when the server request logs are analyzed if the client was not in fact Routinator but somethingbuilt with the Routinator library.

This patch adds a `set_user_agent(&str)` method to the RRDP HTTP client that can be called after `new()` but before `ignite()` to override the default Routinator/x.y.z HTTP User Agent.