### PR TITLE
Build with no default features (second attempt).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log             = "0.4.8"
 log-reroute     = "0.1.5"
 num_cpus        = "1.12.0"
 rand            = "0.8.1"
-reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "default-tls" ] }
+reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "rustls-tls" ] }
 ring            = "0.16.12"
 rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr" ] }
 serde           = { version = "1.0.95", features = [ "derive" ] }
@@ -50,12 +50,11 @@ syslog          = "5.0.0"
 rustc_version   = "0.2.3"
 
 [features]
-default = [ "rustls-tls", "socks", "ui"]
+default = [ "socks", "ui"]
 extra-debug = ["rpki/extra-debug"]
 socks = [ "reqwest/socks" ]
 rta = []
 native-tls = [ "reqwest/native-tls", "tls" ]
-rustls-tls = [ "reqwest/rustls-tls", "tls" ]
 tls = []
 ui = []
 


### PR DESCRIPTION
Reqwest needs a feature to enable TLS but since features are cumulative, we can’t swap out one for another. Luckily, reqwest supports multiple TLS backends at the same time, so now we always include `rustls-tls` and let `native-tls` include that backend and let the HTTP client explicitly choose its backend based on the presence of the `native-tls` feature.

The previous attempt always included OpenSSL on vanilla Unix systems which caused build failures on minimal installations. 