### PR TITLE
Log falling back to rsync only once per repository.

### DIFF
--- a/src/collector/base.rs
+++ b/src/collector/base.rs
@@ -6,7 +6,7 @@ use std::{fs, io};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use bytes::Bytes;
-use log::{error, warn};
+use log::error;
 use rpki::repository::tal::TalUri;
 use rpki::uri;
 use crate::config::Config;
@@ -215,10 +215,6 @@ impl<'a> Run<'a> {
                 if let Some(repository) = rrdp.load_repository(rrdp_uri)? {
                     return Ok(Some(Repository::rrdp(repository)))
                 }
-                warn!(
-                    "RRDP repository {} unavailable. Falling back to rsync.",
-                    rrdp_uri
-                );
             }
         }
 

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -436,6 +436,10 @@ impl<'a> Run<'a> {
             )?)
         }
         else {
+            warn!(
+                "RRDP repository {} unavailable. Falling back to rsync.",
+                rpki_notify
+            );
             None
         };
         
@@ -459,6 +463,10 @@ impl<'a> Run<'a> {
             )?)
         }
         else {
+            warn!(
+                "RRDP repository {} unavailable. Falling back to rsync.",
+                rpki_notify
+            );
             None
         };
         


### PR DESCRIPTION
This PR fixes an annoyance where the message that a fallback to rsync had to happen is logged every single time a publication point from the affected repository is accessed.