### PR TITLE
Optionally store RRDP responses somewhere.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,8 @@ New
 * The HTTP endpoints that supply the current VRP set now include a
   Last-Modified header in their response. ([#474], contributed by
   [@reschke])
+* The new `rrdp-keep-responses` option allows optionally storing the XML
+  content of all received RRDP responses in the file system. ([#490])
 
 Bug Fixes
 
@@ -60,6 +62,7 @@ Other Changes
 [#482]: https://github.com/NLnetLabs/routinator/pull/482
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
+[#490]: https://github.com/NLnetLabs/routinator/pull/490
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1221,7 +1221,7 @@ impl HttpResponse {
         })
     }
 
-    /// Returns the value of the content length header of present.
+    /// Returns the value of the content length header if present.
     pub fn content_length(&self) -> Option<u64> {
         self.response.content_length()
     }

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1189,7 +1189,7 @@ impl io::Read for HttpResponse {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         let res = self.response.read(buf)?;
         if let Some(file) = self.file.as_mut() {
-            file.write(&buf[..res])?;
+            file.write_all(&buf[..res])?;
         }
         Ok(res)
     }

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1088,7 +1088,7 @@ impl HttpClient {
     /// Performs an HTTP GET request for the given URI.
     ///
     /// If keeping responses is enabled, the response is written to a file
-    /// corresponding to the URI. If resource behind the URI changes over
+    /// corresponding to the URI. If the resource behind the URI changes over
     /// time and this change should be tracked, set `multi` to `true` to
     /// include the current time in the file name.
     pub fn response(


### PR DESCRIPTION
This PR introduces the `rrdp-keep-responses` option that allows providing a directory in which the content of successfully received RRDP responses is stored. The URIs are turned into a path. For notification files, the URI is turned into a directory and the notification file is stored under the timestamp when it was retrieved.

Resolves #476. 