### PR TITLE
Do not open the database before detaching.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -502,7 +502,6 @@ impl Server {
     /// If `detach` is `true`, will fork the server and exit. Otherwise
     /// just runs the server forever.
     pub fn run(self, mut process: Process) -> Result<(), ExitError> {
-        Engine::init(process.config())?;
         let log = process.switch_logging(
             self.detach,
             !process.config().http_listen.is_empty()


### PR DESCRIPTION
Opening the database involves operations related to multi-threading which clashes with the use of fork for detaching. This PR simply removes opening the database before detaching which was there only to catch issues early. As a side-effect, this also means that the database is only opened after logging is switched which means that issues are logged to syslog if that is enabled.

Fixes #554, fixes #555.