### PR TITLE
Re-introduce refreshing the log output for the /log endpoint.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -518,7 +518,7 @@ impl Server {
             history.clone(), rtr_metrics.clone(), process.config()
         )?;
         let http = http_listener(
-            history.clone(), rtr_metrics, log, process.config()
+            history.clone(), rtr_metrics, log.clone(), process.config()
         )?;
 
         process.drop_privileges()?;
@@ -534,6 +534,9 @@ impl Server {
 
         let join = thread::spawn(move || {
             loop {
+                if let Some(log) = log.as_ref() {
+                    log.start();
+                }
                 let timeout = match LocalExceptions::load(
                     process.config(), false
                 ) {
@@ -553,6 +556,9 @@ impl Server {
                         Duration::from_secs(10)
                     }
                 };
+                if let Some(log) = log.as_ref() {
+                    log.flush();
+                }
                 match sig_rx.recv_timeout(timeout) {
                     Ok(UserSignal::ReloadTals) => {
                         match validation.reload_tals() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -295,11 +295,11 @@ impl LogOutput {
         (tx, res)
     }
 
-    pub fn start(&mut self) {
+    pub fn start(&self) {
         self.current.write().expect("Log lock got poisoned").1 = Utc::now();
     }
 
-    pub fn flush(&mut self) {
+    pub fn flush(&self) {
         let queue = self.queue.lock().expect("Log queue lock got poisoned");
         let started = self.current.read().expect("Log lock got poisoned").1;
 


### PR DESCRIPTION
This PR re-introduces refreshing the log output used by the `/log` HTTP endpoint. This got lost during the refactoring of the payload data.

Fixes #520.