### PR TITLE
Add the .tal extension to TAL file names while installing.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -416,7 +416,9 @@ impl Init {
         name: &str,
         content: &str,
     ) -> Result<(), Failed> {
-        let mut file = match fs::File::create(tal_dir.join(name)) {
+        let mut file = match fs::File::create(tal_dir.join(
+            format!("{}.tal", name)
+        )) {
             Ok(file) => file,
             Err(err) => {
                 error!(


### PR DESCRIPTION
Fixes #518.