### PR TITLE
RTR server: Start with the first withdrawn element.

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1427,13 +1427,15 @@ impl PayloadDiff for DeltaVrpIter {
                         Some((res, Action::Announce))
                     }
                     None => {
-                        self.pos = Err(0);
-                        match self.delta.withdraw.get(pos) {
+                        match self.delta.withdraw.get(0) {
                             Some(res) => {
-                                self.pos = Err(pos + 1);
+                                self.pos = Err(1);
                                 Some((res, Action::Withdraw))
                             }
-                            None => None
+                            None => {
+                                self.pos = Err(0);
+                                None
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The current implementation continues using the index from the going through the announcements and thus misses withdraws if there are any announcements.