### PR TITLE
Don’t clean up if dirty-repository is enabled.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -348,7 +348,10 @@ impl Engine {
 
     /// Cleans the collector and store owned by the engine.
     pub fn cleanup(&self) -> Result<(), Failed> {
-        self.store.cleanup(self.collector.cleanup())
+        if !self.dirty_repository {
+            self.store.cleanup(self.collector.cleanup())?;
+        }
+        Ok(())
     }
 
     /// Dumps the content of the collector and store owned by the engine.


### PR DESCRIPTION
… or, strictly speaking, only clean up if dirty-repository is not enabled.