### PR TITLE
Increase the default RRDP timeout to 300 seconds.

### DIFF
--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -293,7 +293,7 @@ in order to spread out load on the rsync server.
 .BI --rrdp-timeout= seconds
 Sets the timeout in seconds for any RRDP-related network operation, i.e.,
 connects, reads, and writes. If this option is omitted, the default timeout
-of 30 seconds is used. Set the option to 0 to disable the timeout.
+of 300 seconds is used. Set the option to 0 to disable the timeout.
 
 .TP
 .BI --rrdp-connect-timeout= seconds
@@ -1031,7 +1031,7 @@ increased to that value.
 .B rrdp-timeout
 An integer value that provides a timeout in seconds for all individual
 RRDP-related network operations, i.e., connects, reads, and writes. If the
-value is missing, a default timeout of 30 seconds will be used. Set the value
+value is missing, a default timeout of 300 seconds will be used. Set the value
 to 0 to turn the timeout off.
 
 .TP

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -51,14 +51,6 @@ use crate::utils::json::JsonBuilder;
 use crate::utils::uri::UriExt;
 
 
-///----------- Configuration Constants ---------------------------------------
-
-/// The default timeout for RRDP requests.
-///
-/// This is mentioned in the man page. If you change it, also change it there.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-
-
 //------------ Collector -----------------------------------------------------
 
 /// The local copy of RPKI repositories synchronized via RRDP.
@@ -1292,15 +1284,7 @@ impl HttpClient {
         let mut builder = create_builder();
         builder = builder.user_agent(&config.rrdp_user_agent);
         builder = builder.gzip(true);
-        match config.rrdp_timeout {
-            Some(Some(timeout)) => {
-                builder = builder.timeout(timeout);
-            }
-            Some(None) => { /* keep no timeout */ }
-            None => {
-                builder = builder.timeout(DEFAULT_TIMEOUT);
-            }
-        }
+        builder = builder.timeout(config.rrdp_timeout);
         if let Some(timeout) = config.rrdp_connect_timeout {
             builder = builder.connect_timeout(timeout);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@
 
 use std::{env, fmt, fs};
 use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -43,6 +43,9 @@ const DEFAULT_EXPIRE: u64 = 7200;
 
 /// The default number of VRP diffs to keep.
 const DEFAULT_HISTORY_SIZE: usize = 10;
+
+/// The default for the RRDP timeout.
+const DEFAULT_RRDP_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// The default for the RRDP fallback time.
 const DEFAULT_RRDP_FALLBACK_TIME: Duration = Duration::from_secs(3600);
@@ -169,12 +172,10 @@ pub struct Config {
     /// Time since last update of an RRDP repository before fallback to rsync.
     pub rrdp_fallback_time: Duration,
 
-    /// Optional RRDP timeout in seconds.
+    /// RRDP timeout in seconds.
     ///
-    /// If this is not set, the default timeouts of the `reqwest` crate are
-    /// used. Use `Some(None)` for no timeout.
-    #[allow(clippy::option_option)]
-    pub rrdp_timeout: Option<Option<Duration>>,
+    /// If this is None, no timeout is set.
+    pub rrdp_timeout: Option<Duration>,
 
     /// Optional RRDP connect timeout in seconds.
     pub rrdp_connect_timeout: Option<Duration>,
@@ -687,10 +688,12 @@ impl Config {
 
         // rrdp_timeout
         if let Some(value) = from_str_value_of(matches, "rrdp-timeout")? {
-            self.rrdp_timeout = match value {
-                0 => Some(None),
-                value => Some(Some(Duration::from_secs(value))),
+            self.rrdp_timeout = if value == 0 {
+                None
             }
+            else {
+                Some(Duration::from_secs(value))
+            };
         }
 
         // rrdp_connect_timeout
@@ -1013,15 +1016,11 @@ impl Config {
                 .unwrap_or(DEFAULT_RRDP_FALLBACK_TIME)
             },
             rrdp_timeout: {
-                file.take_u64("rrdp-timeout")?
-                .map(|secs| {
-                    if secs == 0 {
-                        None
-                    }
-                    else {
-                        Some(Duration::from_secs(secs))
-                    }
-                })
+                match file.take_u64("rrdp-timeout")? {
+                    Some(0) => None,
+                    Some(value) => Some(Duration::from_secs(value)),
+                    None => Some(DEFAULT_RRDP_TIMEOUT)
+                }
             },
             rrdp_connect_timeout: {
                 file.take_u64("rrdp-connect-timeout")?.map(Duration::from_secs)
@@ -1211,7 +1210,7 @@ impl Config {
             rsync_timeout: Duration::from_secs(DEFAULT_RSYNC_TIMEOUT),
             disable_rrdp: false,
             rrdp_fallback_time: DEFAULT_RRDP_FALLBACK_TIME,
-            rrdp_timeout: None,
+            rrdp_timeout: Some(DEFAULT_RRDP_TIMEOUT), 
             rrdp_connect_timeout: None,
             rrdp_local_addr: None,
             rrdp_root_certs: Vec::new(),
@@ -1355,12 +1354,15 @@ impl Config {
             "rrdp-fallback-time".into(),
             (self.rrdp_fallback_time.as_secs() as i64).into()
         );
-        if let Some(timeout) = self.rrdp_timeout {
-            res.insert(
-                "rrdp-timeout".into(),
-                ((timeout.map(|d| d.as_secs()).unwrap_or(0)) as i64).into()
-            );
-        }
+        res.insert(
+            "rrdp-timeout".into(),
+            match self.rrdp_timeout {
+                None => 0.into(),
+                Some(value) => {
+                    value.as_secs().try_into().unwrap_or(i64::MAX).into()
+                }
+            }
+        );
         if let Some(timeout) = self.rrdp_connect_timeout {
             res.insert(
                 "rrdp-connect-timeout".into(),


### PR DESCRIPTION
This also cleans up the awkward `Option<Option<Duration>>` in the config for this value.

Fixes #595.