### PR TITLE
Gracefully handle bad manifest file entries.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1174,9 +1174,19 @@ impl<'a, P: ProcessRun> ValidPubPoint<'a, P> {
                     return Ok(false)
                 }
             };
-            let uri = self.point.cert.ca_repository().join(
+            let uri = match self.point.cert.ca_repository().join(
                 file.as_ref()
-            ).unwrap();
+            ) {
+                Ok(uri) => uri,
+                Err(_) => {
+                    warn!(
+                        "{}: illegal file name {} in manifest.",
+                        self.point.cert.rpki_manifest(),
+                        file
+                    );
+                    return Ok(false)
+                }
+            };
             let hash = ManifestHash::new(
                 hash, self.manifest.content.file_hash_alg()
             );


### PR DESCRIPTION
The new validation code forgot to deal with bad manifest file names. This PR corrects this oversight.