### PR TITLE
Update rpki-rs to 0.12.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1304035d94fcf3744263c52dd4c470ecf04b7f26ddad6d431d3d47830440140"
+checksum = "718f0d99ad56874728162d2f082e43c2cb378ab62b87202cdf806b9fd13b2d0a"
 dependencies = [
  "base64",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ num_cpus        = "1.12.0"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "rustls-tls" ] }
 ring            = "0.16.12"
-rpki            = { version = "0.12.1", features = [ "repository", "rrdp", "rtr", "serde" ] }
+rpki            = { version = "0.12.2", features = [ "repository", "rrdp", "rtr", "serde" ] }
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"
 tempfile        = "3.1.0"


### PR DESCRIPTION
This update improves checks for address and prefix lengths in certificates and for prefix lengths and max-lengths in ROAs through [rpki #154](https://github.com/NLnetLabs/rpki-rs/pull/154).