### PR TITLE
Don’t invalidate an entire CA if objects themselves are invalid.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,13 @@
 
 Breaking Changes
 
-New
+Changes
+
+* As the rules proposed by [draft-ietf-sidrops-6486bis] turned out to be too
+  strict, validation has been relaxed again. A CA is now only rejected and
+  all its objects ignored if the manifest or CRL are invalid or if any of
+  the objects listed on the manifest are either missing or have a
+  different hash. ([#438])
 
 Bug Fixes
 
@@ -14,6 +20,7 @@ Bug Fixes
 Other Changes
 
 [#433]: https://github.com/NLnetLabs/routinator/pull/433
+[#438]: https://github.com/NLnetLabs/routinator/pull/438
 
 
 ## 0.8.1 ‘Pure as New York Snow’ 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -572,7 +572,8 @@ impl<'a, P: ProcessRun> Run<'a, P> {
         if !process.want(&uri)? {
             return Ok(true)
         }
-        if uri.ends_with(".cer") {
+
+        let res = if uri.ends_with(".cer") {
             self.process_cer(bytes, uri, issuer, crl, process, child_cas)
         }
         else if uri.ends_with(".roa") {
@@ -587,7 +588,12 @@ impl<'a, P: ProcessRun> Run<'a, P> {
         }
         else {
             self.process_other(bytes, uri, issuer, crl, process)
-        }
+        };
+
+        // XXX Invalid objects should not lead to a CA being rejected for now
+        //     pending progress of draft-ietf-sidrops-6486bis
+        let _ = res?;
+        Ok(true)
     }
 
     /// Processes a certificate object.
@@ -742,7 +748,7 @@ impl<'a, P: ProcessRun> Run<'a, P> {
                 Ok(true)
             }
             Err(_) => {
-                warn!("{}: processing failed.", uri);
+                warn!("{}: validation failed.", uri);
                 Ok(false)
             }
         }
@@ -774,7 +780,7 @@ impl<'a, P: ProcessRun> Run<'a, P> {
                 Ok(true)
             }
             Err(_) => {
-                warn!("{}: processing failed.", uri);
+                warn!("{}: validation failed.", uri);
                 Ok(false)
             }
         }


### PR DESCRIPTION
This PR changes validation so that a CA will only be rejected if its manifest or CRL are invalid or if any of the objects listed on the manifest are either missing or have the wrong hash.