### PR TITLE
Bump minimum supported Rust version to 1.45.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.44.0, stable, beta, nightly]
+        rust: [1.45.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -63,7 +63,7 @@ Other Changes
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
 [#488]: https://github.com/NLnetLabs/routinator/pull/488
-[#???]: https://github.com/NLnetLabs/routinator/pull/498
+[#498]: https://github.com/NLnetLabs/routinator/pull/498
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ Breaking Changes
   now fall back to rsync. The time since last successful update before
   this fallback happens is configurable via the `rrdp-fallback-time`
   option and defaults to one hour. ([#473], [#482])
-* The minimal supported Rust version is now 1.45.0. ([#444], [#???])
+* The minimal supported Rust version is now 1.45.0. ([#444], [#498])
 
 New
 
@@ -63,7 +63,7 @@ Other Changes
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
 [#488]: https://github.com/NLnetLabs/routinator/pull/488
-[#???]: https://github.com/NLnetLabs/routinator/pull/???
+[#???]: https://github.com/NLnetLabs/routinator/pull/498
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ Breaking Changes
   now fall back to rsync. The time since last successful update before
   this fallback happens is configurable via the `rrdp-fallback-time`
   option and defaults to one hour. ([#473], [#482])
-* The minimal supported Rust version is now 1.44.0. ([#444])
+* The minimal supported Rust version is now 1.45.0. ([#444], [#???])
 
 New
 
@@ -63,6 +63,7 @@ Other Changes
 [#484]: https://github.com/NLnetLabs/routinator/pull/484
 [#487]: https://github.com/NLnetLabs/routinator/pull/487
 [#488]: https://github.com/NLnetLabs/routinator/pull/488
+[#???]: https://github.com/NLnetLabs/routinator/pull/???
 [rpki-rs]: https://github.com/NLnetLabs/rpki-rs/
 [rpki-rtr]: https://github.com/NLnetLabs/rpki-rtr/
 [@bjpbakker]: https://github.com/bjpbakker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.12.0 as build
+FROM alpine:3.13.3 as build
 
 RUN apk add rust cargo
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Support](https://doc.rust-lang.org/nightly/rustc/platform-support.html) page
 provides an overview of the various platforms and support levels.
 
 While some system distributions include Rust as system packages, Routinator
-relies on a relatively new version of Rust, currently 1.44 or newer. We
+relies on a relatively new version of Rust, currently 1.45 or newer. We
 therefore suggest to use the canonical Rust installation via a tool called
 `rustup`.
 

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,9 @@ use rustc_version::{Version, version};
 
 fn main() {
     let version = version().expect("Failed to get rustc version.");
-    if version < Version::parse("1.44.0").unwrap() {
+    if version < Version::parse("1.45.0").unwrap() {
         eprintln!(
-            "\n\nAt least Rust version 1.44 is required.\n\
+            "\n\nAt least Rust version 1.45 is required.\n\
              Version {} is used for building.\n\
              Build aborted.\n\n",
              version);


### PR DESCRIPTION
This requires the Docker build image to use Alpine 3.13. 