### PR TITLE
Reject premature manifests.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -822,6 +822,13 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 return Ok(None)
             }
         };
+
+        if content.this_update() < Time::now() {
+            self.metrics.premature_manifests += 1;
+            warn!("{}: premature manifest", self.cert.rpki_manifest());
+            return Ok(None)
+        }
+
         if content.is_stale() {
             self.metrics.stale_manifests += 1;
             match self.run.validation.stale {

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -187,6 +187,10 @@ fn object_metrics<'a>(
             .value(metrics.invalid_manifests);
         target.multi(metric).label(group.label(), name)
             .label("type", "manifest")
+            .label("state", "premature")
+            .value(metrics.premature_manifests);
+        target.multi(metric).label(group.label(), name)
+            .label("type", "manifest")
             .label("state", "stale")
             .value(metrics.stale_manifests);
         target.multi(metric).label(group.label(), name)

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -562,6 +562,7 @@ fn json_publication_metrics(
     target.member_raw("rejectedPublicationPoints", metrics.rejected_points);
     target.member_raw("validManifests", metrics.valid_manifests);
     target.member_raw("invalidManifests", metrics.invalid_manifests);
+    target.member_raw("prematureManifests", metrics.premature_manifests);
     target.member_raw("staleManifests", metrics.stale_manifests);
     target.member_raw("missingManifests", metrics.missing_manifests);
     target.member_raw("validCRLs", metrics.valid_crls);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -243,6 +243,9 @@ pub struct PublicationMetrics {
     /// The number of invalid manifests.
     pub invalid_manifests: u32,
 
+    /// The number of premature manifests.
+    pub premature_manifests: u32,
+
     /// The number of stale manifests.
     pub stale_manifests: u32,
 
@@ -313,6 +316,7 @@ impl<'a> ops::AddAssign<&'a Self> for PublicationMetrics {
 
         self.valid_manifests += other.valid_manifests;
         self.invalid_manifests += other.invalid_manifests;
+        self.premature_manifests += other.premature_manifests;
         self.stale_manifests += other.stale_manifests;
         self.missing_manifests += other.missing_manifests;
         self.valid_crls += other.valid_crls;


### PR DESCRIPTION
Manifests are considered premature if their thisUpdate timestamp is
before the current time. Internet draft draft-ietf-sidrops-6486bis added
a requirement to reject such manifests. This PR adds this requirement.

A new state "premature" has been added to the manifest Prometheus
metrics. Similarly, a new prematureManifests counter has been added to
the JSON metrics.

Fixes #589.