### PR TITLE
Introduce ’jsonext’ output format. Rename filter options.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+#       os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         rust: [1.45.0, stable, beta, nightly]
     steps:
     - name: Checkout repository

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -465,6 +465,7 @@ not-before date and not-after date of the validity of the ROA.
 This format was used in the RIPE NCC RPKI Validator version 1. That version
 produces one file per trust anchor. This is not currently supported by
 Routinator -- all entries will be in one single output file.
+
 .TP
 .B json
 The list is placed into a JSON object with a single element
@@ -483,6 +484,48 @@ except for different naming of the trust anchor. Routinator uses the name
 of the TAL file without the extension
 .IR ".tal"
 whereas the RIPE NCC Validator has a dedicated name for each.
+
+.TP
+.B jsonext
+The list is placed into a JSON object with a single element
+.I "roas"
+which contains an array of objects with four elements each: The autonomous
+system number of the network authorized to originate a prefix in
+.IR "asn" ,
+the prefix in slash notation in
+.IR "prefix" ,
+the maximum prefix length of the announced route in
+.IR "maxLength" .
+.IP
+Extensive information about the source of the object is given the array
+.IR "source". Each item in that array is an object providing details of
+a source of the VRP. The object will have a
+.I "type"
+of
+.I "roa"
+if it was derived from a valid ROA object or
+.I "exception"
+if it was an assertion in a local exception file.
+.IP
+For ROAs,
+.I "uri"
+provides the rsync URI of the ROA,
+.I "validity"
+provides the validity of the ROA itself, and
+.I "chainValidity"
+the validity considering the validity of the certificates along the validation
+chain.
+.IP
+For assertions from local exceptions,
+.I "path"
+will provide the path of the local exceptions file and, optionally,
+.I "comment"
+will provide the comment if given for the assertion.
+.IP
+Please note that because of this additional information, output in
+.B jsonext
+format will be quite large.
+
 .TP
 .B openbgpd
 Choosing this format causes Routinator to produce a
@@ -532,13 +575,13 @@ If any of the rsync commands needed to update the repository failed, complete
 the operation but provide exit status 2. If this option is not given, the
 operation will complete with exit status 0 in this case.
 .TP
-.BI \-a \ asn\fR,\  \-\-filter\-asn= asn
+.BI \-a \ asn\fR,\  \-\-select\-asn= asn
 Only output VRPs for the given ASN. The option can be given multiple times,
 in which case VRPs for all provided ASNs are provided. ASNs can be given with
 or without the prefix
 .IR AS .
 .TP
-.BI \-p \ prefix\fR,\  \-\-filter\-prefix= prefix
+.BI \-p \ prefix\fR,\  \-\-select\-prefix= prefix
 Only output VRPs with an address prefix that covers the given prefix, i.e.,
 whose prefix is equal to or less specific than the given prefix. This will
 include VRPs regardless of their ASN and max length. In other words, the
@@ -546,8 +589,8 @@ output will include all VRPs that need to be considered when deciding whether
 an announcement for the prefix is RPKI valid or invalid.
 .IP
 The option can be given multiple times, in which case VRPs for all prefixes
-are provided. It can also be combined with one or more ASN filters. Then all
-matching VRPs are included. That is, filters combine as "or" not "and."
+are provided. It can also be combined with one or more ASN selections. Then
+all matching VRPs are included. That is, selectors combine as "or" not "and."
 
 .SS validate
 This command can be used to perform RPKI route origin validation for a route
@@ -1114,12 +1157,12 @@ at a path with the same name as the output format. E.g., the CSV output is
 available at
 .BR /csv .
 .P
-These paths accept filter expressions to
+These paths accept selector expressions to
 limit the VRPs returned in the form of a query string. The field
-.B filter-asn
-can be used to filter for ASNs and the field
-.B filter-prefix
-can be used to filter for prefixes. The fields can be repeated multiple
+.B select-asn
+can be used to select ASNs and the field
+.B select-prefix
+can be used to select prefixes. The fields can be repeated multiple
 times.
 .P
 This works in the same way as the options of the same name to the

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -498,7 +498,8 @@ the maximum prefix length of the announced route in
 .IR "maxLength" .
 .IP
 Extensive information about the source of the object is given the array
-.IR "source". Each item in that array is an object providing details of
+.IR "source".
+Each item in that array is an object providing details of
 a source of the VRP. The object will have a
 .I "type"
 of

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -34,7 +34,7 @@ use crate::config::Config;
 use crate::error::{ExitError, Failed};
 use crate::http::http_listener;
 use crate::metrics::ServerMetrics;
-use crate::output;
+use crate::output as output;
 use crate::output::OutputFormat;
 use crate::payload::{AddressPrefix, PayloadSnapshot, SharedHistory};
 use crate::process::Process;
