### PR TITLE
Fix dump logic.

### DIFF
--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -142,8 +142,9 @@ impl Collector {
     }
 
     /// Dumps the content of the RRDP collector.
-    #[allow(clippy::mutable_key_type)]
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
+        let dir = dir.join("rrdp");
+        debug!("Dumping RRDP collector content to {}", dir.display());
         let mut registry = DumpRegistry::new(dir.into());
         let mut states = HashMap::new();
         for entry in fatal::read_dir(&self.working_dir)? {
@@ -161,6 +162,7 @@ impl Collector {
             }
         }
         self.dump_repository_json(registry, states)?;
+        debug!("RRDP collector dump complete.");
         Ok(())
     }
 
@@ -181,7 +183,7 @@ impl Collector {
 
         fatal::create_dir_all(&target_path)?;
 
-        Self::dump_tree(&repo_path.join("rrdp"), &target_path)?;
+        Self::dump_tree(&repo_path.join("rsync"), &target_path)?;
 
         state_registry.insert(state.rpki_notify.clone(), state);
 
@@ -202,7 +204,7 @@ impl Collector {
             }
             else if entry.is_file() {
                 let target_path = target_path.join(entry.file_name());
-                fatal::create_dir_all(&target_path)?;
+                fatal::create_parent_all(&target_path)?;
                 if let Err(err) = fs::copy(entry.path(), &target_path) {
                     error!(
                         "Fatal: failed to copy {} to {}: {}",

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -142,10 +142,11 @@ impl Collector {
     }
 
     /// Dumps the content of the RRDP collector.
+    #[allow(clippy::mutable_key_type)]
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
         let dir = dir.join("rrdp");
         debug!("Dumping RRDP collector content to {}", dir.display());
-        let mut registry = DumpRegistry::new(dir.into());
+        let mut registry = DumpRegistry::new(dir);
         let mut states = HashMap::new();
         for entry in fatal::read_dir(&self.working_dir)? {
             let entry = entry?;

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -120,6 +120,7 @@ impl Collector {
     /// Dumps the content of the rsync collector.
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
         let target = dir.join("rsync");
+        debug!("Dumping rsync collector content to {}", target.display());
 
         if let Err(err) = fs::remove_dir_all(&target) {
             if err.kind() != io::ErrorKind::NotFound {
@@ -130,7 +131,9 @@ impl Collector {
                 return Err(Failed)
             }
         }
-        self.dump_dir(&self.working_dir.base, &target)
+        self.dump_dir(&self.working_dir.base, &target)?;
+        debug!("Rsync collector dump complete.");
+        Ok(())
     }
 
     /// Recursively copies the content of `source` to `target`.

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1387,7 +1387,7 @@ impl Dump {
 
     /// Prints the current configuration to stdout and exits.
     fn run(self, process: Process) -> Result<(), ExitError> {
-        let engine = Engine::new(process.config(), false)?;
+        let engine = Engine::new(process.config(), true)?;
         process.switch_logging(false, false)?;
         engine.dump(&self.output)?;
         Ok(())

--- a/src/store.rs
+++ b/src/store.rs
@@ -44,7 +44,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use log::{error, warn};
+use log::{debug, error, warn};
 use rand::random;
 use rpki::repository::Cert;
 use rpki::repository::crypto::digest::DigestAlgorithm;
@@ -127,7 +127,8 @@ impl Store {
 
     /// Dumps the content of the store.
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
-        let dir = dir.join("stored");
+        let dir = dir.join("store");
+        debug!("Dumping store content to {}", dir.display());
 
         if let Err(err) = fs::remove_dir_all(&dir) {
             if err.kind() != io::ErrorKind::NotFound {
@@ -143,6 +144,7 @@ impl Store {
         self.dump_tree(&self.rsync_repository_path(), &mut repos)?;
         self.dump_tree(&self.rrdp_repository_base(), &mut repos)?;
         self.dump_repository_json(repos)?;
+        debug!("Store dump complete.");
         Ok(())
     }
 

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -140,6 +140,23 @@ pub fn create_dir_all(path: &Path) -> Result<(), Failed> {
 }
 
 
+//------------ create_parent_all ---------------------------------------------
+
+/// Creates all directories leading necessary to create a file.
+pub fn create_parent_all(path: &Path) -> Result<(), Failed> {
+    if let Some(path) = path.parent() {
+        fs::create_dir_all(path).map_err(|err| {
+            error!(
+                "Fatal: failed to create directory {}: {}",
+                path.display(), err
+            );
+            Failed
+        })?
+    }
+    Ok(())
+}
+
+
 //------------ remove_dir_all ------------------------------------------------
 
 /// Removes a directory tree.


### PR DESCRIPTION
That apparently got broken during the Second Big Rewrite. This PR fixes triggering the collector dump in the dump command and corrects various wrong paths in the RRDP collector’s dump.

Fixes #604 