### PR TITLE
Sort TALs by name.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -245,6 +245,9 @@ impl Engine {
                 "No TALs found in TAL directory. Starting anyway."
             );
         }
+        res.sort_by(|left, right| {
+            left.info().name().cmp(right.info().name())
+        });
         self.tals = res;
         Ok(())
     }


### PR DESCRIPTION
The PR sorts the list of TALs after loading by their name. This will make them appear in alphabetical order both in the summary as well as in status and metrics.