### PR TITLE
check if /var/lib/routinator directory exists before starting routinator-init

### DIFF
--- a/debian/routinator-init
+++ b/debian/routinator-init
@@ -1,2 +1,8 @@
 #!/bin/sh
+
+if [ ! -d /var/lib/routinator ]; then
+        mkdir /var/lib/routinator
+        chown routinator:routinator /var/lib/routinator
+fi
+
 sudo -u routinator routinator --config /etc/routinator/routinator.conf init "$@"


### PR DESCRIPTION
On a newly installed system, the `debian/routinator-init` script fails because /var/lib/routinator does not exist:

```
rpki01:/root# routinator-init
Fatal: failed to create cache directory /var/lib/routinator/rpki-cache: Permission denied (os error 13)
rpki01:/root#
```

this pull requests tests to ensure that the `/var/lib/routinator` directory exists, and if it doesn't, then it creates it + changes ownership.