### PR TITLE
Upgrade to syslog 6.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -444,6 +444,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -1259,14 +1285,15 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5d8ef1b679c07976f3ee336a436453760c470f54b5e7237556728b8589515d"
+checksum = "978044cc68150ad5e40083c9f6a725e6fd02d7ba1bcf691ec2ff0d66c0b41acc"
 dependencies = [
  "error-chain",
+ "hostname",
  "libc",
  "log",
- "time",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -1342,6 +1369,17 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ routinator-ui   = { version = "0.3.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix             = "0.22.0"
-syslog          = "5.0.0"
+syslog          = "6.0.1"
 
 [build-dependencies]
 rustc_version   = "0.4.0"

--- a/src/process.rs
+++ b/src/process.rs
@@ -128,17 +128,11 @@ impl Process {
         &self,
         facility: syslog::Facility
     ) -> Result<fern::Dispatch, Failed> {
-        let process = std::env::current_exe().ok().and_then(|path|
-            path.file_name()
-                .and_then(std::ffi::OsStr::to_str)
-                .map(ToString::to_string)
-        ).unwrap_or_else(|| String::from("routinator"));
-        let formatter = syslog::Formatter3164 {
-            facility,
-            hostname: None,
-            process,
-            pid: nix::unistd::getpid().as_raw()
-        };
+        let mut formatter = syslog::Formatter3164::default();
+        formatter.facility = facility;
+        if formatter.process.is_empty() {
+            formatter.process = String::from("routinator");
+        }
         let logger = syslog::unix(formatter.clone()).or_else(|_| {
             syslog::tcp(formatter.clone(), ("127.0.0.1", 601))
         }).or_else(|_| {


### PR DESCRIPTION
Somehow, the type for the pid on `Formatter3164` has changed to a `u32` while the pid returned by nix is a `i32`. Since `Formatter3164` comes with an impl of `Default` that mostly does the right thing, we switch to that and adjust as needed after.