### PR TITLE
Only include actually available data in RRDP status on 304.

### DIFF
--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -2181,6 +2181,13 @@ impl HttpStatus {
         }
     }
 
+    pub fn is_not_modified(self) -> bool {
+        matches!(
+            self,
+            HttpStatus::Response(code) if code == StatusCode::NOT_MODIFIED
+        )
+    }
+
     pub fn is_success(self) -> bool {
         matches!(
             self,

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -429,27 +429,29 @@ async fn handle_api_status(
                         }
                         Err(_) => target.member_raw("duration", "null")
                     }
-                    match metrics.serial {
-                        Some(serial) => {
-                            target.member_raw("serial", serial);
+                    if !metrics.status().is_not_modified() {
+                        match metrics.serial {
+                            Some(serial) => {
+                                target.member_raw("serial", serial);
+                            }
+                            None => target.member_raw("serial", "null")
                         }
-                        None => target.member_raw("serial", "null")
-                    }
-                    match metrics.session {
-                        Some(session) => {
-                            target.member_str("session", session);
+                        match metrics.session {
+                            Some(session) => {
+                                target.member_str("session", session);
+                            }
+                            None => target.member_raw("session", "null")
                         }
-                        None => target.member_raw("session", "null")
-                    }
-                    target.member_raw("delta",
-                        if metrics.snapshot_reason.is_none() { "true" }
-                        else { "false" }
-                    );
-                    if let Some(reason) = metrics.snapshot_reason {
-                        target.member_str("snapshot_reason", reason.code())
-                    }
-                    else {
-                        target.member_raw("snapshot_reason", "null");
+                        target.member_raw("delta",
+                            if metrics.snapshot_reason.is_none() { "true" }
+                            else { "false" }
+                        );
+                        if let Some(reason) = metrics.snapshot_reason {
+                            target.member_str("snapshot_reason", reason.code())
+                        }
+                        else {
+                            target.member_raw("snapshot_reason", "null");
+                        }
                     }
                 })
             }


### PR DESCRIPTION
This PR leaves out the irrelevant fields _serial, session, delta,_ and _snapshotReason_ from the JSON status for RRDP servers when they responded with a 304 and we don’t actually have those values available.

Fixes #580. Well, sort of.