### PR TITLE
Force the branch built to be 'main', not 'HEAD'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ If you want to try the master branch from the repository instead of a
 release version, you can run
 
 ```bash
-cargo install --git https://github.com/NLnetLabs/routinator.git
+cargo install --git https://github.com/NLnetLabs/routinator.git --branch main
 ```
 
 If you want to update an installed version, you run the same command but


### PR DESCRIPTION
Without this message the following appears to users:
  "warning: fetching `master` branch from
  `https://github.com/NLnetLabs/routinator.git` but the
  `HEAD` reference for this repository is not the `master`
  branch. This behavior will change in Cargo in the future
  and your build may break, so it's recommended to place
  `branch = "master"` in Cargo.toml when depending on this
  git repository to ensure that your build will continue
  to work.
  Installing routinator v0.8.0-bis (https://github.com/NLnetLabs/routinator.git#93030960)"

That seemed recoverable, but at the end:
----------- snip -----------------
error: failed to run custom build command for `routinator v0.8.0-bis (/home/morrowc/.cargo/git/checkouts/routinator-cce357cafb9b8c32/9303096)`

Caused by:
  process didn't exit successfully: `/tmp/cargo-install0eExb4/release/build/routinator-ad30741a4da162f3/build-script-build` (exit code: 101)
  --- stderr

  You are using an outdated branch of the Routinator repository.

  The default branch is now "main".

  Please run 'git checkout main' before building.

  thread 'main' panicked at 'explicit panic', build.rs:8:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-------------- end snip ----------

So, adding an appropriate (main suggested in output) branch
seems useful/required :)