### PR TITLE
Dump the stored trust anchor certificates.

### DIFF
--- a/doc/manual/source/dump.rst
+++ b/doc/manual/source/dump.rst
@@ -28,4 +28,13 @@ store
     repository similarly structured to the :file:`rrdp` directory and one
     additional directory :file:`rsync` that contains files collected via rsync.
 
+ta
+    This directory contains the trust anchor certificates. Files are stored
+    in a directory structure two levels deep. The first level is the schema
+    portion of the certificate’s URI, i.e., ``https`` or ``rsync``, and the
+    second level is the authority portion of the URI, e.g., ``tal.apnic.net``.
+    Within this second level, the certificate is stored in a file that has
+    the hexadecimal encoding of the SHA-256 hash of the certificate’s URI
+    as the file name with the extension ``.cer`` appended.
+
 .. versionadded:: 0.9.0

--- a/doc/manual/source/dump.rst
+++ b/doc/manual/source/dump.rst
@@ -38,3 +38,6 @@ ta
     as the file name with the extension ``.cer`` appended.
 
 .. versionadded:: 0.9.0
+.. versionchanged:: 0.11.1
+   Stored trust anchor certificates are dumped into the ``ta`` directory.
+

--- a/src/store.rs
+++ b/src/store.rs
@@ -153,6 +153,7 @@ impl Store {
 
     /// Dumps the content of the store.
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
+        self.dump_ta_certs(dir)?;
         let dir = dir.join("store");
         debug!("Dumping store content to {}", dir.display());
         fatal::remove_dir_all(&dir)?;
@@ -161,6 +162,20 @@ impl Store {
         self.dump_tree(&self.rrdp_repository_base(), &mut repos)?;
         self.dump_repository_json(repos)?;
         debug!("Store dump complete.");
+        Ok(())
+    }
+
+    /// Dumps all the stored trust anchor certificates.
+    fn dump_ta_certs(
+        &self,
+        target_base: &Path
+    ) -> Result<(), Failed> {
+        let source = self.path.join("ta");
+        let target = target_base.join("ta");
+        debug!("Dumping trust anchor certificates to {}", target.display());
+        fatal::remove_dir_all(&target)?;
+        fatal::copy_dir_all(&source, &target)?;
+        debug!("Trust anchor certificate dump complete.");
         Ok(())
     }
 

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -315,3 +315,35 @@ pub fn write_file(path: &Path, contents: &[u8]) -> Result<(), Failed> {
     })
 }
 
+
+//------------ copy_dir_all --------------------------------------------------
+
+/// Copies the content of a directory.
+///
+/// Creates the target directory with `create_dir_all`.  Errors out if
+/// anything goes wrong.
+pub fn copy_dir_all(source: &Path, target: &Path) -> Result<(), Failed> {
+    create_dir_all(target)?;
+    for entry in read_dir(source)? {
+        let entry = entry?;
+        if entry.is_file() {
+            if let Err(err) = fs::copy(
+                entry.path(), &target.join(entry.file_name())
+            ) {
+                error!(
+                    "Fatal: failed to copy {}: {}",
+                    entry.path().display(), err
+                );
+                return Err(Failed)
+            }
+        }
+        else if entry.is_dir() {
+            copy_dir_all(
+                entry.path(),
+                &target.join(entry.file_name())
+            )?;
+        }
+    }
+    Ok(())
+}
+


### PR DESCRIPTION
This copies all certificate stored under $(REPOSITORY_DIR)/store/ta to
$(TARGET_DIR)/ta using the same structure as the store itself. The
somewhat unexpected organization has been documented in the manual.

Fixes #722.