### PR TITLE
Remove support for gzip transfer encoding in RRDP client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,19 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
-name = "async-compression"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,7 +918,6 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -957,7 +943,6 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
- "tokio-util",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log             = "0.4.8"
 log-reroute     = "0.1.5"
 num_cpus        = "1.12.0"
 rand            = "0.8.1"
-reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "gzip", "rustls-tls" ] }
+reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.16.12"
 rpki            = { version = "0.12.2", features = [ "repository", "rrdp", "rtr", "serde" ] }
 serde           = { version = "1.0.95", features = [ "derive" ] }

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -338,10 +338,6 @@ the path to make it possible to distinguish the series of requests made over
 time.
 
 .TP
-.B --rrdp-disable-gzip
-If this option is present, the gzip transfer encoding is disabled.
-
-.TP
 .BI --max-object-size= bytes
 Limits the size of individual objects received via either rsync or RRDP to
 the given number of bytes. The default value if this option is not present
@@ -1106,12 +1102,6 @@ responses received from RRDP servers will be stored.
 The sub-path will be constructed using the components of the requested URI.
 For the responses to the notification files, the timestamp is appended to
 the path to make it possible to distinguish the series of requests made over
-time.
-
-.TP
-.B rrdp-disable-gzip
-A boolean value that determines whether the gzip transfer encoding should be
-disabled in RRDP requests. If the option is missing, gzip will be used.
 
 .TP
 .B max-object-size

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1298,7 +1298,6 @@ impl HttpClient {
 
         let mut builder = create_builder();
         builder = builder.user_agent(&config.rrdp_user_agent);
-        builder = builder.gzip(!config.rrdp_disable_gzip);
         builder = builder.timeout(config.rrdp_timeout);
         if let Some(timeout) = config.rrdp_connect_timeout {
             builder = builder.connect_timeout(timeout);


### PR DESCRIPTION
This PR removes support for the gzip transfer encoding from the Routinator RRDP client.

The immediate reason is that the XML parser we are using happily reads data into memory until it finds the first < (which is backed by the XML spec) which makes it susceptible to an gzip bomb. However, even if that were fixed, it is far too easy to make a gzip’d XML file with lots and lots of white-space somewhere which would be entirely legal but significantly slow down processing.

So, as this sounds like a potentially bottomless can of worms, we are going to disable support for gzip.

This PR fixes CVE-2021-43174.