### PR TITLE
Log a message at start of validation run.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -615,6 +615,7 @@ impl Server {
         notify: &mut NotifySender,
         exceptions: LocalExceptions,
     ) -> Result<(), Failed> {
+        info!("Starting a validation run.");
         history.mark_update_start();
         let (report, metrics) = validation.process_origins()?;
         let must_notify = history.update(


### PR DESCRIPTION
Fixes #587.