### PR TITLE
Set the RRDP connect timeout from the correct command line option.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -694,7 +694,9 @@ impl Config {
         }
 
         // rrdp_connect_timeout
-        if let Some(value) = from_str_value_of(matches, "rrdp-timeout")? {
+        if let Some(value) = from_str_value_of(
+            matches, "rrdp-connect-timeout"
+        )? {
             self.rrdp_connect_timeout = Some(Duration::from_secs(value))
         }
 


### PR DESCRIPTION
Currently, the option is set from the `rrdp-timeout` command line option rather than `rrdp-connect-timeout`.