### PR TITLE
Further improve RRDP metrics.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,7 +26,10 @@ New
   ([#437])
 * The metrics of RRDP repositories now also include the serial number of
   the last update. The JSON status information also includes the session
-  ID and whether the last update was via a delta. ([#487])
+  ID and whether the last update was via a delta and if it wasn’t why a
+  snapshot had to be used. It also separately provides the status codes
+  for the request of the notification file and the snapshot or last
+  requested delta file. ([#487], [#489])
 * The RRDP client now supports the gzip transfer encoding for HTTPs.
   ([#463], contributed by [@bjpbakker])
 * The `exception` config file value now also accepts a single string with
@@ -60,6 +63,7 @@ Other Changes
 [#482]: https://github.com/NLnetLabs/routinator/pull/482
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
+[#489]: https://github.com/NLnetLabs/routinator/pull/489
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -25,6 +25,7 @@
 //  `Collector`, `Run`, and `Repository` types.
 //
 pub use self::base::{Collector, Cleanup, Run, Repository};
+pub use self::rrdp::SnapshotReason;
 
 mod base;
 mod rrdp;

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -25,7 +25,7 @@
 //  `Collector`, `Run`, and `Repository` types.
 //
 pub use self::base::{Collector, Cleanup, Run, Repository};
-pub use self::rrdp::SnapshotReason;
+pub use self::rrdp::{HttpStatus, SnapshotReason};
 
 mod base;
 mod rrdp;

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -662,9 +662,13 @@ impl<'a> RepositoryUpdate<'a> {
         };
         self.metrics.serial = Some(notify.serial);
         self.metrics.session = Some(notify.session_id);
-        if self.delta_update(&notify)? {
-            self.metrics.delta = true;
-            return Ok(true)
+        match self.delta_update(&notify)? {
+            None => {
+                return Ok(true)
+            }
+            Some(reason) => {
+                self.metrics.snapshot_reason = Some(reason)
+            }
         }
         self.snapshot_update(&notify)
     }
@@ -677,7 +681,7 @@ impl<'a> RepositoryUpdate<'a> {
     /// The URI and expected meta-data of the snapshot file are taken from
     /// `notify`.
     fn snapshot_update(
-        &self,
+        &mut self,
         notify: &NotificationFile,
     ) -> Result<bool, Failed> {
         match self.try_snapshot_update(
@@ -702,15 +706,23 @@ impl<'a> RepositoryUpdate<'a> {
     /// This is basically the snapshot update except that it returns an error
     /// whenever anything goes wrong whether that is fatal or not.
     fn try_snapshot_update(
-        &self,
+        &mut self,
         notify: &NotificationFile,
     ) -> Result<(), SnapshotError> {
         debug!("RRDP {}: updating from snapshot.", self.rpki_notify);
-        
+
+        let response = match self.http.response(notify.snapshot.uri()) {
+            Ok(response) => {
+                self.metrics.payload_status = Some(response.status());
+                response
+            }
+            Err(err) => {
+                self.metrics.payload_status = None;
+                return Err(err.into())
+            }
+        };
         let mut processor = SnapshotProcessor::new(&notify);
-        let mut reader = io::BufReader::new(HashRead::new(
-            self.http.response(notify.snapshot.uri())?
-        ));
+        let mut reader = io::BufReader::new(HashRead::new(response));
         processor.process(&mut reader)?;
         let hash = reader.into_inner().into_hash();
         if verify_slices_are_equal(
@@ -744,12 +756,12 @@ impl<'a> RepositoryUpdate<'a> {
     ///
     /// Takes information of the available deltas from `notify`. May not do
     /// anything at all if the repository is up-to-date. Returns whether the
-    /// update succeeded. If `Ok(false)` is returned, a snapshot update
-    /// should be tried next.
+    /// update succeeded. If `Ok(Some(reason))` is returned, a snapshot update
+    /// should be tried next because of the reason given.
     fn delta_update(
-        &self,
+        &mut self,
         notify: &NotificationFile,
-    ) -> Result<bool, Failed> {
+    ) -> Result<Option<SnapshotReason>, Failed> {
         let tree = self.collector.db.open_tree(
             Repository::tree_name(self.rpki_notify)
         )?;
@@ -770,17 +782,17 @@ impl<'a> RepositoryUpdate<'a> {
                 }
                 }
             }
-            None => return Ok(false),
+            None => return Ok(Some(SnapshotReason::NewRepository)),
         };
 
         let deltas = match Self::calc_deltas(notify, &state) {
-            Some([]) => return Ok(true),
-            Some(deltas) => deltas,
-            None => return Ok(false),
+            Ok([]) => return Ok(None),
+            Ok(deltas) => deltas,
+            Err(reason) => return Ok(Some(reason)),
         };
 
         for (serial, uri_and_hash) in deltas {
-            if !self.delta_update_step(
+            if let Some(reason) = self.delta_update_step(
                 &tree, notify, *serial,
                 uri_and_hash.uri(), uri_and_hash.hash()
             )? {
@@ -788,14 +800,14 @@ impl<'a> RepositoryUpdate<'a> {
                     "RRDP {}: Delta update failed, falling back to snapshot.",
                     self.rpki_notify
                 );
-                return Ok(false)
+                return Ok(Some(reason))
             }
         }
 
         tree.flush()?;
 
         debug!("RRDP {}: Delta update completed.", self.rpki_notify);
-        Ok(true)
+        Ok(None)
     }
 
     /// Calculates the slice of deltas to follow for updating.
@@ -806,14 +818,14 @@ impl<'a> RepositoryUpdate<'a> {
     fn calc_deltas<'b>(
         notify: &'b NotificationFile,
         state: &RepositoryState
-    ) -> Option<&'b [(u64, UriAndHash)]> {
+    ) -> Result<&'b [(u64, UriAndHash)], SnapshotReason> {
         if notify.session_id != state.session {
             debug!("New session. Need to get snapshot.");
-            return None
+            return Err(SnapshotReason::NewSession)
         }
         debug!("Serials: us {}, them {}", state.serial, notify.serial);
         if notify.serial == state.serial {
-            return Some(&[]);
+            return Ok(&[]);
         }
 
         // If there is no last delta (remember, we have a different
@@ -822,46 +834,46 @@ impl<'a> RepositoryUpdate<'a> {
         // bail out.
         if notify.deltas.last().map(|delta| delta.0) != Some(notify.serial) {
             debug!("Last delta serial differs from current serial.");
-            return None
+            return Err(SnapshotReason::BadDeltaSet)
         }
 
         let mut deltas = notify.deltas.as_slice();
         let serial = match state.serial.checked_add(1) {
             Some(serial) => serial,
-            None => return None
+            None => return Err(SnapshotReason::LargeSerial)
         };
         loop {
             let first = match deltas.first() {
                 Some(first) => first,
                 None => {
                     debug!("Ran out of deltas.");
-                    return None
+                    return Err(SnapshotReason::BadDeltaSet)
                 }
             };
             match first.0.cmp(&serial) {
                 cmp::Ordering::Greater => {
                     debug!("First delta is too new ({})", first.0);
-                    return None
+                    return Err(SnapshotReason::OutdatedLocal)
                 }
                 cmp::Ordering::Equal => break,
                 cmp::Ordering::Less => deltas = &deltas[1..]
             }
         }
-        Some(deltas)
+        Ok(deltas)
     }
 
     /// Performs the update for a single delta.
     ///
-    /// Returns `Ok(true)` if the update step succeeded, `Ok(false)` if the
-    /// delta was faulty, and `Err(Failed)` if things have gone badly.
+    /// Returns `Ok(None)` if the update step succeeded, `Ok(Some(reason))`
+    /// if the delta was faulty, and `Err(Failed)` if things have gone badly.
     fn delta_update_step(
-        &self,
+        &mut self,
         tree: &sled::Tree,
         notify: &NotificationFile,
         serial: u64,
         uri: &uri::Https,
         hash: rrdp::Hash,
-    ) -> Result<bool, Failed> {
+    ) -> Result<Option<SnapshotReason>, Failed> {
         debug!("RRDP {}: Delta update step.", uri);
         let batch = match self.collect_delta_update_step(
             tree, notify, serial, uri, hash
@@ -875,30 +887,38 @@ impl<'a> RepositoryUpdate<'a> {
                     "RRDP {}: failed to process delta: {}",
                     self.rpki_notify, err
                 );
-                return Ok(false)
+                return Ok(Some(SnapshotReason::ConflictingDelta))
             }
         };
         tree.apply_batch(batch)?;
-        Ok(true)
+        Ok(None)
     }
 
     /// Collects the changes to be done for a delta update step.
     ///
     /// Upon success, returns a batch with the changes. 
     fn collect_delta_update_step(
-        &self,
+        &mut self,
         tree: &sled::Tree,
         notify: &NotificationFile,
         serial: u64,
         uri: &uri::Https,
         hash: rrdp::Hash,
     ) -> Result<sled::Batch, DeltaError> {
+        let response = match self.http.response(uri) {
+            Ok(response) => {
+                self.metrics.payload_status = Some(response.status());
+                response
+            }
+            Err(err) => {
+                self.metrics.payload_status = None;
+                return Err(err.into())
+            }
+        };
         let mut processor = DeltaProcessor::new(
             notify.session_id, serial, tree
         );
-        let mut reader = io::BufReader::new(HashRead::new(
-            self.http.response(uri)?
-        ));
+        let mut reader = io::BufReader::new(HashRead::new(response));
 
         processor.process(&mut reader)?;
         
@@ -1737,6 +1757,47 @@ impl fmt::Display for ObjectError {
 }
 
 impl error::Error for ObjectError { }
+
+
+//------------ SnapshotReason ------------------------------------------------
+
+/// The reason why a snapshot was used.
+#[derive(Clone, Copy, Debug)]
+pub enum SnapshotReason {
+    /// The respository is new.
+    NewRepository,
+
+    /// A new session was encountered.
+    NewSession,
+
+    /// The delta set in the notification file is inconsistent.
+    BadDeltaSet,
+
+    /// A larger-than-supported serial number was encountered.
+    LargeSerial,
+
+    /// The local copy is outdated and cannot be updated via deltas.
+    OutdatedLocal,
+
+    /// A delta file was conflicting with locally stored data.
+    ConflictingDelta,
+}
+
+impl SnapshotReason {
+    /// Returns a shorthand code for the reason.
+    pub fn code(self) -> &'static str {
+        use SnapshotReason::*;
+
+        match self {
+            NewRepository => "new-repository",
+            NewSession => "new-session",
+            BadDeltaSet => "inconsistent-delta-set",
+            LargeSerial => "large-serial",
+            OutdatedLocal => "outdate-local",
+            ConflictingDelta => "conflicting-delta",
+        }
+    }
+}
 
 
 //============ Tests =========================================================

--- a/src/http.rs
+++ b/src/http.rs
@@ -356,8 +356,8 @@ fn metrics_active(
     // rrdp_status
     writeln!(res,
         "\n\
-        # HELP routinator_rrdp_status status code for getting \
-            notification file\n\
+        # HELP routinator_rrdp_status combined status code for repository \
+            update requests\n\
         # TYPE routinator_rrdp_status gauge"
     ).unwrap();
     for metrics in metrics.rrdp() {
@@ -366,6 +366,42 @@ fn metrics_active(
             "routinator_rrdp_status{{uri=\"{}\"}} {}",
             metrics.notify_uri,
             metrics.status().map(|code| {
+                code.as_u16() as i16
+            }).unwrap_or(-1),
+        ).unwrap();
+    }
+
+    // rrdp_notification_status
+    writeln!(res,
+        "\n\
+        # HELP routinator_rrdp_notification_status status code for getting \
+            notification file\n\
+        # TYPE routinator_rrdp_notification_status gauge"
+    ).unwrap();
+    for metrics in metrics.rrdp() {
+        writeln!(
+            res,
+            "routinator_rrdp_notification_status{{uri=\"{}\"}} {}",
+            metrics.notify_uri,
+            metrics.notify_status.map(|code| {
+                code.as_u16() as i16
+            }).unwrap_or(-1),
+        ).unwrap();
+    }
+
+    // rrdp_payload_status
+    writeln!(res,
+        "\n\
+        # HELP routinator_rrdp_payload_status status code(s) for getting \
+            payload file(s)\n\
+        # TYPE routinator_rrdp_payload_status gauge"
+    ).unwrap();
+    for metrics in metrics.rrdp() {
+        writeln!(
+            res,
+            "routinator_rrdp_payload_status{{uri=\"{}\"}} {}",
+            metrics.notify_uri,
+            metrics.payload_status.map(|code| {
                 code.as_u16() as i16
             }).unwrap_or(-1),
         ).unwrap();
@@ -675,9 +711,15 @@ fn status_active(
     for metrics in metrics.rrdp() {
         write!(
             res,
-            "   {}: status={}",
+            "   {}: status={}, notification-status={}, payload-status={}",
             metrics.notify_uri,
             metrics.status().map(|code| {
+                code.as_u16() as i16
+            }).unwrap_or(-1),
+            metrics.notify_status.map(|code| {
+                code.as_u16() as i16
+            }).unwrap_or(-1),
+            metrics.payload_status.map(|code| {
                 code.as_u16() as i16
             }).unwrap_or(-1),
         ).unwrap();

--- a/src/http.rs
+++ b/src/http.rs
@@ -365,9 +365,7 @@ fn metrics_active(
             res,
             "routinator_rrdp_status{{uri=\"{}\"}} {}",
             metrics.notify_uri,
-            metrics.status().map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
+            metrics.status().into_i16()
         ).unwrap();
     }
 
@@ -383,9 +381,7 @@ fn metrics_active(
             res,
             "routinator_rrdp_notification_status{{uri=\"{}\"}} {}",
             metrics.notify_uri,
-            metrics.notify_status.map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
+            metrics.notify_status.into_i16(),
         ).unwrap();
     }
 
@@ -401,9 +397,9 @@ fn metrics_active(
             res,
             "routinator_rrdp_payload_status{{uri=\"{}\"}} {}",
             metrics.notify_uri,
-            metrics.payload_status.map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
+            metrics.payload_status.map(|status| {
+                status.into_i16()
+            }).unwrap_or(0),
         ).unwrap();
     }
 
@@ -713,15 +709,11 @@ fn status_active(
             res,
             "   {}: status={}, notification-status={}, payload-status={}",
             metrics.notify_uri,
-            metrics.status().map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
-            metrics.notify_status.map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
-            metrics.payload_status.map(|code| {
-                code.as_u16() as i16
-            }).unwrap_or(-1),
+            metrics.status().into_i16(),
+            metrics.notify_status.into_i16(),
+            metrics.payload_status.map(|status| {
+                status.into_i16()
+            }).unwrap_or(0),
         ).unwrap();
         if let Ok(duration) = metrics.duration {
             write!(
@@ -856,21 +848,17 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
                 target.member_object(&metrics.notify_uri, |target| {
                     target.member_raw(
                         "status",
-                        metrics.status().map(|code| {
-                            code.as_u16() as i16
-                        }).unwrap_or(-1)
+                        metrics.status().into_i16(),
                     );
                     target.member_raw(
                         "notifyStatus",
-                        metrics.notify_status.map(|code| {
-                            code.as_u16() as i16
-                        }).unwrap_or(-1)
+                        metrics.notify_status.into_i16(),
                     );
                     target.member_raw(
                         "payloadStatus",
-                        metrics.notify_status.map(|code| {
-                            code.as_u16() as i16
-                        }).unwrap_or(-1)
+                        metrics.payload_status.map(|status| {
+                            status.into_i16()
+                        }).unwrap_or(0)
                     );
                     match metrics.duration {
                         Ok(duration) => {

--- a/src/http.rs
+++ b/src/http.rs
@@ -791,7 +791,7 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
             target.member_str("lastUpdateDone", done.format("%+"));
         }
         else {
-            target.member_raw("lastUpdateDone", "none");
+            target.member_raw("lastUpdateDone", "null");
         }
         if let Some(duration) = duration {
             target.member_raw("lastUpdateDuration",
@@ -837,7 +837,7 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
                                 format_args!("{:.3}", duration.as_secs_f32())
                             );
                         }
-                        Err(_) => target.member_raw("duration", "none")
+                        Err(_) => target.member_raw("duration", "null")
                     }
                 })
             }
@@ -866,19 +866,19 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
                                 format_args!("{:.3}", duration.as_secs_f32())
                             );
                         }
-                        Err(_) => target.member_raw("duration", "none")
+                        Err(_) => target.member_raw("duration", "null")
                     }
                     match metrics.serial {
                         Some(serial) => {
                             target.member_raw("serial", serial);
                         }
-                        None => target.member_raw("serial", "none")
+                        None => target.member_raw("serial", "null")
                     }
                     match metrics.session {
                         Some(session) => {
                             target.member_str("session", session);
                         }
-                        None => target.member_raw("session", "none")
+                        None => target.member_raw("session", "null")
                     }
                     target.member_raw("delta",
                         if metrics.snapshot_reason.is_none() { "true" }
@@ -888,7 +888,7 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
                         target.member_str("snapshot_reason", reason.code())
                     }
                     else {
-                        target.member_raw("snapshot_reason", "none");
+                        target.member_raw("snapshot_reason", "null");
                     }
                 })
             }

--- a/src/http.rs
+++ b/src/http.rs
@@ -365,7 +365,7 @@ fn metrics_active(
             res,
             "routinator_rrdp_status{{uri=\"{}\"}} {}",
             metrics.notify_uri,
-            metrics.notify_status.map(|code| {
+            metrics.status().map(|code| {
                 code.as_u16() as i16
             }).unwrap_or(-1),
         ).unwrap();
@@ -677,7 +677,7 @@ fn status_active(
             res,
             "   {}: status={}",
             metrics.notify_uri,
-            metrics.notify_status.map(|code| {
+            metrics.status().map(|code| {
                 code.as_u16() as i16
             }).unwrap_or(-1),
         ).unwrap();
@@ -812,22 +812,24 @@ fn api_status(origins: &OriginsHistory) -> Response<Body> {
         target.member_object("rrdp", |target| {
             for metrics in metrics.rrdp() {
                 target.member_object(&metrics.notify_uri, |target| {
-                    let notify_status = metrics.notify_status.map(|code| {
-                        code.as_u16() as i16
-                    }).unwrap_or(-1);
-                    let payload_status = metrics.payload_status.map(|code| {
-                        code.as_u16() as i16
-                    }).unwrap_or(-1);
-                    target.member_raw("status",
-                        if notify_status == 200 {
-                            payload_status
-                        }
-                        else {
-                            notify_status
-                        }
+                    target.member_raw(
+                        "status",
+                        metrics.status().map(|code| {
+                            code.as_u16() as i16
+                        }).unwrap_or(-1)
                     );
-                    target.member_raw("notifyStatus", notify_status);
-                    target.member_raw("payloadStatus",payload_status);
+                    target.member_raw(
+                        "notifyStatus",
+                        metrics.notify_status.map(|code| {
+                            code.as_u16() as i16
+                        }).unwrap_or(-1)
+                    );
+                    target.member_raw(
+                        "payloadStatus",
+                        metrics.notify_status.map(|code| {
+                            code.as_u16() as i16
+                        }).unwrap_or(-1)
+                    );
                     match metrics.duration {
                         Ok(duration) => {
                             target.member_raw("duration",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -247,7 +247,7 @@ impl RrdpRepositoryMetrics {
             }
         }
         else {
-            self.notify_status
+            None
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -236,6 +236,20 @@ impl RrdpRepositoryMetrics {
             duration: Ok(Duration::from_secs(0))
         }
     }
+
+    pub fn status(&self) -> Option<reqwest::StatusCode> {
+        if let Some(status) = self.notify_status {
+            if status.is_success() {
+                self.payload_status
+            }
+            else {
+                Some(status)
+            }
+        }
+        else {
+            self.notify_status
+        }
+    }
 }
 
 


### PR DESCRIPTION
This PR further enhances the RRDP repository metrics and resolves #477.

This changes the meaning of ‘status’ to be the status code of the last HTTP request made with separate status information available for the notification file and the series of payload requests. In addition, if a snapshot was requested, the reason for that is given.

@ties, is it enough to have the new combined status in the Prometheus or do you rather have more Prometheus metrics and if so which?