### PR TITLE
Conditional processing for VRP endpoints of the HTTP server.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,9 +31,11 @@ New
   ([#463], contributed by [@bjpbakker])
 * The `exception` config file value now also accepts a single string with
   a path name instead of an array of strings. ([#471])
-* The HTTP endpoints that supply the current VRP set now include a
-  Last-Modified header in their response. ([#474], contributed by
-  [@reschke])
+* The HTTP endpoints that supply the current VRP set now support
+  conditional request handling. They include Etag and
+  Last-Modified headers in their response and process If-None-Match and
+  If-Modified-Since headers in requests. ([#474], contributed by [@reschke],
+  [#488])
 
 Bug Fixes
 
@@ -60,6 +62,7 @@ Other Changes
 [#482]: https://github.com/NLnetLabs/routinator/pull/482
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
+[#488]: https://github.com/NLnetLabs/routinator/pull/488
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/src/http.rs
+++ b/src/http.rs
@@ -1041,7 +1041,7 @@ fn maybe_not_modified(
     // First, check If-None-Match.
     for value in req.headers().get_all("If-None-Match").iter() {
         // Skip ill-formatted values. By being lazy here we may falsely
-        // return a full response, so this should fine.
+        // return a full response, so this should be fine.
         let value = match value.to_str() {
             Ok(value) => value,
             Err(_) => continue
@@ -1281,7 +1281,7 @@ impl<'a> Iterator for EtagsIter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Skip white space and check with if we are done.
+        // Skip white space and check if we are done.
         self.0 = self.0.trim_start();
         if self.0.is_empty() {
             return None
@@ -1321,10 +1321,10 @@ impl<'a> Iterator for EtagsIter<'a> {
 
 //------------ Parsing and Constructing HTTP Dates ---------------------------
 
-/// Definition of the preferred date format (aka IMF-fixedate).
+/// Definition of the preferred date format (aka IMF-fixdate).
 ///
 /// The definition allows for relaxed parsing: It accepts additional white
-/// space and ignored case for textual representations. It does, however,
+/// space and ignores case for textual representations. It does, however,
 /// construct the correct representation when formatting.
 const IMF_FIXDATE: &[Item<'static>] = &[
     Item::Space(""),

--- a/src/http.rs
+++ b/src/http.rs
@@ -1467,12 +1467,31 @@ mod test {
     use super::*;
 
     #[test]
-    fn parse_http_date() {
-        let date = Datetime::<Utc>::from_utc(
+    fn test_parse_http_date() {
+        let date = DateTime::<Utc>::from_utc(
             chrono::naive::NaiveDate::from_ymd(
                 1994, 11, 6
             ).and_hms(8, 49, 37),
             Utc
+        );
+
+        assert_eq!(
+            parse_http_date(
+                &HeaderValue::from_static("Sun, 06 Nov 1994 08:49:37 GMT")
+            ),
+            Some(date)
+        );
+        assert_eq!(
+            parse_http_date(
+                &HeaderValue::from_static("Sunday, 06-Nov-94 08:49:37 GMT")
+            ),
+            Some(date)
+        );
+        assert_eq!(
+            parse_http_date(
+                &HeaderValue::from_static("Sun Nov  6 08:49:37 1994")
+            ),
+            Some(date)
         );
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -88,26 +88,39 @@ impl FromStr for OutputFormat {
     type Err = Failed;
 
     fn from_str(value: &str) -> Result<Self, Failed> {
-        match value {
-            "csv" => Ok(OutputFormat::Csv),
-            "csvcompat" => Ok(OutputFormat::CompatCsv),
-            "csvext" => Ok(OutputFormat::ExtendedCsv),
-            "json" => Ok(OutputFormat::Json),
-            "openbgpd" => Ok(OutputFormat::Openbgpd),
-            "bird1" => Ok(OutputFormat::Bird1),
-            "bird2" => Ok(OutputFormat::Bird2),
-            "rpsl" => Ok(OutputFormat::Rpsl),
-            "summary" => Ok(OutputFormat::Summary),
-            "none" => Ok(OutputFormat::None),
-            _ => {
-                error!("Unknown output format '{}'", value);
-                Err(Failed)
-            }
-        }
+        Self::try_from_str(value).ok_or_else(|| {
+            error!("Unknown output format: {}", value);
+            Failed
+        })
     }
 }
 
 impl OutputFormat {
+    /// Returns the output format for a string if any.
+    pub fn try_from_str(value: &str) -> Option<Self> {
+        match value {
+            "csv" => Some(OutputFormat::Csv),
+            "csvcompat" => Some(OutputFormat::CompatCsv),
+            "csvext" => Some(OutputFormat::ExtendedCsv),
+            "json" => Some(OutputFormat::Json),
+            "openbgpd" => Some(OutputFormat::Openbgpd),
+            "bird1" => Some(OutputFormat::Bird1),
+            "bird2" => Some(OutputFormat::Bird2),
+            "rpsl" => Some(OutputFormat::Rpsl),
+            "summary" => Some(OutputFormat::Summary),
+            "none" => Some(OutputFormat::None),
+            _ => None,
+        }
+    }
+
+    /// Returns the output format for a given request path.
+    pub fn from_path(path: &str) -> Option<Self> {
+        if !path.starts_with('/') {
+            return None
+        }
+        Self::try_from_str(&path[1..])
+    }
+
     /// Returns whether this output format requires extra output.
     pub fn extra_output(self) -> bool {
         matches!(self, OutputFormat::ExtendedCsv)


### PR DESCRIPTION
This PR adds adding of Etag headers to responses (with Last-Modfied already added previously) and processes If-None-Match and If-Modified-Since headers in requests to all endpoints of the HTTP server providing a list of VRPs.

Resolves #469.

@reschke, if you have the time, maybe you can have a quick look over the implementation of request handling in `src/http.rs`’s `maybe_not_modified` function to check that we follow good HTTP practice?