### PR TITLE
Use the RRDP repository in the store even if the collector falls back.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -636,7 +636,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         repository_index: Option<usize>,
     ) -> Result<Self, Failed> {
         let collector = run.collector.repository(cert)?;
-        let store = run.store.repository(cert, collector.as_ref())?;
+        let store = run.store.repository(cert)?;
         Ok(PubPoint {
             run, cert, processor, collector, store,
             repository_index,


### PR DESCRIPTION
This PR changes the logic how a fallback from RRDP to rsync is dealt with in the store. Previously, we also switched the store to use the rsync repository in this case. Now we use the RRDP repository in the store instead while taking data from the rsync collector.

This means that the RRDP repository’s store is updated from data collected via rsync. This is, however, fine. The reason we keep the two separated is that RRDP can publish data for any rsync URI. Thus, two RRDP repositories can publish data for the same rsync URI. However, this is not what happens here: in this case we use rsync data for an RRDP repository. There will only ever be one source for rsync data since the authority is part of the identifier.

While an RRDP server can still use bogus rsync URIs, it isn’t supposed to and if it does shenanigans, it is its own fault.

So, this change should be safe. It also makes dealing with no-update runs much easier. Previously, we technically would need to know whether the last known state was via the RRDP repository or via the rsync repository because of fallback. Now it is always via the RRDP repository because in case of fallback, the data is added to the RRDP repository.

Fixes #509.