@@ -533,7 +533,7 @@ impl Server {
         let join = thread::spawn(move || {
             loop {
                 let timeout = match LocalExceptions::load(
-                    process.config(), false
+                    process.config(), true
                 ) {
                     Ok(exceptions) => {
                         if Self::process_once(
@@ -642,7 +642,7 @@ pub struct Vrps {
     format: OutputFormat,
 
     /// Optional output filters.
-    filters: Option<Vec<output::Filter>>,
+    selection: Option<output::Selection>,
 
     /// Don’t update the repository.
     noupdate: bool,
@@ -668,7 +668,6 @@ impl Vrps {
                 .short("f")
                 .long("format")
                 .value_name("FORMAT")
-                .possible_values(OutputFormat::VALUES)
                 .default_value(OutputFormat::DEFAULT_VALUE)
                 .help("Sets the output format")
                 .takes_value(true)
@@ -682,17 +681,19 @@ impl Vrps {
                 .long("complete")
                 .help("Return an error status on incomplete update")
             )
-            .arg(Arg::with_name("filter-prefix")
+            .arg(Arg::with_name("select-prefix")
                 .short("p")
-                .long("filter-prefix")
+                .long("select-prefix")
+                .alias("filter-prefix")
                 .help("Filter for an address prefix")
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1)
             )
-            .arg(Arg::with_name("filter-asn")
+            .arg(Arg::with_name("select-asn")
                 .short("a")
-                .long("filter-asn")
+                .long("select-asn")
+                .alias("filter-asn")
                 .help("Filter for an AS number")
                 .takes_value(true)
                 .multiple(true)
@@ -705,32 +706,45 @@ impl Vrps {
     pub fn from_arg_matches(
         matches: &ArgMatches,
     ) -> Result<Self, Failed> {
+        let format = matches.value_of("output").unwrap_or(
+            OutputFormat::DEFAULT_VALUE
+        );
+        let format = match OutputFormat::from_str(format) {
+            Ok(format) => format,
+            Err(_) => {
+                error!("Unknown output format '{}'", format);
+                return Err(Failed)
+            }
+        };
         Ok(Vrps {
-            filters: Self::output_filters(matches)?,
+            selection: Self::output_selection(matches)?,
             output: match matches.value_of("output").unwrap() {
                 "-" => None,
                 path => Some(path.into())
             },
-            format: OutputFormat::from_str(
-                matches.value_of("format").unwrap()
-            )?,
+            format,
             noupdate: matches.is_present("noupdate"),
             complete: matches.is_present("complete"),
         })
     }
 
-    /// Creates the filters for the vrps command.
-    fn output_filters(
+    /// Creates the selection for the vrps command.
+    fn output_selection(
         matches: &ArgMatches
-    ) -> Result<Option<Vec<output::Filter>>, Failed> {
-        let mut res = Vec::new();
-        if let Some(list) = matches.values_of("filter-prefix") {
+    ) -> Result<Option<output::Selection>, Failed> {
+        if !matches.is_present("select-prefix")
+            && !matches.is_present("select-asn")
+        {
+            return Ok(None)
+        }
+        let mut res = output::Selection::new();
+        if let Some(list) = matches.values_of("select-prefix") {
             for value in list {
                 match AddressPrefix::from_str(value) {
-                    Ok(some) => res.push(output::Filter::Prefix(some)),
+                    Ok(some) => res.push_origin_prefix(some),
                     Err(_) => {
                         error!(
-                            "Invalid prefix \"{}\" in --filter-prefix",
+                            "Invalid prefix \"{}\" in --select-prefix",
                             value
                         );
                         return Err(Failed)
@@ -738,27 +752,21 @@ impl Vrps {
                 }
             }
         }
-        if let Some(list) = matches.values_of("filter-asn") {
+        if let Some(list) = matches.values_of("select-asn") {
             for value in list {
-                let asn = match AsId::from_str(value) {
-                    Ok(asn) => asn,
+                match AsId::from_str(value) {
+                    Ok(asn) => res.push_origin_asn(asn),
                     Err(_) => {
                         error!(
-                            "Invalid ASN \"{}\" in --filter-asn",
+                            "Invalid ASN \"{}\" in --select-asn",
                             value
                         );
                         return Err(Failed)
                     }
-                };
-                res.push(output::Filter::As(asn))
+                }
             }
         }
-        if res.is_empty() {
-            Ok(None)
-        }
-        else {
-            Ok(Some(res))
-        }
+        Ok(Some(res))
     }
 
     /// Produces a list of Validated ROA Payload.
@@ -781,7 +789,6 @@ impl Vrps {
             process.config().unsafe_vrps,
         );
         validation.cleanup()?;
-        let filters = self.filters.as_ref().map(AsRef::as_ref);
         let res = match self.output {
             Some(ref path) => {
                 let mut file = match fs::File::create(path) {
@@ -794,12 +801,15 @@ impl Vrps {
                         return Err(Failed.into())
                     }
                 };
-                self.format.output(&vrps, filters, &metrics, &mut file)
+                self.format.output_snapshot(
+                    &vrps, self.selection.as_ref(), &metrics, &mut file)
             }
             None => {
                 let out = io::stdout();
                 let mut out = out.lock();
-                self.format.output(&vrps, filters, &metrics, &mut out)
+                self.format.output_snapshot(
+                    &vrps, self.selection.as_ref(), &metrics, &mut out
+                )
             }
         };
         if let Err(err) = res {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,18 +1,16 @@
-//! Output of lists of VRPs.
+//! Output of validated RPKI payload.
 
-// Some functions here have unnecessarily wrapped return types for
-// consisitency.
-#![allow(clippy::unnecessary_wraps)]
-
-use std::io;
+use std::{error, fmt, io};
 use std::str::FromStr;
+use std::sync::Arc;
 use chrono::Utc;
 use chrono::format::{Item, Numeric, Pad};
 use log::error;
 use rpki::repository::resources::AsId;
+use crate::payload;
 use crate::error::Failed;
-use crate::metrics::Metrics;
 use crate::payload::{AddressPrefix, OriginInfo, PayloadSnapshot, RouteOrigin};
+use crate::metrics::Metrics;
 
 
 //------------ OutputFormat --------------------------------------------------
@@ -74,15 +72,97 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    /// A list of the known output formats.
-    pub const VALUES: &'static [&'static str] = &[
-        "csv", "csvcompat", "csvext", "json", "openbgpd", "bird1", "bird2",
-        "rpsl", "summary", "none"
+    /// All known output formats names and their values.
+    const VALUES: &'static [(&'static str, Self)] = &[
+        ("csv", OutputFormat::Csv),
+        ("csvcompat", OutputFormat::CompatCsv),
+        ("csvext", OutputFormat::ExtendedCsv),
+        ("json", OutputFormat::Json),
+        ("openbgpd", OutputFormat::Openbgpd),
+        ("bird1", OutputFormat::Bird1),
+        ("bird2", OutputFormat::Bird2),
+        ("rpsl", OutputFormat::Rpsl),
+        ("summary", OutputFormat::Summary),
+        ("none", OutputFormat::None),
     ];
 
-    /// The default output format.
+    /// The default output format name.
     pub const DEFAULT_VALUE: &'static str = "csv";
 }
+
+impl OutputFormat {
+    /// Returns the output format for a given request path.
+    pub fn from_path(path: &str) -> Option<Self> {
+        if !path.starts_with('/') {
+            return None
+        }
+        Self::try_from_str(&path[1..])
+    }
+
+    /// Returns the output format for the given string if it is valid.
+    fn try_from_str(value: &str) -> Option<Self> {
+        for &(name, res) in Self::VALUES {
+            if name == value {
+                return Some(res)
+            }
+        }
+        None
+    }
+
+    /// Returns the media type string for this output format.
+    pub fn content_type(self) -> &'static str {
+        match self {
+            OutputFormat::Csv | OutputFormat::CompatCsv |
+            OutputFormat::ExtendedCsv
+                => "text/csv;charset=utf-8;header=present",
+            OutputFormat::Json => "application/json",
+            _ => "text/plain;charset=utf-8",
+        }
+    }
+
+    /// Outputs a payload snapshot to a writer.
+    pub fn output_snapshot<W: io::Write>(
+        self,
+        snapshot: &PayloadSnapshot,
+        selection: Option<&Selection>,
+        metrics: &Metrics,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
+        let mut stream = OutputStream::new(
+            self, snapshot, selection, metrics
+        );
+        while stream.write_next(target)? { }
+        Ok(())
+    }
+
+    /// Creates an output stream for this format.
+    pub fn stream(
+        self,
+        snapshot: Arc<PayloadSnapshot>,
+        selection: Option<Selection>,
+        metrics: Arc<Metrics>,
+    ) -> impl Iterator<Item = Vec<u8>> {
+        OutputStream::new(self, snapshot, selection, metrics)
+    }
+
+    fn formatter<W: io::Write>(self) -> Box<dyn Formatter<W> + Send> {
+        match self {
+            OutputFormat::Csv => Box::new(Csv),
+            OutputFormat::CompatCsv => Box::new(CompatCsv),
+            OutputFormat::ExtendedCsv => Box::new(ExtendedCsv),
+            OutputFormat::Json => Box::new(Json),
+            OutputFormat::Openbgpd => Box::new(Openbgpd),
+            OutputFormat::Bird1 => Box::new(Bird1),
+            OutputFormat::Bird2 => Box::new(Bird2),
+            OutputFormat::Rpsl => Box::new(Rpsl),
+            OutputFormat::Summary => Box::new(Summary),
+            OutputFormat::None => Box::new(NoOutput),
+        }
+    }
+}
+
+
+//--- FromStr
 
 impl FromStr for OutputFormat {
     type Err = Failed;
@@ -95,76 +175,96 @@ impl FromStr for OutputFormat {
     }
 }
 
-impl OutputFormat {
-    /// Returns the output format for a string if any.
-    pub fn try_from_str(value: &str) -> Option<Self> {
-        match value {
-            "csv" => Some(OutputFormat::Csv),
-            "csvcompat" => Some(OutputFormat::CompatCsv),
-            "csvext" => Some(OutputFormat::ExtendedCsv),
-            "json" => Some(OutputFormat::Json),
-            "openbgpd" => Some(OutputFormat::Openbgpd),
-            "bird1" => Some(OutputFormat::Bird1),
-            "bird2" => Some(OutputFormat::Bird2),
-            "rpsl" => Some(OutputFormat::Rpsl),
-            "summary" => Some(OutputFormat::Summary),
-            "none" => Some(OutputFormat::None),
-            _ => None,
+
+//------------ Selection -----------------------------------------------------
+
+/// A set of rules defining which payload to include in output.
+#[derive(Clone, Debug, Default)]
+pub struct Selection {
+    origins: Vec<SelectOrigin>,
+}
+
+impl Selection {
+    /// Creates a new, empty selection.
+    pub fn new() -> Self {
+        Selection::default()
+    }
+
+    /// Creates a selection from a HTTP query string.
+    pub fn from_query(query: Option<&str>) -> Result<Option<Self>, QueryError> {
+        let query = match query {
+            Some(query) => query,
+            None => return Ok(None)
+        };
+
+        let mut res = Self::default();
+        for (key, value) in form_urlencoded::parse(query.as_ref()) {
+            if key == "select-prefix" || key == "filter-prefix" {
+                res.origins.push(
+                    SelectOrigin::Prefix(AddressPrefix::from_str(&value)?)
+                );
+            }
+            else if key == "select-asn" || key == "select-prefix" {
+                res.origins.push(
+                    SelectOrigin::AsId(
+                        AsId::from_str(&value).map_err(|_| QueryError)?
+                    )
+                );
+            }
+            else {
+                return Err(QueryError)
+            }
         }
+
+        Ok(Some(res))
     }
 
-    /// Returns the output format for a given request path.
-    pub fn from_path(path: &str) -> Option<Self> {
-        if !path.starts_with('/') {
-            return None
+    /// Add an origin ASN to select.
+    pub fn push_origin_asn(&mut self, asn: AsId) {
+        self.origins.push(SelectOrigin::AsId(asn))
+    }
+
+    /// Add a origin prefix to select.
+    pub fn push_origin_prefix(&mut self, prefix: AddressPrefix) {
+        self.origins.push(SelectOrigin::Prefix(prefix))
+    }
+
+    /// Returns whether payload should be included in output.
+    pub fn include_origin(&self, origin: RouteOrigin) -> bool {
+        for select in &self.origins {
+            if select.include_origin(origin) {
+                return true
+            }
         }
-        Self::try_from_str(&path[1..])
+        false
     }
+}
 
-    /// Returns whether this output format requires extra output.
-    pub fn extra_output(self) -> bool {
-        matches!(self, OutputFormat::ExtendedCsv)
+impl AsRef<Selection> for Selection {
+    fn as_ref(&self) -> &Self {
+        self
     }
+}
 
-    /// Returns whether this output format requires metrics.
-    pub fn needs_metrics(self) -> bool {
-        matches!(self, OutputFormat::Summary)
-    }
 
-    /// Creates an output stream for this format.
-    pub fn stream<T, F, M>(
-        self,
-        origins: T,
-        filters: Option<F>,
-        metrics: M
-    ) -> OutputStream<T, F, M> {
-        OutputStream::new(origins, self, filters, metrics)
-    }
+//------------ SelectOrigin --------------------------------------------------
 
-    /// Outputs `vrps` to `target` in this format.
-    ///
-    /// This method loggs error messages.
-    pub fn output<W: io::Write>(
-        self,
-        vrps: &PayloadSnapshot,
-        filters: Option<&[Filter]>,
-        metrics: &Metrics,
-        target: &mut W,
-    ) -> Result<(), io::Error> {
-        match self.stream(vrps, filters, metrics).output(target) {
-            Ok(()) => Ok(()),
-            Err(ref err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
-            Err(err) => Err(err)
-        }
-    }
+/// A selection rule for origins.
+#[derive(Clone, Copy, Debug)]
+enum SelectOrigin {
+    /// Include resources related to the given ASN.
+    AsId(AsId),
 
-    pub fn content_type(self) -> &'static str {
+    /// Include resources related to the given prefix.
+    Prefix(AddressPrefix),
+}
+
+impl SelectOrigin {
+    /// Returns whether this rule selects payload.
+    fn include_origin(self, origin: RouteOrigin) -> bool {
         match self {
-            OutputFormat::Csv | OutputFormat::CompatCsv |
-            OutputFormat::ExtendedCsv
-                => "text/csv;charset=utf-8;header=present",
-            OutputFormat::Json => "application/json",
-            _ => "text/plain;charset=utf-8",
+            SelectOrigin::AsId(as_id) => origin.as_id() == as_id,
+            SelectOrigin::Prefix(prefix) => origin.prefix().covers(prefix),
         }
     }
 }
@@ -172,570 +272,454 @@ impl OutputFormat {
 
 //------------ OutputStream --------------------------------------------------
 
-pub struct OutputStream<T, F, M> {
-    snapshot: T,
-    next_id: usize,
-    format: OutputFormat,
-    filters: Option<F>,
-    metrics: M,
-} 
+struct OutputStream<Snap, Sel, Met, Target> {
+    snapshot: Snap,
+    state: StreamState,
+    formatter: Box<dyn Formatter<Target> + Send>,
+    selection: Option<Sel>,
+    metrics: Met,
+}
 
-impl<T, F, M> OutputStream<T, F, M> {
+enum StreamState {
+    Header,
+    Origin { index: usize, first: bool },
+    Done,
+}
+
+impl<Snap, Sel, Met, Target> OutputStream<Snap, Sel, Met, Target>
+where
+    Snap: AsRef<PayloadSnapshot>,
+    Sel: AsRef<Selection>,
+    Met: AsRef<Metrics>,
+    Target: io::Write,
+{
+    /// Creates a new output stream.
     fn new(
-        snapshot: T,
         format: OutputFormat,
-        filters: Option<F>,
-        metrics: M,
+        snapshot: Snap,
+        selection: Option<Sel>,
+        metrics: Met,
     ) -> Self {
-        Self {
+        OutputStream {
             snapshot,
-            next_id: 0,
-            format,
-            filters,
-            metrics
+            state: StreamState::Header,
+            formatter: format.formatter(),
+            selection,
+            metrics,
         }
     }
-}
 
-impl<T, F, M> OutputStream<T, F, M>
-where
-    T: AsRef<PayloadSnapshot>,
-    F: AsRef<[Filter]>,
-    M: AsRef<Metrics>
-{
-    pub fn output<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
-        self.output_header(target)?;
-        let mut first = true;
-        for item in self.snapshot.as_ref().origins() {
-            if self.output_origin(item.0, &item.1, first, target)? {
-                first = false;
+    /// Writes the next item to the target.
+    ///
+    /// Returns whether it wrote an item.
+    fn write_next(&mut self, target: &mut Target) -> Result<bool, io::Error> {
+        match self.state {
+            StreamState::Header => {
+                self.formatter.header(
+                    self.snapshot.as_ref(), self.metrics.as_ref(), target
+                )?;
+                self.state = StreamState::Origin { index: 0, first: true };
+                Ok(true)
             }
-        }
-        self.output_footer(target)
-    }
-
-    pub fn output_len(&self) -> usize {
-        GetLength::get(|w| self.output(w).unwrap())
-    }
-
-    pub fn output_start<W: io::Write>(
-        &mut self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
-        self.output_header(target)?;
-        self.next_batch(true, target)
-    }
-
-    fn has_next_batch(&self) -> bool {
-        self.next_id < self.snapshot.as_ref().origins().len()
-    }
-
-    fn next_batch<W: io::Write>(
-        &mut self,
-        mut first: bool,
-        target: &mut W 
-    ) -> Result<(), io::Error> {
-        let origins = self.snapshot.as_ref().origins();
-        let mut len = 0;
-        while self.next_id < origins.len() && len < 1000 {
-            let item = &origins[self.next_id];
-            if self.output_origin(item.0, &item.1, first, target
-            )? {
-                first = false;
-                len += 1;
-            }
-            self.next_id += 1;
-        }
-        if self.next_id == origins.len() {
-            self.output_footer(target)?;
-        }
-        Ok(())
-    }
-
-    pub fn output_header<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
-        let vrps = self.snapshot.as_ref();
-        match self.format {
-            OutputFormat::Csv => csv_header(vrps, target),
-            OutputFormat::CompatCsv => compat_csv_header(vrps, target),
-            OutputFormat::ExtendedCsv => ext_csv_header(vrps, target),
-            OutputFormat::Json => json_header(vrps, target),
-            OutputFormat::Openbgpd => openbgpd_header(vrps, target),
-            OutputFormat::Bird1 => bird1_header(vrps, target),
-            OutputFormat::Bird2 => bird2_header(vrps, target),
-            OutputFormat::Rpsl => rpsl_header(vrps, target),
-            OutputFormat::Summary => summary_header(&self.metrics, target),
-            OutputFormat::None => Ok(())
-        }
-    }
-
-    pub fn output_origin<W: io::Write>(
-        &self,
-        vrp: RouteOrigin,
-        info: &OriginInfo,
-        first: bool,
-        target: &mut W
-    ) -> Result<bool, io::Error> {
-        if self.skip_origin(vrp) {
-            return Ok(false)
-        }
-        match self.format {
-            OutputFormat::Csv => csv_origin(vrp, info, first, target)?,
-            OutputFormat::CompatCsv => {
-                compat_csv_origin(vrp, info, first, target)?
-            }
-            OutputFormat::ExtendedCsv => {
-                ext_csv_origin(vrp, info, first, target)?
-            }
-            OutputFormat::Json => json_origin(vrp, info, first, target)?,
-            OutputFormat::Openbgpd => {
-                openbgpd_origin(vrp, info, first, target)?
-            }
-            OutputFormat::Bird1 => bird1_origin(vrp, info, first, target)?,
-            OutputFormat::Bird2 => bird2_origin(vrp, info, first, target)?,
-            OutputFormat::Rpsl => rpsl_origin(vrp, info, first, target)?,
-            _ => { }
-        }
-        Ok(true)
-    }
-
-    fn skip_origin(
-        &self, 
-        origin: RouteOrigin,
-    ) -> bool {
-        match self.filters.as_ref() {
-            Some(filters) => {
-                for filter in filters.as_ref() {
-                    if filter.covers(origin) {
-                        return false
+            StreamState::Origin { mut index, first } => {
+                loop {
+                    let (origin, info) = match
+                        self.snapshot.as_ref().origins().get(index)
+                    {
+                        Some(item) => (item.0, &item.1),
+                        None => {
+                            self.formatter.footer(
+                                self.metrics.as_ref(), target
+                            )?;
+                            self.state = StreamState::Done;
+                            break
+                        }
+                    };
+                    index += 1;
+                    if let Some(selection) = self.selection.as_ref() {
+                        if !selection.as_ref().include_origin(origin) {
+                            continue
+                        }
                     }
+                    if !first {
+                        self.formatter.delimiter(target)?;
+                    }
+                    self.formatter.origin(origin, info, target)?;
+                    self.state = StreamState::Origin { index, first: false };
+                    break
                 }
-                true
+                Ok(true)
             }
-            None => false
+            StreamState::Done => Ok(false)
         }
     }
-
-    pub fn output_footer<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
-        let vrps = self.snapshot.as_ref();
-        match self.format {
-            OutputFormat::Csv => csv_footer(vrps, target),
-            OutputFormat::CompatCsv => compat_csv_footer(vrps, target),
-            OutputFormat::ExtendedCsv => ext_csv_footer(vrps, target),
-            OutputFormat::Json => json_footer(vrps, target),
-            OutputFormat::Openbgpd => openbgpd_footer(vrps, target),
-            OutputFormat::Bird1 => bird1_footer(vrps, target),
-            OutputFormat::Bird2 => bird2_footer(vrps, target),
-            OutputFormat::Rpsl => rpsl_footer(vrps, target),
-            _ => Ok(())
-        }
-    }
-
 }
 
-impl<T, F, M> Iterator for OutputStream<T, F, M>
-where
-    T: AsRef<PayloadSnapshot>,
-    F: AsRef<[Filter]>,
-    M: AsRef<Metrics>
-{
+impl Iterator for OutputStream<
+    Arc<PayloadSnapshot>, Selection, Arc<Metrics>, Vec<u8>
+> {
     type Item = Vec<u8>;
 
-    fn next(&mut self) -> Option<Vec<u8>> {
-        if self.next_id == 0 {
-            let mut target = Vec::new();
-            self.output_start(&mut target).unwrap();
-            Some(target)
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut res = Vec::new();
+        while self.write_next(&mut res).expect("write to vec failed") {
+            if res.len() > 64000 {
+                return Some(res)
+            }
         }
-        else if !self.has_next_batch() {
+        if res.is_empty() {
             None
         }
         else {
-            let mut target = Vec::new();
-            self.next_batch(false, &mut target).unwrap();
-            Some(target)
+            Some(res)
         }
     }
 }
 
 
-//------------ csv -----------------------------------------------------------
+//------------ QueryError ----------------------------------------------------
 
-fn csv_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "ASN,IP Prefix,Max Length,Trust Anchor")
-}
+#[derive(Debug)]
+pub struct QueryError;
 
-fn csv_origin<W: io::Write>(
-    addr: RouteOrigin,
-    info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "{},{}/{},{},{}",
-        addr.as_id(),
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-        info.tal_name().unwrap_or("N/A"),
-    )
-}
-
-fn csv_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ compat_csv ----------------------------------------------------
-
-fn compat_csv_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "\"ASN\",\"IP Prefix\",\"Max Length\",\"Trust Anchor\"")
-}
-
-fn compat_csv_origin<W: io::Write>(
-    addr: RouteOrigin,
-    info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "\"{}\",\"{}/{}\",\"{}\",\"{}\"",
-        u32::from(addr.as_id()),
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-        info.tal_name().unwrap_or("N/A"),
-    )
-}
-
-fn compat_csv_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ ext_csv -------------------------------------------------------
-
-// 2017-08-25 13:12:19
-const EXT_CSV_TIME_ITEMS: &[Item<'static>] = &[
-    Item::Numeric(Numeric::Year, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Month, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Day, Pad::Zero),
-    Item::Literal(" "),
-    Item::Numeric(Numeric::Hour, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Minute, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Second, Pad::Zero),
-];
-
-fn ext_csv_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "URI,ASN,IP Prefix,Max Length,Not Before,Not After")
-}
-
-fn ext_csv_origin<W: io::Write>(
-    addr: RouteOrigin,
-    info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    write!(output, "{},{},{}/{},{},",
-        info.uri().map(|uri| uri.as_str()).unwrap_or("N/A"),
-        addr.as_id(),
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-    )?;
-    match info.validity() {
-        Some(validity) => {
-            writeln!(output, "{},{}",
-                validity.not_before().format_with_items(
-                    EXT_CSV_TIME_ITEMS.iter().cloned()
-                ),
-                validity.not_after().format_with_items(
-                    EXT_CSV_TIME_ITEMS.iter().cloned()
-                )
-            )
-        }
-        None => writeln!(output, "N/A,N/A"),
+impl From<payload::FromStrError> for QueryError {
+    fn from(_: payload::FromStrError) -> Self {
+        QueryError
     }
 }
 
-fn ext_csv_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ json ----------------------------------------------------------
-
-fn json_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "{{\n  \"roas\": [")
-}
-
-fn json_origin<W: io::Write>(
-    addr: RouteOrigin,
-    info: &OriginInfo,
-    first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    if !first {
-        writeln!(output, ",")?;
-    }
-    write!(output,
-        "    {{ \"asn\": \"{}\", \"prefix\": \"{}/{}\", \
-        \"maxLength\": {}, \"ta\": \"{}\" }}",
-        addr.as_id(),
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-        info.tal_name().unwrap_or("N/A"),
-    )
-}
-
-fn json_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "\n  ]\n}}")
-}
-
-
-//------------ openbgpd ------------------------------------------------------
-
-fn openbgpd_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "roa-set {{")
-}
-
-fn openbgpd_origin<W: io::Write>(
-    addr: RouteOrigin,
-    _info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    write!(output, "    {}/{}", addr.address(), addr.address_length())?;
-    if addr.address_length() < addr.max_length() {
-        write!(output, " maxlen {}", addr.max_length())?;
-    }
-    writeln!(output, " source-as {}", u32::from(addr.as_id()))
-}
-
-fn openbgpd_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "}}")
-}
-
-
-//------------ bird1 ------------------------------------------------------
-
-fn bird1_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-fn bird1_origin<W: io::Write>(
-    addr: RouteOrigin,
-    _info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "roa {}/{} max {} as {};",
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-        u32::from(addr.as_id()))
-}
-
-fn bird1_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ bird2 ------------------------------------------------------
-
-fn bird2_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-fn bird2_origin<W: io::Write>(
-    addr: RouteOrigin,
-    _info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    writeln!(output, "route {}/{} max {} as {};",
-        addr.address(), addr.address_length(),
-        addr.max_length(),
-        u32::from(addr.as_id()))
-}
-
-fn bird2_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ rpsl ----------------------------------------------------------
-
-// 2017-08-25T13:12:19Z
-const RPSL_TIME_ITEMS: &[Item<'static>] = &[
-    Item::Numeric(Numeric::Year, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Month, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Day, Pad::Zero),
-    Item::Literal("T"),
-    Item::Numeric(Numeric::Hour, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Minute, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Second, Pad::Zero),
-    Item::Literal("Z"),
-];
-
-fn rpsl_header<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-fn rpsl_origin<W: io::Write>(
-    addr: RouteOrigin,
-    info: &OriginInfo,
-    _first: bool,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    let now = Utc::now().format_with_items(RPSL_TIME_ITEMS.iter().cloned());
-    writeln!(output,
-        "\n{}: {}/{}\norigin: {}\n\
-        descr: RPKI attestation\nmnt-by: NA\ncreated: {}\n\
-        last-modified: {}\nsource: ROA-{}-RPKI-ROOT\n",
-        if addr.address().is_ipv4() { "route" }
-        else { "route6" },
-        addr.address(), addr.address_length(),
-        addr.as_id(), now, now,
-        info.tal_name().map(|name| {
-            name.to_uppercase()
-        }).unwrap_or_else(|| "N/A".into())
-    )
-}
-
-fn rpsl_footer<W: io::Write>(
-    _vrps: &PayloadSnapshot,
-    _output: &mut W,
-) -> Result<(), io::Error> {
-    Ok(())
-}
-
-
-//------------ summary -------------------------------------------------------
-
-fn summary_header<M: AsRef<Metrics>, W: io::Write>(
-    metrics: &M,
-    output: &mut W,
-) -> Result<(), io::Error> {
-    let metrics = metrics.as_ref();
-    writeln!(output, "Summary at {}", metrics.time)?;
-    for tal in &metrics.tals {
-        writeln!(output,
-            "{}: {} verified ROAs, {} verified VRPs, \
-             {} unsafe VRPs, {} final VRPs.",
-            tal.name(), tal.publication.valid_roas, tal.vrps.valid,
-            tal.vrps.marked_unsafe, tal.vrps.contributed
-        )?;
-    }
-    writeln!(output,
-        "total: {} verified ROAs, {} verified VRPs, \
-         {} unsafe VRPs, {} final VRPs.",
-        metrics.publication.valid_roas,
-        metrics.vrps.valid, metrics.vrps.marked_unsafe,
-        metrics.vrps.contributed,
-    )
-}
-
-
-//------------ Filter --------------------------------------------------------
-
-#[derive(Clone, Copy, Debug)]
-pub enum Filter {
-    As(AsId),
-    Prefix(AddressPrefix),
-}
-
-impl Filter {
-    /// Returns whether this filter covers this origin.
-    fn covers(self, origin: RouteOrigin) -> bool {
-        match self {
-            Filter::As(as_id) => origin.as_id() == as_id,
-            Filter::Prefix(prefix) => origin.prefix().covers(prefix)
-        }
+impl fmt::Display for QueryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid query")
     }
 }
 
+impl error::Error for QueryError { }
 
-//------------ GetLength -----------------------------------------------------
 
-/// A writer that adds up the length of whatever has been written.
-#[derive(Clone, Copy, Debug, Default)]
-struct GetLength(usize);
+//------------ Formatter -----------------------------------------------------
 
-impl GetLength {
-    /// Returns the length of what’s been written in the closure.
-    ///
-    /// The closure receives a writer it should write to.
-    pub fn get<F: FnOnce(&mut Self)>(op: F) -> usize {
-        let mut target = Self::default();
-        op(&mut target);
-        target.0
-    }
-}
-
-impl io::Write for GetLength {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
-        self.0 += buf.len();
-        Ok(buf.len())
+trait Formatter<W> {
+    fn header(
+        &self, snapshot: &PayloadSnapshot, metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        let _ = (snapshot, metrics, target);
+        Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), io::Error> {
+    fn footer(
+        &self, metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        let _ = (metrics, target);
+        Ok(())
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error>;
+
+    fn delimiter(&self, target: &mut W) -> Result<(), io::Error> {
+        let _ = target;
         Ok(())
     }
 }
+
+
+//------------ Csv -----------------------------------------------------------
+
+struct Csv;
+
+impl<W: io::Write> Formatter<W> for Csv {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "ASN,IP Prefix,Max Length,Trust Anchor")
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "{},{}/{},{},{}",
+            origin.as_id(),
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+            info.tal_name().unwrap_or("N/A"),
+        )
+    }
+}
+
+
+//------------ CompatCsv -----------------------------------------------------
+
+struct CompatCsv;
+
+impl<W: io::Write> Formatter<W> for CompatCsv {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(
+            target, "\"ASN\",\"IP Prefix\",\"Max Length\",\"Trust Anchor\""
+        )
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "\"{}\",\"{}/{}\",\"{}\",\"{}\"",
+            origin.as_id(),
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+            info.tal_name().unwrap_or("N/A"),
+        )
+    }
+}
+
+
+//------------ ExtendedCsv ---------------------------------------------------
+
+struct ExtendedCsv;
+
+impl ExtendedCsv {
+    // 2017-08-25 13:12:19
+    const TIME_ITEMS: &'static [Item<'static>] = &[
+        Item::Numeric(Numeric::Year, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Month, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Day, Pad::Zero),
+        Item::Literal(" "),
+        Item::Numeric(Numeric::Hour, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Minute, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Second, Pad::Zero),
+    ];
+}
+
+impl<W: io::Write> Formatter<W> for ExtendedCsv {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "URI,ASN,IP Prefix,Max Length,Not Before,Not After")
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        write!(target, "{},{},{}/{},{},",
+            info.uri().map(|uri| uri.as_str()).unwrap_or("N/A"),
+            origin.as_id(),
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+        )?;
+        match info.validity() {
+            Some(validity) => {
+                writeln!(target, "{},{}",
+                    validity.not_before().format_with_items(
+                        Self::TIME_ITEMS.iter().cloned()
+                    ),
+                    validity.not_after().format_with_items(
+                        Self::TIME_ITEMS.iter().cloned()
+                    )
+                )
+            }
+            None => writeln!(target, "N/A,N/A"),
+        }
+    }
+}
+
+
+//------------ Json ----------------------------------------------------------
+
+struct Json;
+
+impl<W: io::Write> Formatter<W> for Json {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "{{\n  \"roas\": [")
+    }
+
+    fn footer(
+        &self, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "\n  ]\n}}")
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        write!(target,
+            "    {{ \"asn\": \"{}\", \"prefix\": \"{}/{}\", \
+            \"maxLength\": {}, \"ta\": \"{}\" }}",
+            origin.as_id(),
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+            info.tal_name().unwrap_or("N/A"),
+        )
+    }
+
+    fn delimiter(&self, target: &mut W) -> Result<(), io::Error> {
+        writeln!(target, ",")
+    }
+}
+
+
+//------------ Openbgpd ------------------------------------------------------
+
+struct Openbgpd;
+
+impl<W: io::Write> Formatter<W> for Openbgpd {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "roa-set {{")
+    }
+
+    fn footer(
+        &self, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "}}")
+    }
+
+    fn origin(
+        &self, origin: RouteOrigin, _info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        write!(
+            target, "    {}/{}", origin.address(), origin.address_length()
+        )?;
+        if origin.address_length() < origin.max_length() {
+            write!(target, " maxlen {}", origin.max_length())?;
+        }
+        writeln!(target, " source-as {}", u32::from(origin.as_id()))
+    }
+}
+
+
+//------------ Bird1 ---------------------------------------------------------
+
+struct Bird1;
+
+impl<W: io::Write> Formatter<W> for Bird1 {
+    fn origin(
+        &self, origin: RouteOrigin, _info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "roa {}/{} max {} as {};",
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+            u32::from(origin.as_id())
+        )
+    }
+}
+
+
+//------------ Bird2 ---------------------------------------------------------
+
+struct Bird2;
+
+impl<W: io::Write> Formatter<W> for Bird2 {
+    fn origin(
+        &self, origin: RouteOrigin, _info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "route {}/{} max {} as {};",
+            origin.address(), origin.address_length(),
+            origin.max_length(),
+            u32::from(origin.as_id())
+        )
+    }
+}
+
+
+//------------ Rpsl ----------------------------------------------------------
+
+struct Rpsl;
+
+impl Rpsl {
+    const TIME_ITEMS: &'static [Item<'static>] = &[
+        Item::Numeric(Numeric::Year, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Month, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Day, Pad::Zero),
+        Item::Literal("T"),
+        Item::Numeric(Numeric::Hour, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Minute, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Second, Pad::Zero),
+        Item::Literal("Z"),
+    ];
+}
+
+impl<W: io::Write> Formatter<W> for Rpsl {
+    fn origin(
+        &self, origin: RouteOrigin, info: &OriginInfo, target: &mut W
+    ) -> Result<(), io::Error> {
+        let now = Utc::now().format_with_items(
+            Self::TIME_ITEMS.iter().cloned()
+        );
+        writeln!(target,
+            "\n{}: {}/{}\norigin: {}\n\
+            descr: RPKI attestation\nmnt-by: NA\ncreated: {}\n\
+            last-modified: {}\nsource: ROA-{}-RPKI-ROOT\n",
+            if origin.address().is_ipv4() { "route" }
+            else { "route6" },
+            origin.address(), origin.address_length(),
+            origin.as_id(), now, now,
+            info.tal_name().map(|name| {
+                name.to_uppercase()
+            }).unwrap_or_else(|| "N/A".into())
+        )
+    }
+}
+
+
+
+//------------ Summary -------------------------------------------------------
+
+struct Summary;
+
+impl<W: io::Write> Formatter<W> for Summary {
+    fn header(
+        &self, _snapshot: &PayloadSnapshot, metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "Summary at {}", metrics.time)?;
+        for tal in &metrics.tals {
+            writeln!(target,
+                "{}: {} verified ROAs, {} verified VRPs, \
+                 {} unsafe VRPs, {} final VRPs.",
+                tal.name(), tal.publication.valid_roas, tal.vrps.valid,
+                tal.vrps.marked_unsafe, tal.vrps.contributed
+            )?;
+        }
+        writeln!(target,
+            "total: {} verified ROAs, {} verified VRPs, \
+             {} unsafe VRPs, {} final VRPs.",
+            metrics.publication.valid_roas,
+            metrics.vrps.valid, metrics.vrps.marked_unsafe,
+            metrics.vrps.contributed,
+        )
+    }
+
+    fn origin(
+        &self, _origin: RouteOrigin, _info: &OriginInfo, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+}
+
+
+
+//------------ NoOutput-------------------------------------------------------
+
+struct NoOutput;
+
+impl<W: io::Write> Formatter<W> for NoOutput {
+    fn origin(
+        &self, _origin: RouteOrigin, _info: &OriginInfo, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+}
+
 

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -181,8 +181,8 @@ impl From<RawPrefixFilter> for PrefixFilter {
 
 #[derive(Clone, Debug, Default)]
 pub struct ExceptionInfo {
-    path: Option<Arc<Path>>,
-    comment: Option<String>,
+    pub path: Option<Arc<Path>>,
+    pub comment: Option<String>,
 }
 
 


### PR DESCRIPTION
This output format includes more detailed information about the source of a VRP.

The PR also uses the opportunity to refactor the output code. As part of it, it renames the `filter-asn` and `filter-prefix` options for output generation (both command line and HTTP query) to `select-asn` and `select-prefix` as I was thoroughly confused about what they do. The new name should be more obvious. The old names are still accepted as aliases.

Resolves #435.