### PR TITLE
Introduce optional per-client RTR metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.11.0-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#e89fc80c01fc1b22348c52003ad8dbe0306352ad"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=rtr-metrics#81e3cd7b78ed3e9ac6f83f236b82b8024e1d5aa9"
 dependencies = [
  "base64",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ num_cpus        = "1.12.0"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "rustls-tls" ] }
 ring            = "0.16.12"
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr" ] }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "rtr-metrics", features = [ "repository", "rrdp", "rtr" ] }
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"
 sled            = "0.34.6"

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -636,6 +636,12 @@ established RTR connection. By default, TCP keepalive is enable on all RTR
 connections with an idle time of 60 seconds. Set this option to 0 to disable
 keepalives.
 .TP
+.BI --rtr-client-metrics
+If provided, the server metrics will include separate metrics for every RTR
+client. Clients are identified by their RTR source IP address. This is
+disabled by default to avoid accidentally leaking information about the
+local network topology.
+.TP
 .BI \-\-refresh= seconds
 The amount of seconds the server should wait after having finished updating
 and validating the local repository before starting to update again. The
@@ -1016,6 +1022,11 @@ TCP keepalive on an established RTR connection. If this option is missing,
 TCP keepalive will be enabled on all RTR connections with an idle time of 60
 seconds. If this option is present and set to zero, TCP keepalives are
 disabled.
+.TP
+.BI rtr-client-metrics
+A boolean value specifying whether server metrics should include separate
+metrics for every RTR client. If the value is missing, no RTR client
+metrics will be provided.
 .TP
 .B refresh
 An integer value specifying the number of seconds Routinator should wait

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,7 +7,7 @@
 //!
 //! [`http_listener`]: fn.http_listener.html
 
-use std::io;
+use std::{cmp, io};
 use std::convert::Infallible;
 use std::fmt::Write;
 use std::future::Future;
@@ -33,7 +33,9 @@ use tokio::net::{TcpListener, TcpStream};
 use crate::output;
 use crate::config::Config;
 use crate::error::{Failed, ExitError};
-use crate::metrics::{ServerMetrics, PublicationMetrics, VrpMetrics};
+use crate::metrics::{
+    HttpServerMetrics, PublicationMetrics, SharedRtrServerMetrics, VrpMetrics
+};
 use crate::output::OutputFormat;
 use crate::payload::{AddressPrefix, PayloadSnapshot, SharedHistory};
 use crate::process::LogOutput;
