### PR TITLE
Follow new, stricter CRL rules.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,10 @@ Breaking Changes
   However, unlike suggested by the draft, Routinator currently will not fall
   back to cached older versions of the CA’s objects that may still be valid.
   ([#371])
+* Similarly, CRL handling has been tightened significantly. Each CA must
+  now have exactly one CRL which must be the one stated in the manifest’s
+  EE certificate. Any violation will lead to the whole CA being rejected
+  with the same consequences as above. ([#397])
 * The default for dealing with stale objects has been changed to `reject`
   in accordance with the same draft. ([#387])
 * All VRPs overlapping with resources from rejected CAs are filtered. This
@@ -78,6 +82,7 @@ Other Changes
 [#392]: https://github.com/NLnetLabs/routinator/pull/392
 [#394]: https://github.com/NLnetLabs/routinator/pull/394
 [#396]: https://github.com/NLnetLabs/routinator/pull/396
+[#397]: https://github.com/NLnetLabs/routinator/pull/397
 [594186c]: https://github.com/NLnetLabs/routinator/commit/594186cc2e1521a258f960c4196131e29f6cb1f9
 [RFC 8210]: https://tools.ietf.org/html/rfc8210
 [RFC 8416]: https://tools.ietf.org/html/rfc8416

--- a/Changelog.md
+++ b/Changelog.md
@@ -47,7 +47,7 @@ New
   syslog logging. ([#385])
 * Release builds will now abort on panic, i.e., when an unexpected
   internal condition is detected. This ensures that there won’t be a
-  Routinator process in a coma. ([#394])
+  Routinator in a coma. ([#394])
 * The feature `rta` enables the new command `rta` for validating Resource
   Tagged Assertions as described in [draft-michaelson-rpki-rta]. This
   feature is not enabled by default and needs to be activated by adding

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -892,7 +892,7 @@ impl<'a, P: ProcessRun> Run<'a, P> {
                 res = Some(crl);
             }
             else if file.ends_with(b".crl") {
-                warn!("{}: manifest contains multiple CRLs.", manifest_uri);
+                warn!("{}: manifest contains unexpected CRLs.", manifest_uri);
                 return Err(ValidationError)
             }
         }


### PR DESCRIPTION
This modifies CRL handling to only allow exactly one CRL per CA which must be the one mentioned on the manifest’s EE certificate.

Fixes #395. 