### PR TITLE
Attribute the DEB changelog entry to RPKI team.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -266,18 +266,7 @@ jobs:
 
         case ${OS_NAME} in
           debian|ubuntu)
-            case ${{ github.event_name }} in
-              pull_request | workflow_dispatch)
-                MAINTAINER="${{ github.event.sender.login }} <pkg@nlnetlabs.nl>"
-                ;;
-              push)
-                MAINTAINER="${{ github.event.pusher.name }} <${{ github.event.pusher.email }}>"
-                ;;
-              *)
-                echo 2>&1 "ERROR: Unexpected GitHub Actions event"
-                exit 1
-                ;;
-            esac
+            MAINTAINER="The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"
 
             # Generate the RFC 5322 format date by hand instead of using date --rfc-email
             # because that option doesn't exist on Ubuntu 16.04 and Debian 9


### PR DESCRIPTION
For context the DEB info says this: (using an RTR DEB as an example as I have it unpacked already in front of me but it's the same for Routinator):

```
$ dpkg --info ~/Downloads/rtrtr_0.2.0-1bullseye_amd64.deb   | grep Maintainer
 Maintainer: The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>
```

But the embedded mandatory changelog file contains this:

```
$ zcat tmp/usr/share/doc/rtrtr/changelog.Debian.gz 
rtrtr (0.2.0) unstable; urgency=medium
  * See: https://github.com/NLnetLabs/rtrtr/releases/tag/v0.2.0
 -- maintainer partim <hn@nvnc.de>  Wed, 19 Jan 2022 10:09:11 +0000
```