### PR TITLE
Also set TCP_KEEPIDLE when enable TCP keepalive.

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -750,7 +750,7 @@ These can be requested by providing different commands on the command line.
               enabled on all RTR connections with an idle time of 60 seconds. 
               Set this option to 0 to disable keepalives.
 
-              On some systems, notably OpenBSD, this options only enables TCP
+              On some systems, notably OpenBSD, this option only enables TCP
               keepalives if set to any value other than 0. You will have to
               use the system's own mechanisms to change the idle times.
 
@@ -1201,7 +1201,7 @@ All values can be overridden via the command line options.
             connections with an idle time of 60 seconds. If this option is
             present and set to zero, TCP keepalives are disabled.
 
-            On some systems, notably OpenBSD, this options only enables TCP
+            On some systems, notably OpenBSD, this option only enables TCP
             keepalives if set to any value other than 0. You will have to
             use the system's own mechanisms to change the idle times.
 

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -750,6 +750,10 @@ These can be requested by providing different commands on the command line.
               enabled on all RTR connections with an idle time of 60 seconds. 
               Set this option to 0 to disable keepalives.
 
+              On some systems, notably OpenBSD, this options only enables TCP
+              keepalives if set to any value other than 0. You will have to
+              use the system's own mechanisms to change the idle times.
+
        .. option:: --rtr-client-metrics
        
               If provided, the server metrics will include separate metrics
@@ -1196,6 +1200,10 @@ All values can be overridden via the command line options.
             option is missing, TCP keepalive will be enabled on all RTR
             connections with an idle time of 60 seconds. If this option is
             present and set to zero, TCP keepalives are disabled.
+
+            On some systems, notably OpenBSD, this options only enables TCP
+            keepalives if set to any value other than 0. You will have to
+            use the system's own mechanisms to change the idle times.
 
       rtr-client-metrics
             A boolean value specifying whether server metrics should include

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "ROUTINATOR" "1" "Feb 28, 2022" "0.11.1-dev" "Routinator"
+.TH "ROUTINATOR" "1" "Mar 29, 2022" "0.11.1-dev" "Routinator"
 .SH NAME
 routinator \- RPKI relying party software
 .SH SYNOPSIS
@@ -838,6 +838,10 @@ The number of seconds to wait before sending a TCP keepalive on
 an established RTR  connection. By  default, TCP keepalive is
 enabled on all RTR connections with an idle time of 60 seconds.
 Set this option to 0 to disable keepalives.
+.sp
+On some systems, notably OpenBSD, this options only enables TCP
+keepalives if set to any value other than 0. You will have to
+use the system\(aqs own mechanisms to change the idle times.
 .UNINDENT
 .INDENT 7.0
 .TP
@@ -1309,6 +1313,10 @@ sending a TCP keepalive on an established RTR connection. If this
 option is missing, TCP keepalive will be enabled on all RTR
 connections with an idle time of 60 seconds. If this option is
 present and set to zero, TCP keepalives are disabled.
+.sp
+On some systems, notably OpenBSD, this options only enables TCP
+keepalives if set to any value other than 0. You will have to
+use the system\(aqs own mechanisms to change the idle times.
 .TP
 .B rtr\-client\-metrics
 A boolean value specifying whether server metrics should include

--- a/src/rtr.rs
+++ b/src/rtr.rs
@@ -166,11 +166,15 @@ impl RtrStream {
         use nix::sys::socket::{setsockopt, sockopt};
 
         (|fd, duration: Duration| {
+            setsockopt(fd, sockopt::KeepAlive, &true)?;
+            setsockopt(
+                fd, sockopt::TcpKeepIdle,
+                &u32::try_from(duration.as_secs()).unwrap_or(u32::MAX)
+            )?;
             setsockopt(
                 fd, sockopt::TcpKeepInterval,
                 &u32::try_from(duration.as_secs()).unwrap_or(u32::MAX)
-            )?;
-            setsockopt(fd, sockopt::KeepAlive, &true)
+            )
         })(sock.as_raw_fd(), duration).map_err(|err| {
             io::Error::new(io::ErrorKind::Other, err)
         })

--- a/src/rtr.rs
+++ b/src/rtr.rs
@@ -167,15 +167,36 @@ impl RtrStream {
 
         (|fd, duration: Duration| {
             setsockopt(fd, sockopt::KeepAlive, &true)?;
+
+            // The attributes are copied from the definitions in
+            // nix::sys::socket::sockopt. Let’s hope they never change.
+
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            setsockopt(
+                fd, sockopt::TcpKeepAlive,
+                &u32::try_from(duration.as_secs()).unwrap_or(u32::MAX)
+            )?;
+
+            #[cfg(any(
+                target_os = "android",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "linux",
+                target_os = "nacl"
+            ))]
             setsockopt(
                 fd, sockopt::TcpKeepIdle,
                 &u32::try_from(duration.as_secs()).unwrap_or(u32::MAX)
             )?;
+
+            #[cfg(not(target_os = "openbsd"))]
             setsockopt(
                 fd, sockopt::TcpKeepInterval,
                 &u32::try_from(duration.as_secs()).unwrap_or(u32::MAX)
-            )
-        })(sock.as_raw_fd(), duration).map_err(|err| {
+            )?;
+
+            Ok(())
+        })(sock.as_raw_fd(), duration).map_err(|err: nix::errno::Errno| {
             io::Error::new(io::ErrorKind::Other, err)
         })
     }


### PR DESCRIPTION
This will be set to `rtr-tcp-keepalive` in order to overwrite the OS’s default value which, in case of Linux, is 7200 seconds.