### PR TITLE
Add Ubuntu 22.04 packaging support.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -418,6 +418,9 @@ jobs:
         # exclude:
         #   - image: 'debian:bullseye'
         #     mode: 'upgrade-from-published'
+        exclude:
+          - image: 'ubuntu:jammy'
+            mode: 'upgrade-from-published'
         target:
           - 'x86_64'
     steps:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -79,6 +79,7 @@ jobs:
           - "ubuntu:xenial"   # ubuntu/16.04
           - "ubuntu:bionic"   # ubuntu/18.04
           - "ubuntu:focal"    # ubuntu/20.04
+          - "ubuntu:jammy"    # ubuntu/22.04
           - "debian:stretch"  # debian/9
           - "debian:buster"   # debian/10
           - "debian:bullseye" # debian/11
@@ -399,6 +400,7 @@ jobs:
           - "ubuntu:xenial"   # ubuntu/16.04
           - "ubuntu:bionic"   # ubuntu/18.04
           - "ubuntu:focal"    # ubuntu/20.04
+          - "ubuntu:jammy"    # ubuntu/22.04
           - "debian:stretch"  # debian/9
           - "debian:buster"   # debian/10
           - "debian:bullseye" # debian/11

--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -123,6 +123,7 @@ to get started.
        To install a Routinator package, you need the 64-bit version of one of
        these Ubuntu versions:
 
+         - Ubuntu Jammy 22.04 (LTS)
          - Ubuntu Focal 20.04 (LTS)
          - Ubuntu Bionic 18.04 (LTS)
          - Ubuntu Xenial 16.04 (LTS)


### PR DESCRIPTION
Add support for packaging for Ubuntu 22.04 Jammy Jellyfish, due for release on April 21, 2022.