### PR TITLE
Fix spelling error in log message

### DIFF
--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1290,7 +1290,7 @@ impl HttpResponse {
         if let Err(err) = fs::create_dir_all(&parent) {
             warn!(
                 "Cannot keep HTTP response; \
-                creating director {} failed: {}",
+                creating directory {} failed: {}",
                 parent.display(), err
             );
             return Err(Failed)


### PR DESCRIPTION
s/director /directory /