### PR TITLE
Add unknown-objects policy for dealing with unknown object types.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,9 @@ Breaking Changes
   manifest will lead to the issuing CA and all its objects being rejected.
   However, unlike suggested by the draft, Routinator currently will not fall
   back to cached older versions of the CA’s objects that may still be valid.
-  ([#371])
+  In addition, unknown RPKI object types are currently accepted with a
+  warning logged. This behaviour can be changed via the `unknown-types`
+  policy option. ([#371], [#401])
 * Similarly, CRL handling has been tightened significantly. Each CA must
   now have exactly one CRL which must be the one stated in the manifest’s
   EE certificate. Any violation will lead to the whole CA being rejected
@@ -27,7 +29,7 @@ Breaking Changes
 New
 
 * All VRPs overlapping with resources from rejected CAs – dubbed ‘unsafe
-  VRPs’ can filtered via the new `usafe-vrps` option. Doing so will avoid
+  VRPs’ can filtered via the new `unsafe-vrps` option. Doing so will avoid
   situations were routes become RPKI invalid if their VRPs are split over
   multiple CAs or there are less specific ROAs. By default, unsafe VRPs
   are only warned about. ([#377], [#400])
@@ -89,6 +91,7 @@ Other Changes
 [#397]: https://github.com/NLnetLabs/routinator/pull/397
 [#398]: https://github.com/NLnetLabs/routinator/pull/398
 [#400]: https://github.com/NLnetLabs/routinator/pull/400
+[#401]: https://github.com/NLnetLabs/routinator/pull/401
 [594186c]: https://github.com/NLnetLabs/routinator/commit/594186cc2e1521a258f960c4196131e29f6cb1f9
 [RFC 8210]: https://tools.ietf.org/html/rfc8210
 [RFC 8416]: https://tools.ietf.org/html/rfc8416

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -199,6 +199,38 @@ see the section
 below.
 
 .TP
+.BI --unknown-objects= policy
+Defines how to deal with unknown types of RPKI objects. Currently, only
+certificates (.cer), CRLs (.crl), manifests (.mft), ROAs (.roa), and
+Ghostbuster Records (.gbr) are allowed to appear in the RPKI repository.
+.IP
+There are, once more, three policies for dealing with an object of any
+other type:
+.IP
+The
+.I reject
+policy will reject the object as well as the entire CA. Consequently, an
+unknown object appearing in a CA will mark all other objects issued by the
+CA as invalid as well.
+.IP
+The policy of
+.I warn
+will log a warning, ignore the object, and accept all known
+objects issued by the CA.
+.IP
+The similar policy of
+.I accept
+will quietly ignore the object and accept all known objects issued by the CA.
+.IP
+The defaul policy if the option is missing is
+.IR warn .
+.IP
+Note that even if unknown objects are accepted, they must appear in the
+manifest and the hash over their content must match the one given in the
+manifest. If the hash does not match, the CA and all its objects are still
+rejected.
+
+.TP
 .B --allow-dubious-hosts
 As a precaution, Routinator will reject rsync and HTTPS URIs from RPKI data
 with dubious host names. In particular, it will reject the name
@@ -726,6 +758,7 @@ A string specifying the policy for dealing with stale objects.
 .I reject
 Consider all stale objects invalid rendering all material published by the CA
 issuing the stale object to be invalid including all material of any child CA.
+This is the default policy if the value is missing.
 .TP
 .I warn
 Consider stale objects to be valid but print a warning to the log.
@@ -744,9 +777,26 @@ Filter unsafe VPRs and add warning messages to the log.
 .TP
 .I warn
 Warn about unsafe VRPs in the log but add them to the final set of VRPs.
+This is the default policy if the value is missing.
 .TP
 .I accept
 Quietly add unsafe VRPs to the final set of VRPs.
+.RE
+
+.TP
+.B unsafe-vrps
+A string specifying the policy for dealing with unknown RPKI object types.
+.RS
+.TP
+.I reject
+Reject the object and its issuing CA.
+.TP
+.I warn
+Warn about the object but ignore it and accept the issuing CA.
+This is the default policy if the value is missing.
+.TP
+.I accept
+Quietly ignore the object and accept the issuing CA.
 .RE
 
 .TP
@@ -1037,9 +1087,18 @@ starting with those referred to in the configured TALs.
 .P
 Each CA is checked whether all its published objects are present, correctly
 encoded, and have been signed by the CA. If any of the objects fail this
-check, the entire CA will be rejected. This means that none of its ROAs will
-be added to the VRP set but also that none of its child CAs will be considered
-at all; their published will not be fetched or validated.
+check, the entire CA will be rejected. If an object of an unknown type is
+encountered, the behaviour depends on the
+.B unknown-objects
+policy. If this policy has a value of
+.I reject
+the entire CA will be rejected. In this case, only certificates (.cer), CRLs
+(.crl), manifestes (.mft), ROAs (.roa), and Ghostbuster records (.gbr) will
+be accepted.
+.P
+If a CA is rejected, none of its ROAs will
+be added to the VRP set but also none of its child CAs will be considered
+at all; their published data will not be fetched or validated.
 .P
 If a prefix has its ROAs published by different CAs, this will lead to some
 of its VRPs being dropped while others are still added. If the VRP for the

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,9 @@ const DEFAULT_STALE_POLICY: FilterPolicy = FilterPolicy::Reject;
 /// The default unsafe-vrps policy.
 const DEFAULT_UNSAFE_VRPS_POLICY: FilterPolicy = FilterPolicy::Warn;
 
+/// The default unknown-objects policy.
+const DEFAULT_UNKNOWN_OBJECTS_POLICY: FilterPolicy = FilterPolicy::Warn;
+
 
 //------------ Config --------------------------------------------------------  
 
@@ -125,6 +128,9 @@ pub struct Config {
     ///
     /// The default for now is to warn about them.
     pub unsafe_vrps: FilterPolicy,
+
+    /// How to deal with unknown RPKI object types.
+    pub unknown_objects: FilterPolicy,
 
     /// Allow dubious host names.
     pub allow_dubious_hosts: bool,
@@ -293,6 +299,12 @@ impl Config {
             .long("unsafe-vrps")
             .value_name("POLICY")
             .help("The policy for handling unsafe VRPs")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name("unknown-objects")
+            .long("unknown-objects")
+            .value_name("POLICY")
+            .help("The policy for handling unknown object types")
             .takes_value(true)
         )
         .arg(Arg::with_name("allow-dubious-hosts")
@@ -574,6 +586,11 @@ impl Config {
         // unsafe_vrps
         if let Some(value) = from_str_value_of(matches, "unsafe-vrps")? {
             self.unsafe_vrps = value
+        }
+
+        // unknown_objects
+        if let Some(value) = from_str_value_of(matches, "unknown-objects")? {
+            self.unknown_objects = value
         }
 
         // allow_dubious_hosts
@@ -877,6 +894,10 @@ impl Config {
                 file.take_from_str("unsafe-vrps")?
                     .unwrap_or(DEFAULT_UNSAFE_VRPS_POLICY)
             },
+            unknown_objects: {
+                file.take_from_str("unknown_objects")?
+                    .unwrap_or(DEFAULT_UNKNOWN_OBJECTS_POLICY)
+            },
             allow_dubious_hosts:
                 file.take_bool("allow-dubious-hosts")?.unwrap_or(false),
             disable_rsync: file.take_bool("disable-rsync")?.unwrap_or(false),
@@ -1070,6 +1091,7 @@ impl Config {
             strict: DEFAULT_STRICT,
             stale: DEFAULT_STALE_POLICY,
             unsafe_vrps: DEFAULT_UNSAFE_VRPS_POLICY,
+            unknown_objects: DEFAULT_UNKNOWN_OBJECTS_POLICY,
             allow_dubious_hosts: false,
             disable_rsync: false,
             rsync_command: "rsync".into(),
@@ -1190,6 +1212,9 @@ impl Config {
         res.insert("stale".into(), format!("{}", self.stale).into());
         res.insert(
             "unsafe-vrps".into(), format!("{}", self.unsafe_vrps).into()
+        );
+        res.insert(
+            "unknown-objects".into(), format!("{}", self.unknown_objects).into()
         );
         res.insert(
             "allow-dubious-hosts".into(), self.allow_dubious_hosts.into()


### PR DESCRIPTION
This allows changing the policy on how to deal with unknown object types. It currently defaults to warn and ignore so as to not block the introduction of new object types until the new manifest rules have been codified.