### PR TITLE
Fix config file key name of unknown-objects.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,8 +9,16 @@ New
 
 Bug Fixes
 
+* The config file option for the policy on dealing with objects on unknown
+  types is now correctly spelled `unknown-objects` (with a dash rather
+  than an underscore). The old spelling will be also be accepted in 0.8
+  releases. (Found and fixed by @johannesmoos, [#413], [#414].)
+
 Other Changes
 
+[#413]: https://github.com/NLnetLabs/routinator/pull/413
+[#416]: https://github.com/NLnetLabs/routinator/pull/416
+[@johannesmoos]: https://github.com/johannesmoos
 
 ## 0.8.0 ‘Strikes and Gutters, Ups and Downs’
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -895,8 +895,14 @@ impl Config {
                     .unwrap_or(DEFAULT_UNSAFE_VRPS_POLICY)
             },
             unknown_objects: {
-                file.take_from_str("unknown_objects")?
-                    .unwrap_or(DEFAULT_UNKNOWN_OBJECTS_POLICY)
+                // XXX Remove check for unknown_objectes in 0.9.
+                match file.take_from_str("unknown-objects")? {
+                    Some(value) => value,
+                    None => {
+                        file.take_from_str("unknown_objects")?
+                            .unwrap_or(DEFAULT_UNKNOWN_OBJECTS_POLICY)
+                    }
+                }
             },
             allow_dubious_hosts:
                 file.take_bool("allow-dubious-hosts")?.unwrap_or(false),


### PR DESCRIPTION
Fixes the config file key for the unknown objects option to use a dash instead of an underscore. The broken spelling is still allowed and will be removed in 0.9.

Originally reported and fixed by @johannesmoos in #413.