### PR TITLE
Add --fresh to wipe all local data before starting.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,12 @@ Breaking Changes
 
 New
 
+* Routinator now keeps the last valid data from a publication point and
+  falls back to using that if an update to the publication point does not
+  have a valid manifest or the data does not match the manifest. ([#456]).
+* The new option `--fresh` causes Routinator to delete all locally stored
+  data before starting. This can be used when data corruption is
+  reported. ([#470])
 * Status information is now available in JSON format at `/api/v1/status`.
   ([#437])
 * The RRDP client now supports the gzip transfer encoding for HTTPs.
@@ -26,7 +32,9 @@ Other Changes
 [#437]: https://github.com/NLnetLabs/routinator/pull/437
 [#443]: https://github.com/NLnetLabs/routinator/pull/443
 [#444]: https://github.com/NLnetLabs/routinator/pull/444
+[#456]: https://github.com/NLnetLabs/routinator/pull/456
 [#463]: https://github.com/NLnetLabs/routinator/pull/463
+[#470]: https://github.com/NLnetLabs/routinator/pull/470
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,9 +12,8 @@ New
 * Routinator now keeps the last valid data from a publication point and
   falls back to using that if an update to the publication point does not
   have a valid manifest or the data does not match the manifest. ([#456]).
-* The new option `--fresh` causes Routinator to delete all locally stored
-  data before starting. This can be used when data corruption is
-  reported. ([#470])
+* The new option `--fresh` causes Routinator to delete all cached data
+  before starting. This can be used when data corruption is reported. ([#470])
 * Status information is now available in JSON format at `/api/v1/status`.
   ([#437])
 * The RRDP client now supports the gzip transfer encoding for HTTPs.

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -241,6 +241,12 @@ explicit port.
 This option allows to disable this filtering.
 
 .TP
+.B --fresh
+Delete and re-initialize all local data storage before starting. This option
+should be provided when Routinator fails after reporting corrupt data
+storage.
+
+.TP
 .B --disable-rsync
 If this option is present, rsync is disabled and only RRDP will be used.
 

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -242,9 +242,8 @@ This option allows to disable this filtering.
 
 .TP
 .B --fresh
-Delete and re-initialize all local data storage before starting. This option
-should be provided when Routinator fails after reporting corrupt data
-storage.
+Delete and re-initialize all cached before starting. This option should be
+provided when Routinator fails after reporting corrupt data storage.
 
 .TP
 .B --disable-rsync

--- a/src/cache/rrdp/cache.rs
+++ b/src/cache/rrdp/cache.rs
@@ -2,7 +2,7 @@
 ///
 /// This is a private module. It’s types are reexported by the parent.
 
-use std::fs;
+use std::{fs, io};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -46,6 +46,19 @@ pub struct Cache {
 impl Cache {
     pub fn init(config: &Config) -> Result<(), Failed> {
         let rrdp_dir = Self::cache_dir(config);
+
+        if config.fresh {
+            if let Err(err) = fs::remove_dir_all(&rrdp_dir) {
+                if err.kind() != io::ErrorKind::NotFound {
+                    error!(
+                        "Failed to delete RRDP cache at {}: {}",
+                        rrdp_dir.display(), err
+                    );
+                    return Err(Failed)
+                }
+            }
+        }
+
         if let Err(err) = fs::create_dir_all(&rrdp_dir) {
             error!(
                 "Failed to create RRDP cache directory {}: {}.",

--- a/src/cache/rsync.rs
+++ b/src/cache/rsync.rs
@@ -60,6 +60,19 @@ impl Cache {
     /// Creates the cache dir and returns its path.
     fn create_cache_dir(config: &Config) -> Result<PathBuf, Failed> {
         let cache_dir = config.cache_dir.join("rsync");
+
+        if config.fresh {
+            if let Err(err) = fs::remove_dir_all(&cache_dir) {
+                if err.kind() != io::ErrorKind::NotFound {
+                    error!(
+                        "Failed to delete rsync cache at {}: {}",
+                        cache_dir.display(), err
+                    );
+                    return Err(Failed)
+                }
+            }
+        }
+
         if let Err(err) = fs::create_dir_all(&cache_dir) {
             error!(
                 "Failed to create RRDP cache directory {}: {}.",

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,7 +135,7 @@ pub struct Config {
     /// Allow dubious host names.
     pub allow_dubious_hosts: bool,
 
-    /// Should we wipe store and cache before starting?
+    /// Should we wipe the cache before starting?
     ///
     /// (This option is only available on command line.)
     pub fresh: bool,
@@ -318,7 +318,7 @@ impl Config {
         )
         .arg(Arg::with_name("fresh")
             .long("fresh")
-            .help("Delete all locally stored data, download everything again") 
+            .help("Delete cached data, download everything again") 
         )
         .arg(Arg::with_name("disable-rsync")
             .long("disable-rsync")

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,6 +135,11 @@ pub struct Config {
     /// Allow dubious host names.
     pub allow_dubious_hosts: bool,
 
+    /// Should we wipe store and cache before starting?
+    ///
+    /// (This option is only available on command line.)
+    pub fresh: bool,
+
     /// Whether to disable rsync.
     pub disable_rsync: bool,
 
@@ -310,6 +315,10 @@ impl Config {
         .arg(Arg::with_name("allow-dubious-hosts")
              .long("allow-dubious-hosts")
              .help("Allow dubious host names in rsync and HTTPS URIs")
+        )
+        .arg(Arg::with_name("fresh")
+            .long("fresh")
+            .help("Delete all locally stored data, download everything again") 
         )
         .arg(Arg::with_name("disable-rsync")
             .long("disable-rsync")
@@ -596,6 +605,11 @@ impl Config {
         // allow_dubious_hosts
         if matches.is_present("allow-dubious-hosts") {
             self.allow_dubious_hosts = true
+        }
+
+        // fresh
+        if matches.is_present("fresh") {
+            self.fresh = true
         }
 
         // disable_rsync
@@ -907,6 +921,7 @@ impl Config {
             },
             allow_dubious_hosts:
                 file.take_bool("allow-dubious-hosts")?.unwrap_or(false),
+            fresh: false,
             disable_rsync: file.take_bool("disable-rsync")?.unwrap_or(false),
             rsync_command: {
                 file.take_string("rsync-command")?
@@ -1101,6 +1116,7 @@ impl Config {
             unsafe_vrps: DEFAULT_UNSAFE_VRPS_POLICY,
             unknown_objects: DEFAULT_UNKNOWN_OBJECTS_POLICY,
             allow_dubious_hosts: false,
+            fresh: false,
             disable_rsync: false,
             rsync_command: "rsync".into(),
             rsync_args: None,

--- a/src/process.rs
+++ b/src/process.rs
@@ -200,7 +200,8 @@ impl Process {
                 .level_for("tokio_reactor", LevelFilter::Info)
                 .level_for("hyper", LevelFilter::Info)
                 .level_for("reqwest", LevelFilter::Info)
-                .level_for("h2", LevelFilter::Info);
+                .level_for("h2", LevelFilter::Info)
+                .level_for("sled", LevelFilter::Info);
         }
         res
     }


### PR DESCRIPTION
This option can be used in case of a database corruption.