### PR TITLE
Allow integer for rtr-tcp-keepalive config value.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,12 @@ Bug Fixes
 * The config file option for the policy on dealing with objects on unknown
   types is now correctly spelled `unknown-objects` (with a dash rather
   than an underscore). The old spelling will be also be accepted in 0.8
-  releases. (Found and fixed by @johannesmoos, [#413], [#416].)
+  releases. (Found and fixed by [@johannesmoos], [#413], [#416].)
+* The config file option `rtr-tcp-keepalive` now accepts an integer value
+  as it should have from the beginning (and the `config` command even
+  created). For the time being, both integers and strings will be
+  accepted. String values will be rejected starting with 0.9.0.
+  ([#427], discovered by [@johannesmoos])
 
 New
 


### PR DESCRIPTION
For the moment, this this patch allows both integers and strings for the `rtr-tcp-keepalive` config file entry. This will be changed to allowing an integer only with the next breaking release.

The change also adds a test that tries parsing the output of the `config` command to hopefully avoid similar mistakes in the future.

Fixes #418.