### PR TITLE
Rearrange and clean up logging.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,14 +27,12 @@ New
 
 * New metrics for the VRPs produced and filtered on the various TALs.
   ([#377])
+* The logging output of the latest validation run is now available via the
+  HTTP service’s `/log` endpoint. ([#396])
 * TCP keep-alive is now supported and enabled by default on RTR
   connections as suggested by [RFC 8210]. It can be disabled and its idle
   time changed from the default 60 seconds via the new `rtr-tcp-keepalive`
   command line and config file option. ([#390])
-* The feature `rta` enables the new command `rta` for validating Resource
-  Tagged Assertions as described in [draft-michaelson-rpki-rta]. This
-  feature is not enabled by default and needs to be activated by adding
-  the option `--features rta` to the Cargo build command.
 * The `pid-file`, `working-dir`, `chroot`, `user`, and `group` config file
   and server command options now also work without the `--detach` command
   line option. ([#392])
@@ -46,6 +44,10 @@ New
 * Release builds will now abort on panic, i.e., when an unexpected
   internal condition is detected. This ensures that there won’t be a
   Routinator process in a coma. ([#394])
+* The feature `rta` enables the new command `rta` for validating Resource
+  Tagged Assertions as described in [draft-michaelson-rpki-rta]. This
+  feature is not enabled by default and needs to be activated by adding
+  the option `--features rta` to the Cargo build command.
 
 Bug Fixes
 
@@ -57,9 +59,12 @@ Bug Fixes
   after loading local exceptions fails and try again instead of repeatedly
   starting validation runs and discarding them. ([594186c])
 
-Dependencies
-
 Other Changes
+
+* Logging has been cleaned up. The meaning of the four log levels is now
+  better defined – see the man page – and all log output has been
+  reassigned accordingly. ([#396])
+
 
 [#357]: https://github.com/NLnetLabs/routinator/pull/357
 [#371]: https://github.com/NLnetLabs/routinator/pull/371
@@ -72,6 +77,7 @@ Other Changes
 [#390]: https://github.com/NLnetLabs/routinator/pull/390
 [#392]: https://github.com/NLnetLabs/routinator/pull/392
 [#394]: https://github.com/NLnetLabs/routinator/pull/394
+[#396]: https://github.com/NLnetLabs/routinator/pull/396
 [594186c]: https://github.com/NLnetLabs/routinator/commit/594186cc2e1521a258f960c4196131e29f6cb1f9
 [RFC 8210]: https://tools.ietf.org/html/rfc8210
 [RFC 8416]: https://tools.ietf.org/html/rfc8416

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -256,6 +256,11 @@ to
 .I info\fR,
 specifying it more than once increases it to
 .I debug\fR.
+.IP
+See
+.B LOGGING
+below for more information on what information is logged at the different
+levels.
 .TP
 .BR \-q ,\  \fB\-\-quiet
 Print less information. Given twice, print nothing at all.
@@ -470,7 +475,7 @@ The address prefix the route announcement is for.
 .TP
 .BR \-j ,\  \-\-json
 A detailed analysis on the reasoning behind the validation is printed in
-JSON format including lists of the VPRs that caused the particular result.
+JSON format including lists of the VRPs that caused the particular result.
 If this option is omitted, Routinator will only print the determined
 state.
 .TP
@@ -776,6 +781,11 @@ in the system is used.
 A string value specifying the maximum log level for which log messages should
 be emitted. The default is
 .IR warn .
+.IP
+See
+.B LOGGING
+below for more information on what information is logged at the different
+levels.
 .TP
 .B log
 A string specifying where to send log messages to. This can be one of the
@@ -934,6 +944,33 @@ times.
 This works in the same way as the options of the same name to the
 .B vrps
 command.
+
+.SH LOGGING
+In order to allow diagnosis of the VRP data set as well as its overall health,
+Routinator logs an extensive amount of information. The log levels used by
+syslog are utilized to allow filtering this information for particular use
+cases.
+.P
+The log levels represent the following information:
+.TP
+.I error
+Information related to events that prevent Routinator from continuing to
+operate at all as well as all issues related to local configuration even
+if Routinator will continue to run.
+.TP
+.I warn
+Information about events and data that influences the set of VRPs produced
+by Routinator. This includes failures to communicate with repository servers,
+or encountering invalid objects.
+.TP
+.I info
+Information about events and data that could be considered abnormal but do
+not influence the set of VRPs produced. For example, when filtering of unsafe
+VRPs is disabled, the unsafe VRPs are logged with this level.
+.TP
+.I debug
+Information about the internal state of Routinator that may be useful for,
+well, debugging.
 
 .SH VALIDATION
 In

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -914,6 +914,13 @@ the output of the
 .B /metrics
 endpoint but in a more human friendly format.
 .TP
+.B /log
+Returns the logging output of the last validation run. The log level matches
+that set upon start.
+.IP
+Note that the output is collected after each validation run and is therefore
+only available after the initial run has concluded.
+.TP
 .B /version
 Returns the version of the Routinator instance.
 .TP

--- a/src/http.rs
+++ b/src/http.rs
@@ -58,7 +58,7 @@ pub fn http_listener(
         match StdListener::bind(addr) {
             Ok(listener) => listeners.push(listener),
             Err(err) => {
-                error!("Fatal error listening on {}: {}", addr, err);
+                error!("Fatal: error listening on {}: {}", addr, err);
                 return Err(ExitError::Generic);
             }
         };
@@ -102,7 +102,7 @@ async fn single_http_listener(
         sock: match TcpListener::from_std(listener) {
             Ok(listener) => listener,
             Err(err) => {
-                error!("Fatal error on HTTP listener: {}", err);
+                error!("Error on HTTP listener: {}", err);
                 return
             }
         },

--- a/src/http.rs
+++ b/src/http.rs
@@ -131,6 +131,7 @@ async fn handle_request(
         "/csvext"
             => vrps(origins, req.uri().query(), OutputFormat::ExtendedCsv),
         "/json" => vrps(origins, req.uri().query(), OutputFormat::Json),
+        "/log" => log(origins),
         "/metrics" => metrics(origins),
         "/openbgpd" => {
             vrps(origins, req.uri().query(), OutputFormat::Openbgpd)
@@ -682,6 +683,13 @@ fn status_active(
     Response::builder()
     .header("Content-Type", "text/plain")
     .body(res.into())
+    .unwrap()
+}
+
+fn log(origins: &OriginsHistory) -> Response<Body> {
+    Response::builder()
+    .header("Content-Type", "text/plain;charset=UTF-8")
+    .body(origins.log().into())
     .unwrap()
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTimeError};
 use chrono::{DateTime, Utc};
-use log::info;
 use rpki::uri;
 use rpki::tal::TalInfo;
 
@@ -112,16 +111,6 @@ impl Metrics {
 
     pub fn inc_local_vrps(&mut self) {
         self.local_vrps += 1
-    }
-
-    pub fn log(&self) {
-        info!("Summary:");
-        for tal in &self.tals {
-            info!(
-                "{}: {} valid ROAs, {} valid VRPs, {} final VRPs.",
-                tal.tal.name(), tal.roas, tal.total_valid_vrps, tal.final_vrps
-            )
-        }
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -17,7 +17,7 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 #[cfg(feature = "rta")] use bytes::Bytes;
 use clap::{App, Arg, ArgMatches, SubCommand};
-use log::{error, info, warn};
+use log::{error, info};
 use rpki::resources::AsId;
 #[cfg(feature = "rta")] use rpki::rta::Rta;
 use rpki_rtr::server::NotifySender;
@@ -418,7 +418,7 @@ impl Server {
                         history.refresh_wait()
                     }
                     Err(_) => {
-                        warn!(
+                        error!(
                             "Failed to load exceptions. \
                             Trying again in 10 seconds."
                         );
@@ -433,7 +433,7 @@ impl Server {
                             },
                             Err(_) => {
                                 error!(
-                                    "Reloading TALs failed, \
+                                    "Fatal: Reloading TALs failed, \
                                      shutting down."
                                 );
                                 break;
@@ -491,11 +491,11 @@ impl Server {
             "Validation completed. New serial is {}.",
             history.serial()
         );
-        history.mark_update_done();
         if must_notify {
             info!("Sending out notifications.");
             notify.notify();
         }
+        history.mark_update_done();
         Ok(())
     }
 }

--- a/src/origins.rs
+++ b/src/origins.rs
@@ -411,7 +411,7 @@ impl OriginsHistory {
             Some(duration) => start + duration + duration,
             None => start + refresh,
         };
-        start.duration_since(SystemTime::now()).unwrap_or_else(|_| refresh)
+        start.duration_since(SystemTime::now()).unwrap_or(refresh)
     }
 
     /// Returns a diff from the given serial number.
@@ -467,7 +467,7 @@ impl OriginsHistory {
 
     pub fn log(&self) -> Bytes {
         match self.0.read().unwrap().log {
-            Some(ref log) => log.get_output().clone(),
+            Some(ref log) => log.get_output(),
             None => Bytes::new(),
         }
     }
@@ -631,14 +631,12 @@ impl HistoryInner {
                 return Some(diff.clone())
             }
         }
-        else {
-            if serial == 0 {
+        else if serial == 0 {
                 return Some(Arc::new(OriginsDiff::empty(serial)))
-            }
-            else {
-                // That pesky future serial again.
-                return None
-            }
+        }
+        else {
+            // That pesky future serial again.
+            return None
         }
         let mut iter = self.diffs.iter().rev();
         while let Some(diff) = iter.next() {

--- a/src/rrdp/cache.rs
+++ b/src/rrdp/cache.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use bytes::Bytes;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use rpki::uri;
 use rpki::tal::TalInfo;
 use crate::config::Config;
@@ -138,7 +138,7 @@ impl<'a> Run<'a> {
                 }
             };
             if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                info!(
+                debug!(
                     "{}: unexpected file. Skipping.",
                     entry.path().display()
                 );
@@ -147,7 +147,7 @@ impl<'a> Run<'a> {
             let path = entry.path();
             match ServerState::load(&path.join("state.txt")) {
                 Ok(state) => {
-                    info!(
+                    debug!(
                         "RRDP: Known server {} at {}",
                         state.notify_uri,
                         path.display()
@@ -157,7 +157,7 @@ impl<'a> Run<'a> {
                     );
                 }
                 Err(_) => {
-                    info!(
+                    debug!(
                         "{}: bad RRDP server directory. Skipping.",
                         entry.path().display()
                     );
@@ -288,19 +288,19 @@ impl<'a> Run<'a> {
         let mut file = match fs::File::create(&path) {
             Ok(file) => file,
             Err(err) => {
-                warn!("Failed to create TA file {}: {}", path.display(), err);
+                error!("Failed to create TA file {}: {}", path.display(), err);
                 return
             }
         };
         if let Err(err) = file.write_all(
                                  &(uri.as_str().len() as u64).to_be_bytes()) {
-            warn!("Failed to write to TA file {}: {}", path.display(), err);
+            info!("Failed to write to TA file {}: {}", path.display(), err);
         }
         if let Err(err) = file.write_all(uri.as_str().as_ref()) {
-            warn!("Failed to write to TA file {}: {}", path.display(), err);
+            info!("Failed to write to TA file {}: {}", path.display(), err);
         }
         if let Err(err) = file.write_all(bytes.as_ref()) {
-            warn!("Failed to write to TA file {}: {}", path.display(), err);
+            info!("Failed to write to TA file {}: {}", path.display(), err);
         }
     }
 

--- a/src/rrdp/utils.rs
+++ b/src/rrdp/utils.rs
@@ -5,7 +5,7 @@
 use std::io;
 use std::fs::{File, create_dir_all};
 use std::path::{Path, PathBuf};
-use log::info;
+use log::error;
 use rand::random;
 use crate::operation::Error;
 
@@ -18,7 +18,7 @@ pub fn create_unique_dir(path: &Path) -> Result<PathBuf, Error> {
             Ok(()) => return Ok(target),
             Err(err) => {
                 if err.kind() != io::ErrorKind::AlreadyExists {
-                    info!(
+                    error!(
                         "Failed to create unique directory under {}: {}",
                         path.display(), err
                     );
@@ -27,7 +27,7 @@ pub fn create_unique_dir(path: &Path) -> Result<PathBuf, Error> {
             }
         }
     }
-    info!(
+    error!(
         "Failed to create unique directory under {}: tried a hundred times.",
         path.display()
     );
@@ -42,7 +42,7 @@ pub fn create_unique_file(path: &Path) -> Result<(File, PathBuf), Error> {
             Ok(file) => return Ok((file, target)),
             Err(err) => {
                 if err.kind() != io::ErrorKind::AlreadyExists {
-                    info!(
+                    error!(
                         "Failed to create unique directory under {}: {}",
                         path.display(), err
                     );
@@ -51,7 +51,7 @@ pub fn create_unique_file(path: &Path) -> Result<(File, PathBuf), Error> {
             }
         }
     }
-    info!(
+    error!(
         "Failed to create unique directory under {}: tried a hundred times.",
         path.display()
     );

--- a/src/rsync.rs
+++ b/src/rsync.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::SystemTime;
 use bytes::Bytes;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use rpki::uri;
 use crate::config::Config;
 use crate::metrics::RsyncModuleMetrics;
@@ -135,7 +135,7 @@ impl<'a> Run<'a> {
 
         // Check if the module name is dubious. If so, skip updating.
         if self.cache.filter_dubious && module.has_dubious_authority() {
-            info!(
+            warn!(
                 "{}: Dubious host name. Skipping update.",
                 module
             )
@@ -166,7 +166,7 @@ impl<'a> Run<'a> {
             Ok(mut file) => {
                 let mut data = Vec::new();
                 if let Err(err) = io::Read::read_to_end(&mut file, &mut data) {
-                    warn!(
+                    error!(
                         "Failed to read file '{}': {}",
                         path.display(),
                         err
@@ -181,7 +181,7 @@ impl<'a> Run<'a> {
                 if err.kind() == io::ErrorKind::NotFound {
                     info!("{}: not found in local repository", uri);
                 } else {
-                    warn!(
+                    error!(
                         "Failed to open file '{}': {}",
                         path.display(), err
                     );
@@ -199,7 +199,7 @@ impl<'a> Run<'a> {
         let dir = match fs::read_dir(&self.cache.cache_dir.base) {
             Ok(dir) => dir,
             Err(err) => {
-                warn!(
+                error!(
                     "Failed to read rsync cache directory: {}",
                     err
                 );
@@ -210,7 +210,7 @@ impl<'a> Run<'a> {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    warn!(
+                    error!(
                         "Failed to iterate over rsync cache directory: {}",
                         err
                     );
@@ -230,7 +230,7 @@ impl<'a> Run<'a> {
         let host = match entry_to_uri_component(&entry) {
             Some(host) => host,
             None => {
-                warn!(
+                info!(
                     "{}: illegal rsync host directory. Skipping.",
                     path.display()
                 );
@@ -240,7 +240,7 @@ impl<'a> Run<'a> {
         let dir = match fs::read_dir(&path) {
             Ok(dir) => dir,
             Err(err) => {
-                warn!(
+                info!(
                     "Failed to read directory {}: {}. Skipping.",
                     path.display(), err
                 );
@@ -252,7 +252,7 @@ impl<'a> Run<'a> {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    warn!(
+                    info!(
                         "Failed to iterate over directory {}: {}",
                         path.display(), err
                     );
@@ -424,7 +424,7 @@ impl Command {
            .arg("--delete")
            .arg(source.to_string())
            .arg(destination);
-        info!(
+        debug!(
             "rsync://{}/{}: Running command {:?}",
             source.authority(), source.module(), cmd
         );

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -2,7 +2,7 @@
 
 use std::{cmp, error, fmt, fs, io};
 use std::convert::TryFrom;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use log::error;
@@ -77,9 +77,9 @@ impl LocalExceptions {
     #[allow(clippy::option_option)]
     fn info_from_path<P: AsRef<Path>>(
         path: P, extra: bool
-    ) -> Option<Option<Arc<PathBuf>>> {
+    ) -> Option<Option<Arc<Path>>> {
         if extra {
-            Some(Some(Arc::new(path.as_ref().into())))
+            Some(Some(path.as_ref().to_path_buf().into()))
         }
         else {
             None
@@ -90,7 +90,7 @@ impl LocalExceptions {
     pub fn extend_from_json(
         &mut self,
         json: &str,
-        info: Option<Option<Arc<PathBuf>>>,
+        info: Option<Option<Arc<Path>>>,
     ) -> Result<(), serde_json::Error> {
         let json = SlurmFile::from_str(json)?;
         self.filters.extend(json.filters.prefix.into_iter().map(Into::into));
@@ -168,7 +168,7 @@ impl From<RawPrefixFilter> for PrefixFilter {
 
 #[derive(Clone, Debug, Default)]
 pub struct ExceptionInfo {
-    path: Option<Arc<PathBuf>>,
+    path: Option<Arc<Path>>,
     comment: Option<String>,
 }
 


### PR DESCRIPTION
Adds a proper definition for all log levels (see the man page). Revisits the log level of all log messages to comply with that definition.

Makes logging from the last validation run available via the HTTP service.

Fixes #383.
