### PR TITLE
Fixes to DEB and RPM packaging

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -174,7 +174,6 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target
         key: ${{ matrix.image }}-${{ matrix.target}}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     # Speed up tooling installation by only re-downloading and re-building

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -268,8 +268,9 @@ jobs:
         # release but without having to decide what higher semver number to bump
         # to. In this case we do NOT want dash '-' to become '~' because `-`
         # is treated as higher and tilda is treated as lower.
-        ROUTINATOR_VER=$(cargo read-manifest | jq -r '.version' | tr '-' '~')
-        PKG_ROUTINATOR_VER=$(echo $ROUTINATOR_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
+        ROUTINATOR_VER=$(cargo read-manifest | jq -r '.version')
+        PKG_ROUTINATOR_VER=$(echo $ROUTINATOR_VER | tr '-' '~')
+        PKG_ROUTINATOR_VER=$(echo $PKG_ROUTINATOR_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -313,7 +314,7 @@ jobs:
             strip -s target/release/routinator
 
             # Fix the version string to be used for the RPM package
-            sed -i -e "s/$ROUTINATOR_VER/$PKG_ROUTINATOR_VER/" Cargo.toml
+            sed -i -e "s/<RPM_PKG_VER_PLACEHOLDER>/$PKG_ROUTINATOR_VER/" Cargo.toml
 
             # Select the correct systemd service unit file for the target operating system
             case ${MATRIX_IMAGE} in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ systemd-units = { unit-name = "routinator", unit-scripts = "pkg/common", enable 
 depends = "adduser, passwd"
 
 [package.metadata.generate-rpm]
+version = "<RPM_PKG_VER_PLACEHOLDER>"
 # "BSD" alone is the 3-clause license. Inheriting "license" from above causes rpmlint to
 # complain with "invalid-license".
 # See: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing


### PR DESCRIPTION
The v0.11.0-rc1 release had incorrect version numbers on the RPM packages. They should have been `0.11.0~rc1` but were `0.11.0-rc1` meaning that our packaging system published them in the `main` package repo instead of the `proposed` package repo (where release candidates are supposed to be published). Anyone who upgraded packages with `yum` who had an older Routinator RPM installed will have been prompted to install (or if `-y` was used will have installed) the RC version even if they didn't have the `proposed` repo configured.

This PR fixes the versioning issue, and a separate PR on the packaging system itself adds a check to prevent publication of mixed proposed and non-proposed packages to prevent such a mistake getting to the final package repos.

This PR also fixes a couple of other packaging issues discovered at the same time. Firstly the GitHub Actions cache wrongly contained the `target` directory, other versions of our packaging workflow (e.g. the one for Krill) don't have this. With this a previous run that generated one RPM filename can fetch that RPM back from the cache on a subsequent run and then fail because it produces two RPMs unexpectedly instead of one. It could probably also fail in more interesting and painful ways.

Secondly, it also fixes the tag URL in the DEB package `debian/changelog` file to use the actual Git tag without a minus sign instead of a tilda (as the tilda is only in the package version, not in the application version).