### PR TITLE
Packaging fixes

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -191,7 +191,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-generate-rpm
-        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ startsWith(${OS_REL}, "xenial")}}
+        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ endsWith(matrix.image, "xenial")}}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -333,7 +333,7 @@ jobs:
         esac
 
     # See what O/S specific linting tools think of our package.
-    - name: Verify the DEB package
+    - name: Verify the package
       env:
         CROSS_TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -399,7 +399,7 @@ jobs:
           - "ubuntu:bionic"   # ubuntu/18.04
           - "ubuntu:focal"    # ubuntu/20.04
           - "ubuntu:jammy"    # ubuntu/22.04
-          - "debian:stretch"  # debian/9
+          # - "debian:stretch"  # debian/9 - LXC image is no longer available on images.linuxcontainers.org
           - "debian:buster"   # debian/10
           - "debian:bullseye" # debian/11
           - "centos:7"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: 1.28.0
+      CARGO_DEB_VER: 1.38.2
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -199,8 +199,18 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            cargo install cargo-deb --version ${CARGO_DEB_VER}
-            ;;
+            if [[ "${OS_REL}" == "xenial" ]]; then
+              # Disable use of the default lzma feature which causes XZ compression to be used
+              # which then causes Lintian to fail with error:
+              #   E: krill: malformed-deb-archive newer compressed control.tar.xz
+              # Passing --fast to cargo-deb to disable use of XZ compression didn't help.
+              # See: https://github.com/kornelski/cargo-deb/issues/12
+              EXTRA_CARGO_INSTALL_ARGS="--no-default-features"
+            else
+              EXTRA_CARGO_INSTALL_ARGS=""
+            fi
+            cargo install cargo-deb --version ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
+          ;;
         esac
 
     - name: Install Cargo Generate RPM if needed

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -191,7 +191,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-generate-rpm
-        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ endsWith(matrix.image, "xenial")}}
+        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ endsWith(matrix.image, 'xenial')}}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -98,7 +98,7 @@ jobs:
             target: 'aarch64-unknown-linux-musl'
     env:
       CARGO_DEB_VER: 1.28.0
-      CARGO_GENERATE_RPM_VER: 0.4.0
+      CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.
       NEXT_VER_LABEL: dev
@@ -208,9 +208,7 @@ jobs:
       run: |
         case ${OS_NAME} in
           centos)
-            # Temporary workaround for https://github.com/cat-in-136/cargo-generate-rpm/issues/21
-            rustup toolchain install 1.52.0
-            cargo +1.52.0 install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
+            cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
             ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -316,19 +316,22 @@ jobs:
 
             # Select the correct systemd service unit file for the target operating system
             case ${MATRIX_IMAGE} in
-            centos:7)
-              SYSTEMD_SERVICE_UNIT_FILE="routinator-minimal.routinator.service"
-              ;;
-            *)
-              SYSTEMD_SERVICE_UNIT_FILE="routinator.routinator.service"
-              ;;
+              centos:7)
+                SYSTEMD_SERVICE_UNIT_FILE="routinator-minimal.routinator.service"
+                # yum install fails on older CentOS with the default LZMA compression used by cargo generate-rpm since v0.5.0
+                EXTRA_CARGO_GENERATE_RPM_ARGS="--payload-compress gzip"
+                ;;
+              *)
+                SYSTEMD_SERVICE_UNIT_FILE="routinator.routinator.service"
+                EXTRA_CARGO_GENERATE_RPM_ARGS=""
+                ;;
             esac
 
             # Copy the chosen systemd service unit file to where Cargo.toml expects it to be
             mkdir -p target/rpm
             cp pkg/common/${SYSTEMD_SERVICE_UNIT_FILE} target/rpm/routinator.service
     
-            cargo generate-rpm
+            cargo generate-rpm ${EXTRA_CARGO_GENERATE_RPM_ARGS}
             ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -191,7 +191,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-generate-rpm
-        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
+        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ startsWith(${OS_REL}, "xenial")}}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: 1.36.0 # Newer cargo-deb fails to compile with --no-default-features, see https://github.com/kornelski/cargo-deb/issues/43.
+      CARGO_DEB_VER: 1.34.2 # Newer cargo-deb fails to compile with --no-default-features, see https://github.com/kornelski/cargo-deb/issues/43.
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: 1.38.2
+      CARGO_DEB_VER: 1.36.0 # Newer cargo-deb fails to compile with --no-default-features, see https://github.com/kornelski/cargo-deb/issues/43.
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -184,14 +184,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-deb
-        key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}
+        key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
 
     - name: Cache Cargo Generate RPM if available
       id: cache-cargo-generate-rpm
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-generate-rpm
-        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}-${{ endsWith(matrix.image, 'xenial')}}
+        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed


### PR DESCRIPTION
This PR:
- Fixes the failure on `main` by disabling testing of the generated DEB package for the Debian Stretch platform, as the Debian Stretch LXC image is no longer available on images.linuxcontainers.org.
- Removes the need to use an old Rust version to build Routinator when generating RPMs by upgrading to latest `cargo-generate-rpm`.
- Fixes a minor issue where one of the step names still referred to DEB packaging even though it is also run for RPMs.
- Upgrades cargo-deb to 1.36.0, the newest version that both supports Rust edition 2021 (to support PR #760) **AND** compiles without `lzma` support (required with newer Cargo deb versions in order to build a valid package on Ubuntu Xenial). See cargo deb issues https://github.com/kornelski/cargo-deb/issues/12 and https://github.com/kornelski/cargo-deb/issues/43.

A successful run of the `pkg` workflow using this PR branch can be seen [here](https://github.com/NLnetLabs/routinator/actions/runs/2782340811).