### PR TITLE
Truncate PID file upon opening.

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -449,7 +449,7 @@ mod unix {
         fn create_pid_file(&mut self, path: &Path) -> Result<(), Failed> {
             let fd = match open(
                 path,
-                OFlag::O_WRONLY | OFlag::O_CREAT,
+                OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_TRUNC,
                 Mode::from_bits_truncate(0o666)
             ) {
                 Ok(fd) => fd,


### PR DESCRIPTION
Fixes #734.