@@ -46,10 +48,11 @@ use crate::validity::RouteValidity;
 /// Returns a future for all HTTP server listeners.
 pub fn http_listener(
     origins: SharedHistory,
-    metrics: Arc<ServerMetrics>,
+    rtr_metrics: SharedRtrServerMetrics,
     log: Option<Arc<LogOutput>>,
     config: &Config,
 ) -> Result<impl Future<Output = ()>, ExitError> {
+    let metrics = Arc::new(HttpServerMetrics::default());
     let mut listeners = Vec::new();
     for addr in &config.http_listen {
         // Binding needs to have happened before dropping privileges
@@ -67,12 +70,13 @@ pub fn http_listener(
         }
         listeners.push(listener);
     }
-    Ok(_http_listener(origins, metrics, log, listeners))
+    Ok(_http_listener(origins, metrics, rtr_metrics, log, listeners))
 }
 
 async fn _http_listener(
     origins: SharedHistory,
-    metrics: Arc<ServerMetrics>,
+    metrics: Arc<HttpServerMetrics>,
+    rtr_metrics: SharedRtrServerMetrics,
     log: Option<Arc<LogOutput>>,
     listeners: Vec<StdListener>
 ) {
@@ -83,7 +87,8 @@ async fn _http_listener(
         let _ = select_all(
             listeners.into_iter().map(|listener| {
                 tokio::spawn(single_http_listener(
-                    listener, origins.clone(), metrics.clone(), log.clone()
+                    listener, origins.clone(), metrics.clone(),
+                    rtr_metrics.clone(), log.clone()
                 ))
             })
         ).await;
@@ -99,21 +104,24 @@ async fn _http_listener(
 async fn single_http_listener(
     listener: StdListener,
     origins: SharedHistory,
-    metrics: Arc<ServerMetrics>,
+    metrics: Arc<HttpServerMetrics>,
+    rtr_metrics: SharedRtrServerMetrics,
     log: Option<Arc<LogOutput>>,
 ) {
     let make_service = make_service_fn(|_conn| {
         let origins = origins.clone();
         let metrics = metrics.clone();
+        let rtr_metrics = rtr_metrics.clone();
         let log = log.clone();
         async move {
             Ok::<_, Infallible>(service_fn(move |req| {
                 let origins = origins.clone();
                 let metrics = metrics.clone();
+                let rtr_metrics = rtr_metrics.clone();
                 let log = log.clone();
                 async move {
                     handle_request(
-                        req, &origins, &metrics,
+                        req, &origins, &metrics, &rtr_metrics,
                         log.as_ref().map(|x| x.as_ref())
                     ).await
                 }
@@ -141,10 +149,11 @@ async fn single_http_listener(
 async fn handle_request(
     req: Request<Body>,
     origins: &SharedHistory,
-    metrics: &ServerMetrics,
+    metrics: &HttpServerMetrics,
+    rtr_metrics: &SharedRtrServerMetrics,
     log: Option<&LogOutput>,
 ) -> Result<Response<Body>, Infallible> {
-    metrics.inc_http_requests();
+    metrics.inc_requests();
     if *req.method() != Method::GET {
         return Ok(method_not_allowed())
     }
@@ -154,9 +163,11 @@ async fn handle_request(
     else {
         Ok(match req.uri().path() {
             "/log" => handle_log(log),
-            "/metrics" => handle_metrics(origins, metrics),
-            "/status" => handle_status(origins, metrics),
-            "/api/v1/status" => handle_api_status(origins, metrics),
+            "/metrics" => handle_metrics(origins, metrics, rtr_metrics).await,
+            "/status" => handle_status(origins, metrics, rtr_metrics).await,
+            "/api/v1/status" => {
+                handle_api_status(origins, metrics, rtr_metrics).await
+            }
             "/validity" => handle_validity_query(origins, req.uri().query()),
             "/version" => handle_version(),
             path if path.starts_with("/api/v1/validity/") => {
@@ -173,9 +184,10 @@ async fn handle_request(
 
 //------------ handle_metrics ------------------------------------------------
 
-fn handle_metrics(
+async fn handle_metrics(
     history: &SharedHistory,
-    server_metrics: &ServerMetrics,
+    server_metrics: &HttpServerMetrics,
+    rtr_metrics: &SharedRtrServerMetrics,
 ) -> Response<Body> {
     let (metrics, serial, start, done, duration) = {
         let history = history.read();
@@ -456,15 +468,8 @@ fn handle_metrics(
         }
     }
 
-    // rtr_connections
-    writeln!(res,
-        "\n\
-        # HELP routinator_rtr_connections total number of RTR connections\n\
-        # TYPE routinator_rtr_connections counter"
-    ).unwrap();
-    writeln!(res,
-        "routinator_rtr_connections {}", server_metrics.rtr_conn_open()
-    ).unwrap();
+    let detailed_rtr = rtr_metrics.detailed();
+    let rtr_metrics = rtr_metrics.read().await;
 
     // rtr_current_connections
     writeln!(res,
@@ -475,7 +480,7 @@ fn handle_metrics(
     ).unwrap();
     writeln!(res,
         "routinator_rtr_current_connections {}",
-        server_metrics.rtr_conn_open() - server_metrics.rtr_conn_close()
+        rtr_metrics.current_connections()
     ).unwrap();
 
     // rtr_bytes_read
@@ -485,7 +490,7 @@ fn handle_metrics(
         # TYPE routinator_rtr_bytes_read counter"
     ).unwrap();
     writeln!(res,
-        "routinator_rtr_bytes_read {}", server_metrics.rtr_bytes_read()
+        "routinator_rtr_bytes_read {}", rtr_metrics.bytes_read()
     ).unwrap();
 
     // rtr_bytes_written
@@ -495,8 +500,117 @@ fn handle_metrics(
         # TYPE routinator_rtr_bytes_written counter"
     ).unwrap();
     writeln!(res,
-        "routinator_rtr_bytes_written {}", server_metrics.rtr_bytes_written()
+        "routinator_rtr_bytes_written {}", rtr_metrics.bytes_written()
     ).unwrap();
+
+    if detailed_rtr {
+        // rtr_client_connections
+        writeln!(res,
+            "\n\
+            # HELP routinator_rtr_client_connections number of current \
+                connections per client\n\
+            # TYPE routinator_rtr_client_connections gauge"
+        ).unwrap();
+        rtr_metrics.fold_clients(0, |count, client| {
+            if client.is_open() {
+                *count += 1
+            }
+        }).for_each(|(addr, count)| {
+            writeln!(res,
+                "routinator_rtr_client_connections{{addr=\"{}\"}} {}",
+                addr, count
+            ).unwrap();
+        });
+
+        // rtr_client_serial
+        writeln!(res,
+            "\n\
+            # HELP routinator_rtr_client_serial \
+                last serial seen by a client\n\
+            # TYPE routinator_rtr_client_serial gauge"
+        ).unwrap();
+        rtr_metrics.fold_clients(None, |serial, client| {
+            *serial = match (*serial, client.serial().map(u32::from)) {
+                (Some(left), Some(right)) => Some(cmp::max(left, right)),
+                (Some(left), None) => Some(left),
+                (None, Some(right)) => Some(right),
+                (None, None) => None
+            };
+        }).for_each(|(addr, count)| {
+            write!(res,
+                "routinator_rtr_client_serial{{addr=\"{}\"}} ",
+                addr,
+            ).unwrap();
+            match count {
+                Some(count) => writeln!(res, "{}", count).unwrap(),
+                None => writeln!(res, "-1").unwrap(),
+            }
+        });
+
+        // rtr_client_last_update_seconds
+        writeln!(res,
+            "\n\
+            # HELP routinator_rtr_last_update_seconds \
+                last serial seen by a client\n\
+            # TYPE routinator_rtr_last_update_seconds gauge"
+        ).unwrap();
+        rtr_metrics.fold_clients(None, |update, client| {
+            *update = match (*update, client.updated()) {
+                (Some(left), Some(right)) => Some(cmp::max(left, right)),
+                (Some(left), None) => Some(left),
+                (None, Some(right)) => Some(right),
+                (None, None) => None
+            };
+        }).for_each(|(addr, update)| {
+            write!(res,
+                "routinator_rtr_last_update_seconds{{addr=\"{}\"}} ",
+                addr,
+            ).unwrap();
+            match update {
+                Some(update) => {
+                    let duration = Utc::now() - update;
+                    writeln!(res,
+                        "{}.{:03}",
+                        duration.num_seconds(),
+                        duration.num_milliseconds() % 1000,
+                    ).unwrap();
+                }
+                None => writeln!(res, "-1").unwrap(),
+            }
+        });
+
+        // rtr_client_read_bytes
+        writeln!(res,
+            "\n\
+            # HELP routinator_rtr_client_read_bytes \
+                number of bytes read per client\n\
+            # TYPE routinator_rtr_client_read_bytes counter"
+        ).unwrap();
+        rtr_metrics.fold_clients(0, |count, client| {
+            *count += client.bytes_read();
+        }).for_each(|(addr, count)| {
+            writeln!(res,
+                "routinator_rtr_client_read_bytes{{addr=\"{}\"}} {}",
+                addr, count
+            ).unwrap()
+        });
+
+        // rtr_client_written_bytes
+        writeln!(res,
+            "\n\
+            # HELP routinator_rtr_client_written_bytes \
+                number of bytes written per client\n\
+            # TYPE routinator_rtr_client_written_bytes counter"
+        ).unwrap();
+        rtr_metrics.fold_clients(0, |count, client| {
+            *count += client.bytes_written();
+        }).for_each(|(addr, count)| {
+            writeln!(res,
+                "routinator_rtr_client_bytes_written{{addr=\"{}\"}} {}",
+                addr, count
+            ).unwrap()
+        });
+    }
 
     // http_connections
     writeln!(res,
@@ -505,7 +619,7 @@ fn handle_metrics(
         # TYPE routinator_http_connections counter"
     ).unwrap();
     writeln!(res,
-        "routinator_http_connections {}", server_metrics.http_conn_open()
+        "routinator_http_connections {}", server_metrics.conn_open()
     ).unwrap();
 
     // http_current_connections
@@ -517,7 +631,7 @@ fn handle_metrics(
     ).unwrap();
     writeln!(res,
         "routinator_http_current_connections {}",
-        server_metrics.http_conn_open() - server_metrics.http_conn_close()
+        server_metrics.conn_open() - server_metrics.conn_close()
     ).unwrap();
 
     // http_bytes_read
@@ -527,7 +641,7 @@ fn handle_metrics(
         # TYPE routinator_http_bytes_read counter"
     ).unwrap();
     writeln!(res,
-        "routinator_http_bytes_read {}", server_metrics.http_bytes_read()
+        "routinator_http_bytes_read {}", server_metrics.bytes_read()
     ).unwrap();
 
     // http_bytes_written
@@ -537,7 +651,7 @@ fn handle_metrics(
         # TYPE routinator_http_bytes_written counter"
     ).unwrap();
     writeln!(res,
-        "routinator_http_bytes_written {}", server_metrics.http_bytes_written()
+        "routinator_http_bytes_written {}", server_metrics.bytes_written()
     ).unwrap();
 
     // http_requests
@@ -547,7 +661,7 @@ fn handle_metrics(
         # TYPE routinator_http_requests counter"
     ).unwrap();
     writeln!(res,
-        "routinator_http_requests {}", server_metrics.http_requests()
+        "routinator_http_requests {}", server_metrics.requests()
     ).unwrap();
 
 
@@ -560,9 +674,10 @@ fn handle_metrics(
 
 //------------ handle_status -------------------------------------------------
 
-fn handle_status(
+async fn handle_status(
     history: &SharedHistory,
-    server_metrics: &ServerMetrics,
+    server_metrics: &HttpServerMetrics,
+    rtr_metrics: &SharedRtrServerMetrics,
 ) -> Response<Body> {
     let (metrics, serial, start, done, duration) = {
         let history = history.read();
@@ -748,32 +863,84 @@ fn handle_status(
         writeln!(res).unwrap()
     }
 
+    let detailed_rtr = rtr_metrics.detailed();
+    let rtr_metrics = rtr_metrics.read().await;
+
     // rtr
     writeln!(res,
-        "rtr-connections: {} current, {} total",
-        server_metrics.rtr_conn_open() - server_metrics.rtr_conn_close(),
-        server_metrics.rtr_conn_open()
+        "rtr-connections: {} current",
+        rtr_metrics.current_connections(),
     ).unwrap();
     writeln!(res,
         "rtr-data: {} bytes sent, {} bytes received",
-        server_metrics.rtr_bytes_written(),
-        server_metrics.rtr_bytes_read()
+        rtr_metrics.bytes_written(),
+        rtr_metrics.bytes_read()
     ).unwrap();
+
+    if detailed_rtr {
+        // rtr-clients
+        writeln!(res, "rtr-clients:").unwrap();
+        rtr_metrics.fold_clients(
+            // connections, serial, update, read, written
+            (0, None, None, 0, 0),
+            |data, client| {
+                if client.is_open() {
+                    data.0 += 1
+                }
+                data.1 = match (
+                    data.1, client.serial().map(u32::from)
+                ) {
+                    (Some(left), Some(right)) => Some(cmp::max(left, right)),
+                    (Some(left), None) => Some(left),
+                    (None, Some(right)) => Some(right),
+                    (None, None) => None
+                };
+                data.2 = match (data.2, client.updated()) {
+                    (Some(left), Some(right)) => Some(cmp::max(left, right)),
+                    (Some(left), None) => Some(left),
+                    (None, Some(right)) => Some(right),
+                    (None, None) => None
+                };
+                data.3 += client.bytes_read();
+                data.4 += client.bytes_written();
+            }
+        ).for_each(|(addr, (conns, serial, update, read, written))| {
+            write!(res, "    {}: connections={}, ", addr, conns).unwrap();
+            if let Some(serial) = serial {
+                write!(res, "serial={}, ", serial).unwrap();
+            }
+            else {
+                write!(res, "serial=N/A, ").unwrap();
+            }
+            if let Some(update) = update {
+                let update = Utc::now() - update;
+                write!(
+                    res,
+                    "updated-ago={}.{:03}s, ",
+                    update.num_seconds(), update.num_milliseconds() % 1000
+                ).unwrap();
+            }
+            else {
+                write!(res, "updated=N/A, ").unwrap();
+            }
+            writeln!(res, "read={}, written={}", read, written).unwrap();
+        });
+    }
 
     // http
     writeln!(res,
         "http-connections: {} current, {} total",
-        server_metrics.http_conn_open() - server_metrics.http_conn_close(),
-        server_metrics.http_conn_open()
+        server_metrics.conn_open() - server_metrics.conn_close(),
+        server_metrics.conn_open()
     ).unwrap();
     writeln!(res,
         "http-data: {} bytes sent, {} bytes received",
-        server_metrics.http_bytes_written(),
-        server_metrics.http_bytes_read()
+        server_metrics.bytes_written(),
+        server_metrics.bytes_read()
     ).unwrap();
     writeln!(res,
         "http-requests: {} ",
-        server_metrics.http_requests()
+        server_metrics.requests()
     ).unwrap();
 
     Response::builder()
@@ -785,9 +952,10 @@ fn handle_status(
 
 //------------ handle_api_status ---------------------------------------------
 
-fn handle_api_status(
+async fn handle_api_status(
     history: &SharedHistory,
-    server_metrics: &ServerMetrics,
+    server_metrics: &HttpServerMetrics,
+    rtr_metrics: &SharedRtrServerMetrics,
 ) -> Response<Body> {
     let (metrics, serial, start, done, duration) = {
         let history = history.read();
@@ -808,7 +976,10 @@ fn handle_api_status(
             history.last_update_duration(),
         )
     };
+
     let now = Utc::now();
+    let detailed_rtr = rtr_metrics.detailed();
+    let rtr_metrics = rtr_metrics.read().await;
 
     let res = JsonBuilder::build(|target| {
         target.member_str("version",
@@ -939,37 +1110,92 @@ fn handle_api_status(
 
         target.member_object("rtr", |target| {
             target.member_raw(
-                "totalConnections", server_metrics.rtr_conn_open()
-            );
-            target.member_raw(
                 "currentConnections",
-                server_metrics.rtr_conn_open() - server_metrics.rtr_conn_close()
+                rtr_metrics.current_connections()
             );
             target.member_raw(
-                "bytesRead", server_metrics.rtr_bytes_read()
+                "bytesRead", rtr_metrics.bytes_read()
             );
             target.member_raw(
-                "bytesWritten", server_metrics.rtr_bytes_written()
+                "bytesWritten", rtr_metrics.bytes_written()
             );
+
+            if detailed_rtr {
+                target.member_object("clients", |target| {
+                    rtr_metrics.fold_clients(
+                        // connections, serial, update, read, written
+                        (0, None, None, 0, 0),
+                        |data, client| {
+                            if client.is_open() {
+                                data.0 += 1
+                            }
+                            data.1 = match (
+                                data.1,
+                                client.serial().map(u32::from)
+                            ) {
+                                (Some(left), Some(right)) => {
+                                    Some(cmp::max(left, right))
+                                }
+                                (Some(left), None) => Some(left),
+                                (None, Some(right)) => Some(right),
+                                (None, None) => None
+                            };
+                            data.2 = match (data.2, client.updated()) {
+                                (Some(left), Some(right)) => {
+                                    Some(cmp::max(left, right))
+                                }
+                                (Some(left), None) => Some(left),
+                                (None, Some(right)) => Some(right),
+                                (None, None) => None
+                            };
+                            data.3 += client.bytes_read();
+                            data.4 += client.bytes_written();
+                        }
+                    ).for_each(
+                        |(addr, (conns, serial, update, read, written))| {
+                            target.member_object(addr, |target| {
+                                target.member_raw("connections", conns);
+                                if let Some(serial) = serial {
+                                    target.member_raw("serial", serial);
+                                }
+                                else {
+                                    target.member_raw("serial", "null");
+                                }
+                                if let Some(update) = update {
+                                    target.member_str(
+                                        "updated",
+                                        update.format("%+")
+                                    );
+                                }
+                                else {
+                                    target.member_raw("updated", "null");
+                                }
+                                target.member_raw("read", read);
+                                target.member_raw("written", written);
+                            })
+                        }
+                    );
+                });
+            }
         });
 
         target.member_object("http", |target| {
             target.member_raw(
-                "totalConnections", server_metrics.http_conn_open()
+                "totalConnections", server_metrics.conn_open()
             );
             target.member_raw(
                 "currentConnections",
-                server_metrics.http_conn_open()
-                - server_metrics.http_conn_close()
+                server_metrics.conn_open()
+                - server_metrics.conn_close()
             );
             target.member_raw(
-                "requests", server_metrics.http_requests()
+                "requests", server_metrics.requests()
             );
             target.member_raw(
-                "bytesRead", server_metrics.http_bytes_read()
+                "bytesRead", server_metrics.bytes_read()
             );
             target.member_raw(
-                "bytesWritten", server_metrics.http_bytes_written()
+                "bytesWritten", server_metrics.bytes_written()
             );
         });
     });
@@ -1325,7 +1551,7 @@ fn not_found() -> Response<Body> {
 
 struct HttpAccept {
     sock: TcpListener,
-    metrics: Arc<ServerMetrics>,
+    metrics: Arc<HttpServerMetrics>,
 }
 
 impl Accept for HttpAccept {
@@ -1341,7 +1567,7 @@ impl Accept for HttpAccept {
         match sock.poll_accept(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok((sock, _addr))) => {
-                self.metrics.inc_http_conn_open();
+                self.metrics.inc_conn_open();
                 Poll::Ready(Some(Ok(HttpStream {
                     sock,
                     metrics: self.metrics.clone()
@@ -1357,7 +1583,7 @@ impl Accept for HttpAccept {
 
 struct HttpStream {
     sock: TcpStream,
-    metrics: Arc<ServerMetrics>,
+    metrics: Arc<HttpServerMetrics>,
 }
 
 impl AsyncRead for HttpStream {
@@ -1369,7 +1595,7 @@ impl AsyncRead for HttpStream {
         pin_mut!(sock);
         let res = sock.poll_read(cx, buf);
         if let Poll::Ready(Ok(())) = res {
-            self.metrics.inc_http_bytes_read(
+            self.metrics.inc_bytes_read(
                 (buf.filled().len().saturating_sub(len)) as u64
             )    
         }
@@ -1385,7 +1611,7 @@ impl AsyncWrite for HttpStream {
         pin_mut!(sock);
         let res = sock.poll_write(cx, buf);
         if let Poll::Ready(Ok(n)) = res {
-            self.metrics.inc_http_bytes_written(n as u64)
+            self.metrics.inc_bytes_written(n as u64)
         }
         res
     }
@@ -1409,7 +1635,7 @@ impl AsyncWrite for HttpStream {
 
 impl Drop for HttpStream {
     fn drop(&mut self) {
-        self.metrics.inc_http_conn_close()
+        self.metrics.inc_conn_close()
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,13 +5,17 @@
 //! [`Metrics`] that collects all metrics gathered during the run. Additional
 //! types contain the metrics related to specific processed entities.
 
-use std::{io, ops, process};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{cmp, io, ops, process, slice};
+use std::iter::Peekable;
+use std::net::IpAddr;
+use std::sync::{Arc};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicI64, AtomicU64, Ordering};
 use std::time::{Duration, SystemTimeError};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use rpki::uri;
 use rpki::repository::tal::TalInfo;
+use rpki::rtr::state::Serial;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 use crate::collector::{HttpStatus, SnapshotReason};
 
@@ -389,93 +393,465 @@ impl ops::AddAssign for VrpMetrics {
 }
 
 
-//------------ ServerMetrics -------------------------------------------------
+//------------ HttpServerMetrics ---------------------------------------------
 
 #[derive(Debug, Default)]
-pub struct ServerMetrics {
-    rtr_conn_open: AtomicU64,
-    rtr_conn_close: AtomicU64,
-    rtr_bytes_read: AtomicU64,
-    rtr_bytes_written: AtomicU64,
-
-    http_conn_open: AtomicU64,
-    http_conn_close: AtomicU64,
-    http_bytes_read: AtomicU64,
-    http_bytes_written: AtomicU64,
-    http_requests: AtomicU64,
+pub struct HttpServerMetrics {
+    conn_open: AtomicU64,
+    conn_close: AtomicU64,
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+    requests: AtomicU64,
 }
 
-impl ServerMetrics {
-    pub fn rtr_conn_open(&self) -> u64 {
-        self.rtr_conn_open.load(Ordering::Relaxed)
+impl HttpServerMetrics {
+    pub fn conn_open(&self) -> u64 {
+        self.conn_open.load(Ordering::Relaxed)
     }
 
-    pub fn inc_rtr_conn_open(&self) {
-        self.rtr_conn_open.fetch_add(1, Ordering::Relaxed);
+    pub fn inc_conn_open(&self) {
+        self.conn_open.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn rtr_conn_close(&self) -> u64 {
-        self.rtr_conn_close.load(Ordering::Relaxed)
+    pub fn conn_close(&self) -> u64 {
+        self.conn_close.load(Ordering::Relaxed)
     }
 
-    pub fn inc_rtr_conn_close(&self) {
-        self.rtr_conn_close.fetch_add(1, Ordering::Relaxed);
+    pub fn inc_conn_close(&self) {
+        self.conn_close.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn rtr_bytes_read(&self) -> u64 {
-        self.rtr_bytes_read.load(Ordering::Relaxed)
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes_read.load(Ordering::Relaxed)
     }
 
-    pub fn inc_rtr_bytes_read(&self, count: u64) {
-        self.rtr_bytes_read.fetch_add(count, Ordering::Relaxed);
+    pub fn inc_bytes_read(&self, count: u64) {
+        self.bytes_read.fetch_add(count, Ordering::Relaxed);
     }
 
-    pub fn rtr_bytes_written(&self) -> u64 {
-        self.rtr_bytes_written.load(Ordering::Relaxed)
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
     }
 
-    pub fn inc_rtr_bytes_written(&self, count: u64) {
-        self.rtr_bytes_written.fetch_add(count, Ordering::Relaxed);
+    pub fn inc_bytes_written(&self, count: u64) {
+        self.bytes_written.fetch_add(count, Ordering::Relaxed);
     }
 
-    pub fn http_conn_open(&self) -> u64 {
-        self.http_conn_open.load(Ordering::Relaxed)
+    pub fn requests(&self) -> u64 {
+        self.requests.load(Ordering::Relaxed)
     }
 
-    pub fn inc_http_conn_open(&self) {
-        self.http_conn_open.fetch_add(1, Ordering::Relaxed);
+    pub fn inc_requests(&self) {
+        self.requests.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+
+//------------ SharedRtrServerMetrics ----------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct SharedRtrServerMetrics {
+    /// The actual metrics behind a thick, safe wall.
+    metrics: Arc<Mutex<RtrServerMetrics>>,
+
+    /// Do we want to publish detailed metrics?
+    detailed: bool,
+}
+
+impl SharedRtrServerMetrics {
+    pub fn new(detailed: bool) -> Self {
+        SharedRtrServerMetrics {
+            metrics: Default::default(),
+            detailed
+        }
     }
 
-    pub fn http_conn_close(&self) -> u64 {
-        self.http_conn_close.load(Ordering::Relaxed)
+    pub async fn add_client(&self, client: Arc<RtrClientMetrics>) {
+        let mut metrics = self.metrics.lock().await;
+        metrics.insert_client(client);
     }
 
-    pub fn inc_http_conn_close(&self) {
-        self.http_conn_close.fetch_add(1, Ordering::Relaxed);
+    pub fn detailed(&self) -> bool {
+        self.detailed
     }
 
-    pub fn http_bytes_read(&self) -> u64 {
-        self.http_bytes_read.load(Ordering::Relaxed)
+    pub async fn read(
+        &self
+    ) -> impl ops::Deref<Target = RtrServerMetrics> + '_ {
+        self.metrics.lock().await
+    }
+}
+
+
+//------------ RtrServerMetrics ----------------------------------------------
+
+#[derive(Clone, Debug, Default)]
+pub struct RtrServerMetrics {
+    /// A list of client metrics.
+    ///
+    /// The vec will always be sorted by socket address. Each new connection
+    /// inserts a new value. Closed connections (the `open` flag is `false`)
+    /// will be collapsed into a single value ever so often.
+    clients: Vec<Arc<RtrClientMetrics>>,
+}
+
+
+
+impl RtrServerMetrics {
+    /// Returns the number of current connections.
+    pub fn current_connections(&self) -> usize {
+        self.clients.iter().filter(|client| client.is_open()).count()
     }
 
-    pub fn inc_http_bytes_read(&self, count: u64) {
-        self.http_bytes_read.fetch_add(count, Ordering::Relaxed);
+    /// Returns the total number of bytes read.
+    pub fn bytes_read(&self) -> u64 {
+        self.clients.iter().map(|client| client.bytes_read()).sum()
     }
 
-    pub fn http_bytes_written(&self) -> u64 {
-        self.http_bytes_written.load(Ordering::Relaxed)
+    /// Returns the total number of bytes written.
+    pub fn bytes_written(&self) -> u64 {
+        self.clients.iter().map(|client| client.bytes_written()).sum()
     }
 
-    pub fn inc_http_bytes_written(&self, count: u64) {
-        self.http_bytes_written.fetch_add(count, Ordering::Relaxed);
+    /// Returns an iterator over all clients.
+    ///
+    /// There can be multiple element for an address. However, these are
+    /// guaranteed to be clustered together.
+    pub fn iter_clients(
+        &self
+    ) -> impl Iterator<Item = &RtrClientMetrics> + '_ {
+        self.clients.iter().map(AsRef::as_ref)
     }
 
-    pub fn http_requests(&self) -> u64 {
-        self.http_requests.load(Ordering::Relaxed)
+    /// Returns an iterated over folded values for clients with same address.
+    pub fn fold_clients<'a, B, F>(
+        &'a self, init: B, fold: F
+    ) -> impl Iterator<Item = (IpAddr, B)> + 'a
+    where
+        B: Clone + 'a,
+        F: FnMut(&mut B, &RtrClientMetrics) + 'a
+    {
+        FoldedRtrClientsIter::new(self, init, fold)
     }
 
-    pub fn inc_http_requests(&self) {
-        self.http_requests.fetch_add(1, Ordering::Relaxed);
+    /// Inserts a new client into the metrics.
+    ///
+    /// Collapses multiple closed client metrics into a single one and
+    /// inserts the new client metrics at the right place to keep the
+    /// client list sorted.
+    fn insert_client(&mut self, client: Arc<RtrClientMetrics>) {
+        // XXX This can be optimised within the same vec. But this is a bit
+        //     scary and I rather get it right for now.
+
+        // See if we need to collapse the vec. This is true if in a sequence
+        // of more than one addr all items are closed.
+        let mut collapse = false;
+        let mut slice = self.clients.as_slice();
+        while let Some((first, tail)) = slice.split_first() {
+            slice = tail;
+            if first.open.load(Ordering::Relaxed) {
+                continue
+            }
+            for item in tail {
+                if item.addr != first.addr {
+                    break
+                }
+                if !item.open.load(Ordering::Relaxed) {
+                    collapse = true;
+                    break;
+                }
+            }
+            if collapse {
+                break
+            }
+        }
+
+        if collapse {
+            // Construct a new vec. Keep all open clients. Collapse closed
+            // clients with the same addr by adding them up. Insert the new
+            // client at the right point.
+            let mut new_clients = Vec::new();
+            let mut pending: Option<Arc<RtrClientMetrics>> = None;
+            let mut client = Some(client);
+            for item in self.clients.drain(..) {
+                // Insert the new client the first time we see a larger addr.
+                if let Some(addr) = client.as_ref().map(|c| c.addr) {
+                    if addr < item.addr {
+                        if let Some(client) = client.take() {
+                            new_clients.push(client)
+                        }
+                    }
+                }
+
+                // Always keep open items.
+                if item.open.load(Ordering::Relaxed) {
+                    new_clients.push(item);
+                    continue;
+                }
+
+                if let Some(pending_item) = pending.take() {
+                    if pending_item.addr == item.addr {
+                        pending = Some(
+                            Arc::new(pending_item.collapse(&item))
+                        );
+                    }
+                    else {
+                        new_clients.push(pending_item);
+                        pending = Some(item);
+                    }
+                }
+                else {
+                    pending = Some(item);
+                }
+            }
+            if let Some(pending) = pending.take() {
+                new_clients.push(pending)
+            }
+            self.clients = new_clients;
+        }
+        else {
+            // Insert the new client at the right point to keep the vec
+            // ordered.
+            let index = match self.clients.binary_search_by(|item| {
+                item.addr.cmp(&client.addr)
+            }) {
+                Ok(index) => index + 1,
+                Err(index) => index
+            };
+            self.clients.insert(index, client);
+        }
+    }
+}
+
+
+//------------ RtrClientMetrics ----------------------------------------------
+
+#[derive(Debug)]
+pub struct RtrClientMetrics {
+    /// The socket address of the client.
+    pub addr: IpAddr,
+
+    /// Is this client currently connected?
+    pub open: AtomicBool,
+
+    /// The serial number of the last successful update.
+    ///
+    /// This is actually an option with the value of `u32::MAX` serves as
+    /// `None`.
+    pub serial: AtomicU32,
+
+    /// The time the last successful update finished.
+    ///
+    /// This is an option of the unix timestamp. The value of `i64::MIN`
+    /// serves as a `None`.
+    pub updated: AtomicI64,
+
+    /// The number of bytes read.
+    pub bytes_read: AtomicU64,
+
+    /// The number of bytes written.
+    pub bytes_written: AtomicU64,
+}
+
+impl RtrClientMetrics {
+    pub fn new(addr: IpAddr) -> Self {
+        RtrClientMetrics {
+            addr,
+            open: AtomicBool::new(true),
+            serial: AtomicU32::new(u32::MAX),
+            updated: AtomicI64::new(i64::MIN),
+            bytes_read: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open.load(Ordering::Relaxed)
+    }
+
+    pub fn close(&self) {
+        self.open.store(false, Ordering::Relaxed)
+    }
+
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes_read.load(Ordering::Relaxed)
+    }
+
+    pub fn inc_bytes_read(&self, count: u64) {
+        self.bytes_read.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
+    }
+
+    pub fn inc_bytes_written(&self, count: u64) {
+        self.bytes_written.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn serial(&self) -> Option<Serial> {
+        let serial = self.serial.load(Ordering::Relaxed);
+        if serial == u32::MAX {
+            None
+        }
+        else {
+            Some(serial.into())
+        }
+    }
+
+    pub fn updated(&self) -> Option<DateTime<Utc>> {
+        let updated = self.updated.load(Ordering::Relaxed);
+        if updated == i64::MIN {
+            None
+        }
+        else {
+            Some(Utc.timestamp(updated, 0))
+        }
+    }
+
+    pub fn update_now(&self, serial: Serial) {
+        self.serial.store(serial.into(), Ordering::Relaxed);
+        self.updated.store(Utc::now().timestamp(), Ordering::Relaxed);
+    }
+
+    fn collapse(&self, other: &Self) -> Self {
+        let left_serial = self.serial.load(Ordering::Relaxed);
+        let right_serial = other.serial.load(Ordering::Relaxed);
+        RtrClientMetrics {
+            addr: self.addr,
+            open: AtomicBool::new(false),
+            serial: AtomicU32::new(
+                if left_serial == u32::MAX {
+                    right_serial
+                }
+                else if right_serial == u32::MAX {
+                    left_serial
+                }
+                else {
+                    cmp::max(left_serial, right_serial)
+                }
+            ),
+            updated: AtomicI64::new(
+                cmp::max(
+                    self.updated.load(Ordering::Relaxed),
+                    other.updated.load(Ordering::Relaxed)
+                )
+            ),
+            bytes_read: AtomicU64::new(
+                self.bytes_read.load(Ordering::Relaxed)
+                + other.bytes_read.load(Ordering::Relaxed)
+            ),
+            bytes_written: AtomicU64::new(
+                self.bytes_written.load(Ordering::Relaxed)
+                + other.bytes_written.load(Ordering::Relaxed)
+            ),
+        }
+    }
+}
+
+
+//------------ FoldedRtrClientsIter ------------------------------------------
+
+struct FoldedRtrClientsIter<'a, B, F> {
+    clients: Peekable<slice::Iter<'a, Arc<RtrClientMetrics>>>,
+    init: B,
+    fold_fn: F
+}
+
+impl<'a, B, F> FoldedRtrClientsIter<'a, B, F> {
+    fn new(metrics: &'a RtrServerMetrics, init: B, fold_fn: F) -> Self {
+        FoldedRtrClientsIter {
+            clients: metrics.clients.iter().peekable(),
+            init,
+            fold_fn
+        }
+    }
+}
+
+impl<'a, B, F> Iterator for FoldedRtrClientsIter<'a, B, F>
+where
+    B: Clone + 'a,
+    F: FnMut(&mut B, &RtrClientMetrics) + 'a
+{
+    type Item = (IpAddr, B);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let first = self.clients.next()?;
+        let addr = first.addr;
+        let mut value = self.init.clone();
+        (self.fold_fn)(&mut value, first);
+        loop {
+            match self.clients.peek() {
+                Some(client) if client.addr == addr => {
+                    let client = match self.clients.next() {
+                        Some(client) => client,
+                        None => break,
+                    };
+                    (self.fold_fn)(&mut value, client);
+                }
+                _ => break
+            }
+        }
+        Some((addr, value))
+    }
+}
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn insert_rtr_metrics() {
+        let addr1 = IpAddr::from_str("10.0.0.1").unwrap();
+        let addr2 = IpAddr::from_str("10.0.0.2").unwrap();
+        let addr3 = IpAddr::from_str("10.0.0.3").unwrap();
+        let addr4 = IpAddr::from_str("10.0.0.4").unwrap();
+        assert!(addr1 < addr2);
+        assert!(addr2 < addr3);
+        assert!(addr3 < addr4);
+
+        fn client(addr: IpAddr) -> Arc<RtrClientMetrics> {
+            RtrClientMetrics::new(addr).into()
+        }
+
+        fn assert_sequence(metrics: &RtrServerMetrics, addrs: &[IpAddr]) {
+            assert_eq!(metrics.clients.len(), addrs.len());
+            metrics.clients.iter().zip(addrs.iter()).for_each(|(m, a)| {
+                assert_eq!(m.addr, *a);
+            });
+        }
+
+        let mut metrics = RtrServerMetrics::default();
+        metrics.insert_client(client(addr4));
+        metrics.insert_client(client(addr2));
+        metrics.insert_client(client(addr4));
+        metrics.insert_client(client(addr3));
+        assert_sequence(&metrics, &[addr2, addr3, addr4, addr4]);
+        metrics.insert_client(client(addr3));
+        metrics.insert_client(client(addr3));
+        assert_sequence(&metrics, &[addr2, addr3, addr3, addr3, addr4, addr4]);
+        metrics.clients[1].inc_bytes_read(10);
+        metrics.clients[1].close();
+        metrics.clients[1].inc_bytes_read(40);
+        metrics.clients[3].close();
+        metrics.clients[4].close();
+        metrics.clients[5].close();
+        metrics.insert_client(client(addr1));
+        assert_sequence(&metrics, &[addr1, addr2, addr3, addr3, addr4]);
+        let (open3, closed3) = if metrics.clients[2].is_open() {
+            (&metrics.clients[2], &metrics.clients[3])
+        }
+        else {
+            (&metrics.clients[3], &metrics.clients[2])
+        };
+        assert!(open3.is_open());
+        assert!(!closed3.is_open());
+        assert_eq!(open3.bytes_read(), 0);
+        assert_eq!(closed3.bytes_read(), 50);
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -33,7 +33,7 @@ use tokio::sync::oneshot;
 use crate::config::Config;
 use crate::error::{ExitError, Failed};
 use crate::http::http_listener;
-use crate::metrics::ServerMetrics;
+use crate::metrics::{SharedRtrServerMetrics};
 use crate::output;
 use crate::output::OutputFormat;
 use crate::payload::{AddressPrefix, PayloadSnapshot, SharedHistory};
@@ -509,14 +509,16 @@ impl Server {
         )?;
         process.setup_service(self.detach)?;
         let log = log.map(Arc::new);
-        let metrics = Arc::new(ServerMetrics::default());
+        let rtr_metrics = SharedRtrServerMetrics::new(
+            process.config().rtr_client_metrics
+        );
 
         let history = SharedHistory::from_config(process.config());
         let (mut notify, rtr) = rtr_listener(
-            history.clone(), metrics.clone(), process.config()
+            history.clone(), rtr_metrics.clone(), process.config()
         )?;
         let http = http_listener(
-            history.clone(), metrics, log, process.config()
+            history.clone(), rtr_metrics, log, process.config()
         )?;
 
         process.drop_privileges()?;


### PR DESCRIPTION
This PR changes the RTR server to collect metrics on a per-client basis and exposes these optionally via the usual endpoints if the `rtr-client-metrics` option is enabled.

All connections with the same source IP address are considered to be the same client.

The metrics are not included by default to avoid accidentally leaking information about the internal network structure if the HTTP server is publicly available.

This resolves #334.