### PR TITLE
Update minimal Rust version to 1.47. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.45.0, stable, beta, nightly]
+        rust: [1.47.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
 name = "async-compression"
@@ -118,9 +118,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -506,15 +506,15 @@ checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -621,9 +621,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "lock_api"
@@ -924,9 +924,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1311,11 +1311,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if",
  "libc",
  "winapi",
 ]
@@ -1380,18 +1379,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1614,9 +1613,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,7 @@ dirs            = "3.0.1"
 fern            = "0.6.0"
 form_urlencoded = "1.0"
 futures         = "0.3.4"
-
-# Pin hyper to 0.14.4 for compatibility with Rust 1.45.
-hyper           = { version = "=0.14.4", features = [ "server", "stream" ] }
-
+hyper           = { version = "0.14", features = [ "server", "stream" ] }
 log             = "0.4.8"
 log-reroute     = "0.1.5"
 num_cpus        = "1.12.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+# -- stage 0: some configuration
+ARG BASE_IMG=alpine:3.13.5
+
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.13.5 as build
+FROM ${BASE_IMG} as build
 
 RUN apk add rust cargo
 
@@ -13,7 +16,7 @@ RUN cargo build \
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.13.5
+FROM ${BASE_IMG}
 COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Build variables for uid and guid of user to run container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- stage 1: build static routinator with musl libc for alpine
-FROM alpine:3.13.3 as build
+FROM alpine:3.13.5 as build
 
 RUN apk add rust cargo
 
@@ -13,7 +13,7 @@ RUN cargo build \
 
 # -- stage 2: create alpine-based container with the static routinator
 #             executable
-FROM alpine:3.11.6
+FROM alpine:3.13.5
 COPY --from=build /tmp/routinator/target/x86_64-alpine-linux-musl/release/routinator /usr/local/bin/
 
 # Build variables for uid and guid of user to run container

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Support](https://doc.rust-lang.org/nightly/rustc/platform-support.html) page
 provides an overview of the various platforms and support levels.
 
 While some system distributions include Rust as system packages, Routinator
-relies on a relatively new version of Rust, currently 1.45 or newer. We
+relies on a relatively new version of Rust, currently 1.47 or newer. We
 therefore suggest to use the canonical Rust installation via a tool called
 `rustup`.
 

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,9 @@ use rustc_version::{Version, version};
 
 fn main() {
     let version = version().expect("Failed to get rustc version.");
-    if version < Version::parse("1.45.0").unwrap() {
+    if version < Version::parse("1.47.0").unwrap() {
         eprintln!(
-            "\n\nAt least Rust version 1.45 is required.\n\
+            "\n\nAt least Rust version 1.47 is required.\n\
              Version {} is used for building.\n\
              Build aborted.\n\n",
              version);


### PR DESCRIPTION
This version is required to allow removing the pin on hyper. As Alpine 3.13 now has updated to a newer Rust version, we can update.

This also updates the Dockerfile to use Alpine 3.13.5 for both stages. Previously, the second stage was still using 3.11 (Alpine, not Windows) for some reason.