### PR TITLE
Clear validation log after cleanup is done.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -500,8 +500,9 @@ impl Server {
             info!("Sending out notifications.");
             notify.notify();
         }
-        validation.cleanup()
+        validation.cleanup()?;
         history.mark_update_done();
+        Ok(())
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -500,8 +500,8 @@ impl Server {
             info!("Sending out notifications.");
             notify.notify();
         }
-        history.mark_update_done();
         validation.cleanup()
+        history.mark_update_done();
     }
 }
 


### PR DESCRIPTION
Currently, the cleanup log shows in `/log` as the first thing of the next validation run. And that is wrong.