### PR TITLE
Switch to the vault package repository for CentOS 8 now that it is EOL.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -150,6 +150,11 @@ jobs:
             apt-get install -y build-essential jq lintian pkg-config
             ;;
           centos)
+            if [[ "${MATRIX_IMAGE}" == "centos:8" ]]; then
+              # allow CentOS 8 to continue working now that it is EOL
+              # see: https://stackoverflow.com/a/70930049
+              sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+            fi
             yum install epel-release -y
             yum update -y
             yum install -y jq rpmlint
@@ -479,6 +484,11 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-get install -y -o Dpkg::Options::=\"--force-confnew\" apt-transport-https ca-certificates man sudo wget"
             ;;
           centos)
+            if [[ "${MATRIX_IMAGE}" == "centos:8" ]]; then
+              # allow CentOS 8 to continue working now that it is EOL
+              # see: https://stackoverflow.com/a/70930049
+              sg lxd -c "lxc exec testcon -- sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*"
+            fi
             sg lxd -c "lxc exec testcon -- yum update -y"
             sg lxd -c "lxc exec testcon -- yum install -y man"
             ;;

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -434,7 +434,19 @@ jobs:
 
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
-        echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV
+
+        case ${MATRIX_IMAGE} in
+          centos:8)
+            # the CentOS 8 LXD image no longer exists since CentOS 8 hit EOL.
+            # there's also no Rocky Linux (a CentOS 8 compatible O/S) LXD image
+            # either, but there is an Alma Linux (another CentOS 8 compatible
+            # O/S) LXD image so use that for testing.
+            echo "LXC_IMAGE=images:almalinux/8/cloud" >> $GITHUB_ENV
+            ;;
+          *)
+            echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV
+            ;;
+        esac
       env:
         MATRIX_IMAGE: ${{ matrix.image }}
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -125,6 +125,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    # Allow CentOS 8 to continue working now that it is EOL
+    # See: https://stackoverflow.com/a/70930049
+    - name: CentOS 8 EOL workaround
+      if: matrix.image == 'centos:8'
+      run: |
+        sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+
     # Install Rust the hard way rather than using a GH Action because the action
     # doesn't work inside a Docker container.
     - name: Install Rust
@@ -150,11 +158,6 @@ jobs:
             apt-get install -y build-essential jq lintian pkg-config
             ;;
           centos)
-            if [[ "${MATRIX_IMAGE}" == "centos:8" ]]; then
-              # allow CentOS 8 to continue working now that it is EOL
-              # see: https://stackoverflow.com/a/70930049
-              sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-            fi
             yum install epel-release -y
             yum update -y
             yum install -y jq rpmlint

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -438,10 +438,8 @@ jobs:
         case ${MATRIX_IMAGE} in
           centos:8)
             # the CentOS 8 LXD image no longer exists since CentOS 8 hit EOL.
-            # there's also no Rocky Linux (a CentOS 8 compatible O/S) LXD image
-            # either, but there is an Alma Linux (another CentOS 8 compatible
-            # O/S) LXD image so use that for testing.
-            echo "LXC_IMAGE=images:almalinux/8/cloud" >> $GITHUB_ENV
+            # use the Rocky Linux (a CentOS 8 compatible O/S) LXD image instead.
+            echo "LXC_IMAGE=images:rockylinux/8/cloud" >> $GITHUB_ENV
             ;;
           *)
             echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -132,7 +132,6 @@ jobs:
       run: |
         sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
-
     # Install Rust the hard way rather than using a GH Action because the action
     # doesn't work inside a Docker container.
     - name: Install Rust


### PR DESCRIPTION
This PR "fixes" the failing CentOS 8 packaging workflow ([see here](https://github.com/NLnetLabs/routinator/actions/runs/1778642751)) by telling CentOS 8 to use vault packages as there are no "current" packages now that it is EOL. This will presumably allow anyone still running CentOS 8 to install a Routinator package.

Note: This PR doesn't attempt to address the separate question of whether or not it makes sense to keep packaging for CentOS 8 or if we should package instead or additionally for Rocky Linux, for example (and whether or not we would need to also extend packages.nlnetlabs.nl with a separate RockyLinux repository as well).

A successful run of the packaging workflow using the changes in this PR can be seen [here](https://github.com/NLnetLabs/routinator/actions/runs/1786566863).