### PR TITLE
Always enable default-tls for reqwest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log             = "0.4.8"
 log-reroute     = "0.1.5"
 num_cpus        = "1.12.0"
 rand            = "0.8.1"
-reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip"] }
+reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "default-tls" ] }
 ring            = "0.16.12"
 rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr" ] }
 serde           = { version = "1.0.95", features = [ "derive" ] }
@@ -49,7 +49,7 @@ syslog          = "5.0.0"
 rustc_version   = "0.2.3"
 
 [features]
-default = ["rustls-tls", "socks", "ui"]
+default = [ "rustls-tls", "socks", "ui"]
 extra-debug = ["rpki/extra-debug"]
 socks = [ "reqwest/socks" ]
 rta = []


### PR DESCRIPTION
This allows Routinator to build with `--no-default-features`.

Fixes #411.