### PR TITLE
Produce per-repository metrics.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ Breaking Changes
   now fall back to rsync. The time since last successful update before
   this fallback happens is configurable via the `rrdp-fallback-time`
   option and defaults to one hour. ([#473], [#482])
-* The minimal supported Rust version is now 1.44.0. [(#444)]
+* The minimal supported Rust version is now 1.44.0. ([#444])
 
 New
 

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -499,7 +499,7 @@ impl<'a> Run<'a> {
     /// If you are not interested in the metrics, you can simple drop the
     /// value, instead.
     pub fn done(self, metrics: &mut Metrics) {
-        metrics.set_rrdp(self.metrics.into_inner().unwrap())
+        metrics.rrdp = self.metrics.into_inner().unwrap()
     }
 }
 

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -455,7 +455,7 @@ impl<'a> Run<'a> {
     /// If you are not interested in the metrics, you can simple drop the
     /// value, instead.
     pub fn done(self, metrics: &mut Metrics) {
-        metrics.set_rsync(self.metrics.into_inner().unwrap())
+        metrics.rsync = self.metrics.into_inner().unwrap();
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,11 @@
 //! Monitoring metrics.
+//!
+//! This module contains all types expressing metrics collected during a
+//! validation run. For each such run, there is an associated value of type
+//! [`Metrics`] that collects all metrics gathered during the run. Additional
+//! types contain the metrics related to specific processed entities.
 
-use std::{io, process};
+use std::{io, ops, process};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTimeError};
@@ -12,93 +17,55 @@ use uuid::Uuid;
 
 //------------ Metrics -------------------------------------------------------
 
+/// The metrics collected during a validation run.
 #[derive(Debug)]
 pub struct Metrics {
     /// Time when these metrics have been collected.
-    time: DateTime<Utc>,
-
-    /// Per-TAL metrics.
-    tals: Vec<TalMetrics>,
+    pub time: DateTime<Utc>,
 
     /// Rsync metrics.
-    rsync: Vec<RsyncModuleMetrics>,
+    pub rsync: Vec<RsyncModuleMetrics>,
 
     /// RRDP metrics.
-    rrdp: Vec<RrdpRepositoryMetrics>,
+    pub rrdp: Vec<RrdpRepositoryMetrics>,
 
-    /// Number of stale objects.
-    stale_count: AtomicU64,
+    /// Per-TAL metrics.
+    pub tals: Vec<TalMetrics>,
 
-    /// Number of VRPs added from local exceptions.
-    local_vrps: u32,
+    /// Per-repository metrics.
+    pub repositories: Vec<RepositoryMetrics>,
 
-    /// Final number of VRPs.
-    final_vrps: u32,
+    /// Overall publication metrics.
+    pub publication: PublicationMetrics,
+
+    /// VRP metrics for local exceptions.
+    pub local: VrpMetrics,
+
+    /// Overall VRP metrics.
+    pub vrps: VrpMetrics,
 }
 
 impl Metrics {
+    /// Creates a new metrics value with default metrics.
     pub fn new() -> Self {
         Metrics {
             time: Utc::now(),
-            tals: Vec::new(),
             rsync: Vec::new(),
             rrdp: Vec::new(),
-            stale_count: AtomicU64::new(0),
-            local_vrps: 0,
-            final_vrps: 0,
+            tals: Vec::new(),
+            repositories: Vec::new(),
+            publication: Default::default(),
+            local: Default::default(),
+            vrps: Default::default(),
         }
     }
 
-    pub fn stale_count(&self) -> u64 {
-        self.stale_count.load(Ordering::Relaxed)
-    }
-
-    pub fn inc_stale_count(&self) {
-        self.stale_count.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn push_tal(&mut self, tal: TalMetrics) {
-        self.tals.push(tal)
-    }
-
-    pub fn set_rsync(
-        &mut self,
-        rsync: Vec<RsyncModuleMetrics>
-    ) {
-        self.rsync = rsync
-    }
-
-    pub fn set_rrdp(
-        &mut self,
-        rrdp: Vec<RrdpRepositoryMetrics>
-    ) {
-        self.rrdp = rrdp
-    }
-
-    pub fn time(&self) -> DateTime<Utc> {
-        self.time
-    }
-
+    /// Returns the time the metrics were created as a Unix timestamp.
     pub fn timestamp(&self) -> i64 {
         self.time.timestamp()
     }
 
-    pub fn set_tals(&mut self, tals: Vec<TalMetrics>) {
-        self.tals = tals
-    }
-
-    pub fn tals(&self) -> &[TalMetrics] {
-        &self.tals
-    }
-
-    pub fn rsync(&self) -> &[RsyncModuleMetrics] {
-        &self.rsync
-    }
-
-    pub fn rrdp(&self) -> &[RrdpRepositoryMetrics] {
-        &self.rrdp
-    }
-
+    /// Returns whether all rsync processes have completed successfully.
     pub fn rsync_complete(&self) -> bool {
         for metrics in &self.rsync {
             match metrics.status {
@@ -108,22 +75,6 @@ impl Metrics {
             }
         }
         true
-    }
-
-    pub fn local_vrps(&self) -> u32 {
-        self.local_vrps
-    }
-
-    pub fn inc_local_vrps(&mut self) {
-        self.local_vrps += 1
-    }
-
-    pub fn final_vrps(&self) -> u32 {
-        self.final_vrps
-    }
-
-    pub fn set_final_vrps(&mut self, count: u32) {
-        self.final_vrps = count
     }
 }
 
@@ -140,57 +91,9 @@ impl AsRef<Self> for Metrics {
 }
 
 
-//------------ TalMetrics ----------------------------------------------------
-
-#[derive(Clone, Debug)]
-pub struct TalMetrics {
-    /// The TAL.
-    pub tal: Arc<TalInfo>,
-
-    /// Number of valid ROAs.
-    pub roas: u32,
-
-    /// Total number of valid VRPs.
-    ///
-    /// This is the total number of VRPs resulting from the validation run
-    /// before any filtering is done. In particular, this number includes
-    /// duplicate VRPs.
-    pub total_valid_vrps: u32,
-
-    /// Number of VRPs overlapping with rejected CAs.
-    pub unsafe_vrps: u32,
-
-    /// Number of VRPs filtered due to local exceptions.
-    pub locally_filtered_vrps: u32,
-
-    /// Number of duplicate VRPs.
-    ///
-    /// This number is only calculated after all filtering is done.
-    pub duplicate_vrps: u32,
-
-    /// Total number of VRPs in the final set.
-    ///
-    /// This is the number of unique valid VRPs minus filtered VRPs.
-    pub final_vrps: u32,
-}
-
-impl TalMetrics {
-    pub fn new(tal: Arc<TalInfo>) -> Self {
-        TalMetrics {
-            tal,
-            roas: 0,
-            total_valid_vrps: 0,
-            unsafe_vrps: 0,
-            locally_filtered_vrps: 0,
-            duplicate_vrps: 0,
-            final_vrps: 0,
-        }
-    }
-}
-
-
 //------------ RrdpRepositoryMetrics -----------------------------------------
 
+/// Metrics collected while updating an RRDP repository.
 #[derive(Clone, Debug)]
 pub struct RrdpRepositoryMetrics {
     /// The rpkiNotify URI of the RRDP repository.
@@ -228,11 +131,236 @@ impl RrdpRepositoryMetrics {
 
 //------------ RsyncModuleMetrics --------------------------------------------
 
+/// Metrics collected while updating an rsync module.
 #[derive(Debug)]
 pub struct RsyncModuleMetrics {
     pub module: uri::Rsync,
     pub status: Result<process::ExitStatus, io::Error>,
     pub duration: Result<Duration, SystemTimeError>,
+}
+
+
+//------------ TalMetrics ----------------------------------------------------
+
+/// Metrics for all publication points under a TAL.
+#[derive(Clone, Debug)]
+pub struct TalMetrics {
+    /// The TAL.
+    pub tal: Arc<TalInfo>,
+
+    /// Publication metrics.
+    pub publication: PublicationMetrics,
+
+    /// The VRP metrics.
+    pub vrps: VrpMetrics,
+}
+
+impl TalMetrics {
+    pub fn new(tal: Arc<TalInfo>) -> Self {
+        TalMetrics {
+            tal,
+            publication: Default::default(),
+            vrps: Default::default(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.tal.name()
+    }
+}
+
+
+//------------ RepositoryMetrics ---------------------------------------------
+
+/// Metrics for all publication points in a repository.
+#[derive(Clone, Debug)]
+pub struct RepositoryMetrics {
+    /// The repository URI as a string.
+    pub uri: String,
+
+    /// The publication metrics.
+    pub publication: PublicationMetrics,
+
+    /// The VRP metrics.
+    pub vrps: VrpMetrics,
+}
+
+impl RepositoryMetrics {
+    pub fn new(uri: String) -> Self {
+        RepositoryMetrics {
+            uri,
+            publication: Default::default(),
+            vrps: Default::default(),
+        }
+    }
+}
+
+
+//------------ PublicationMetrics --------------------------------------------
+
+/// Metrics regarding publication points and published objects.
+#[derive(Clone, Debug, Default)]
+pub struct PublicationMetrics {
+    /// The number of publication points.
+    pub valid_points: u32,
+
+    /// The number of rejected publication points.
+    pub rejected_points: u32,
+
+    /// The number of valid manifests.
+    pub valid_manifests: u32,
+
+    /// The number of invalid manifests.
+    pub invalid_manifests: u32,
+
+    /// The number of stale manifest.
+    pub stale_manifests: u32,
+
+    /// The number of missing manifests.
+    pub missing_manifests: u32,
+
+    /// The number of valid CRLs.
+    pub valid_crls: u32,
+
+    /// The number of invalid CRLs.
+    pub invalid_crls: u32,
+
+    /// The number of stale CRLs.
+    pub stale_crls: u32,
+
+    /// The number of stray CRLs.
+    ///
+    /// Stray CRLs are CRL objects appearing in publication points that are
+    /// not referenced by the manifest’s EE certificate. They make a
+    /// publication point invalid.
+    pub stray_crls: u32,
+
+    /// The number of valid CA certificates.
+    pub valid_ca_certs: u32,
+
+    /// The number of valid EE certificates.
+    pub valid_ee_certs: u32,
+
+    /// The number of invalid certificates.
+    pub invalid_certs: u32,
+
+    /// The number of valid ROAs.
+    pub valid_roas: u32,
+
+    /// The number of invalid ROAs.
+    pub invalid_roas: u32,
+
+    /// The number of valid GBRs.
+    pub valid_gbrs: u32,
+
+    /// The number of invald GBRs.
+    pub invalid_gbrs: u32,
+
+    /// The number of other objects.
+    pub others: u32,
+}
+
+impl PublicationMetrics {
+    /// Returns the number of stale objects.
+    pub fn stale_objects(&self) -> u32 {
+        self.stale_manifests + self.stale_crls
+    }
+}
+
+impl ops::Add for PublicationMetrics {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        let mut res = self.clone();
+        res += other;
+        res
+    }
+}
+
+impl<'a> ops::AddAssign<&'a Self> for PublicationMetrics {
+    fn add_assign(&mut self, other: &'a Self) {
+        self.valid_points += other.valid_points;
+        self.rejected_points += other.rejected_points;
+
+        self.valid_manifests += other.valid_manifests;
+        self.invalid_manifests += other.invalid_manifests;
+        self.stale_manifests += other.stale_manifests;
+        self.missing_manifests += other.missing_manifests;
+        self.valid_crls += other.valid_crls;
+        self.invalid_crls += other.invalid_crls;
+        self.stale_crls += other.stale_crls;
+        self.stray_crls += other.stray_crls;
+
+        self.valid_ca_certs += other.valid_ca_certs;
+        self.valid_ee_certs += other.valid_ee_certs;
+        self.invalid_certs += other.invalid_certs;
+        self.valid_roas += other.valid_roas;
+        self.invalid_roas += other.invalid_roas;
+        self.valid_gbrs += other.valid_gbrs;
+        self.invalid_gbrs += other.invalid_gbrs;
+        self.others += other.others;
+    }
+}
+
+impl ops::AddAssign for PublicationMetrics {
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other)
+    }
+}
+
+
+//------------ VrpMetrics ----------------------------------------------------
+
+/// Metrics regarding the generated VRP set.
+#[derive(Clone, Debug, Default)]
+pub struct VrpMetrics {
+    /// The total number of valid VRPs.
+    pub valid: u32,
+
+    /// The number of VRPs overlapping with rejected publication points.
+    pub marked_unsafe: u32,
+
+    /// The number of VRPs filtered due to local exceptions.
+    pub locally_filtered: u32,
+
+    /// The number of duplicate VRPs.
+    ///
+    /// This number is only calculated after local filtering. If duplicates
+    /// come from different entitites, who get’s to contribute their VRP and
+    /// whose gets filtered depends on the order of processing. This number
+    /// therefore has to be taken with a grain of salt.
+    pub duplicate: u32,
+
+    /// The total number of VRPs contributed to the final set.
+    ///
+    /// See the note on `duplicate_vrps` for caveats.
+    pub contributed: u32,
+}
+
+impl ops::Add for VrpMetrics {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        let mut res = self.clone();
+        res += other;
+        res
+    }
+}
+
+impl<'a> ops::AddAssign<&'a Self> for VrpMetrics {
+    fn add_assign(&mut self, other: &'a Self) {
+        self.valid += other.valid;
+        self.marked_unsafe += other.marked_unsafe;
+        self.locally_filtered += other.locally_filtered;
+        self.duplicate += other.duplicate;
+        self.contributed += other.contributed;
+    }
+}
+
+impl ops::AddAssign for VrpMetrics {
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other)
+    }
 }
 
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -652,25 +652,21 @@ fn summary_header<M: AsRef<Metrics>, W: io::Write>(
     output: &mut W,
 ) -> Result<(), io::Error> {
     let metrics = metrics.as_ref();
-    let mut roas = 0;
-    let mut valid_vrps = 0;
-    let mut unsafe_vrps = 0;
-    writeln!(output, "Summary at {}", metrics.time())?;
-    for tal in metrics.tals() {
+    writeln!(output, "Summary at {}", metrics.time)?;
+    for tal in &metrics.tals {
         writeln!(output,
             "{}: {} verified ROAs, {} verified VRPs, \
              {} unsafe VRPs, {} final VRPs.",
-            tal.tal.name(), tal.roas, tal.total_valid_vrps,
-            tal.unsafe_vrps, tal.final_vrps
+            tal.name(), tal.publication.valid_roas, tal.vrps.valid,
+            tal.vrps.marked_unsafe, tal.vrps.contributed
         )?;
-        roas += tal.roas;
-        valid_vrps += tal.total_valid_vrps;
-        unsafe_vrps += tal.unsafe_vrps;
     }
     writeln!(output,
         "total: {} verified ROAs, {} verified VRPs, \
          {} unsafe VRPs, {} final VRPs.",
-        roas, valid_vrps, unsafe_vrps, metrics.final_vrps(),
+        metrics.publication.valid_roas,
+        metrics.vrps.valid, metrics.vrps.marked_unsafe,
+        metrics.vrps.contributed,
     )
 }
 

--- a/src/rta.rs
+++ b/src/rta.rs
@@ -36,7 +36,7 @@ impl<'a> ValidationReport<'a> {
         &self,
         engine: &Engine,
     ) -> Result<(), Failed> {
-        let run = engine.start(self)?;
+        let mut run = engine.start(self)?;
         run.process()
     }
 
@@ -49,7 +49,8 @@ impl<'a, 's> ProcessRun for &'s ValidationReport<'a> {
     type ProcessCa = ValidateCa<'a, 's>;
 
     fn process_ta(
-        &self, tal: &Tal, _uri: &TalUri, _cert: &ResourceCert
+        &self, tal: &Tal, _uri: &TalUri, _cert: &ResourceCert,
+        _tal_index: usize
     ) -> Result<Option<Self::ProcessCa>, Failed> {
         let mut validation = self.validation.lock().unwrap();
         match validation.supply_tal(tal) {
@@ -87,7 +88,7 @@ impl<'a, 's> ProcessCa for ValidateCa<'a, 's> {
     }
 
     fn process_ca(
-        &mut self, _uri: &uri::Rsync, cert: &ResourceCert
+        &mut self, _uri: &uri::Rsync, cert: &ResourceCert,
     ) -> Result<Option<Self>, Failed> {
         if self.report.complete.load(Ordering::Relaxed) {
             return Ok(None)


### PR DESCRIPTION
This PR introduces a whole lot more metrics related to publication and validation. The already existing metrics over VRPs are now also provided per repository. In addition, metrics over the number and status of published objects are available per TAL, per repository, and overall.

Fixes #338. 