### PR TITLE
TlsTcpStream mustn’t crash after a failed TLS handshake.

### DIFF
--- a/src/utils/tls.rs
+++ b/src/utils/tls.rs
@@ -95,11 +95,11 @@ pub fn create_server_config(
 
 //------------ TlsTcpStream --------------------------------------------------
 
-/// A TLS stream that behaves like a regular TCP stream.
-///
-/// Specifically, `AsyncRead` and `AsyncWrite` will return `Poll::NotReady`
-/// until the TLS accept machinery has concluded.
 pin_project! {
+    /// A TLS stream that behaves like a regular TCP stream.
+    ///
+    /// Specifically, `AsyncRead` and `AsyncWrite` will return `Poll::NotReady`
+    /// until the TLS accept machinery has concluded.
     #[project = TlsTcpStreamProj]
     enum TlsTcpStream {
         /// The TLS handshake is going on.


### PR DESCRIPTION
Hyper still does a clean shutdown via AsyncWrite::flush and
AsyncWrite::shutdown after receiving an error upon reading or writing.
So we still need to pretend that the socket works after the error even
if we don’t actually do anything.

Fixes #691.