### PR TITLE
Use datetimes instead of instants in metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.9.2-bis"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=u64-for-rrdp-serial#c6d0e32e7d713cc2bef895d17b4753e6bfd3cd45"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git#535c1a28f341960ab742861f6f4d9f1d05f607dc"
 dependencies = [
  "base64",
  "bcder",

--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,8 @@ New
 
 Bug Fixes
 
+* Update start and end times will not change between consecutive metrics
+  reports any more. ([#389])
 
 Dependencies
 
@@ -49,6 +51,7 @@ Other Changes
 [#384]: https://github.com/NLnetLabs/routinator/pull/384
 [#385]: https://github.com/NLnetLabs/routinator/pull/385
 [#387]: https://github.com/NLnetLabs/routinator/pull/387
+[#389]: https://github.com/NLnetLabs/routinator/pull/389
 [RFC 8416]: https://tools.ietf.org/html/rfc8416
 [draft-ietf-sidrops-6486bis]: https://datatracker.ietf.org/doc/draft-ietf-sidrops-6486bis/
 [draft-michaelson-rpki-rta]: https://datatracker.ietf.org/doc/html/draft-michaelson-rpki-rta


### PR DESCRIPTION
Fixes #361.