### PR TITLE
Change the default and logging behaviour for unsafe-vrps

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -134,11 +134,7 @@ The available options are:
       to the valid VRPs.
 
       Finally, the *accept* policy will quietly add unsafe VRPs to the valid
-      VRPs.
-
-      Currently, the default policy is *warn* in order to gain operational
-      experience with the frequency and impact of unsafe VRPs. This default
-      may change in future versions.
+      VRPs. This is the default policy.
 
       For more information on the process of validation implemented in
       Routinator, see the section `VALIDATION`_ below.
@@ -1000,11 +996,11 @@ All values can be overridden via the command line options.
 
             warn
                   Warn about unsafe VRPs in the log but add them to the final
-                  set of VRPs. This is the default policy if the value is
-                  missing.
+                  set of VRPs.
 
             accept
-                  Quietly add unsafe VRPs to the final set of VRPs.
+                  Quietly add unsafe VRPs to the final set of VRPs.  This is
+                  the default policy if the value is missing.
 
       unknown-objects
             A string specifying the policy for dealing with unknown RPKI

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ const DEFAULT_RTR_TCP_KEEPALIVE: Option<Duration>
 const DEFAULT_STALE_POLICY: FilterPolicy = FilterPolicy::Reject;
 
 /// The default unsafe-vrps policy.
-const DEFAULT_UNSAFE_VRPS_POLICY: FilterPolicy = FilterPolicy::Warn;
+const DEFAULT_UNSAFE_VRPS_POLICY: FilterPolicy = FilterPolicy::Accept;
 
 /// The default unknown-objects policy.
 const DEFAULT_UNKNOWN_OBJECTS_POLICY: FilterPolicy = FilterPolicy::Warn;
@@ -1827,6 +1827,15 @@ pub enum FilterPolicy {
 
     /// Quietly accept objects matched by the filter.
     Accept
+}
+
+impl FilterPolicy {
+    /// Does the filter policy require logging?
+    ///
+    /// This is true for reject and warn.
+    pub fn log(self) -> bool {
+        matches!(self, FilterPolicy::Reject | FilterPolicy::Warn)
+    }
 }
 
 impl FromStr for FilterPolicy {

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -42,7 +42,7 @@ async fn handle_status(
     server_metrics: &HttpServerMetrics,
     rtr_metrics: &SharedRtrServerMetrics,
 ) -> Response {
-    let (metrics, serial, start, done, duration) = {
+    let (metrics, serial, start, done, duration, unsafe_vrps) = {
         let history = history.read();
         (
             match history.metrics() {
@@ -53,6 +53,7 @@ async fn handle_status(
             history.last_update_start(),
             history.last_update_done(),
             history.last_update_duration(),
+            history.unsafe_vrps(),
         )
     };
 
@@ -123,22 +124,24 @@ async fn handle_status(
     }
     writeln!(res).unwrap();
 
-    // unsafe-filtered-vrps
-    writeln!(res,
-        "unsafe-vrps: {}",
-        metrics.payload.vrps().marked_unsafe
-    ).unwrap();
-
-    // unsafe-vrps-per-tal
-    write!(res, "unsafe-filtered-vrps-per-tal: ").unwrap();
-    for tal in &metrics.tals {
-        write!(res,
-            "{}={} ",
-            tal.name(),
-            tal.payload.vrps().marked_unsafe
+    if unsafe_vrps.log() {
+        // unsafe-filtered-vrps
+        writeln!(res,
+            "unsafe-vrps: {}",
+            metrics.payload.vrps().marked_unsafe
         ).unwrap();
+
+        // unsafe-vrps-per-tal
+        write!(res, "unsafe-filtered-vrps-per-tal: ").unwrap();
+        for tal in &metrics.tals {
+            write!(res,
+                "{}={} ",
+                tal.name(),
+                tal.payload.vrps().marked_unsafe
+            ).unwrap();
+        }
+        writeln!(res).unwrap();
     }
-    writeln!(res).unwrap();
 
     // locally-filtered-vrps
     writeln!(res,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -631,7 +631,7 @@ impl Server {
         info!("Starting a validation run.");
         history.mark_update_start();
         let (report, metrics) = ValidationReport::process(
-            engine, config.enable_bgpsec
+            engine, config.unsafe_vrps.log(), config.enable_bgpsec
         )?;
         let must_notify = history.update(
             report, &exceptions, metrics,
@@ -820,7 +820,9 @@ impl Vrps {
         process.switch_logging(false, false)?;
         let exceptions = LocalExceptions::load(process.config(), true)?;
         let (report, mut metrics) = ValidationReport::process(
-            &engine, process.config().enable_bgpsec
+            &engine,
+            process.config().unsafe_vrps.log(),
+            process.config().enable_bgpsec,
         )?;
         let vrps = PayloadSnapshot::from_report(
             report,
@@ -1093,7 +1095,9 @@ impl Validate {
         engine.ignite()?;
         process.switch_logging(false, false)?;
         let (report, mut metrics) = ValidationReport::process(
-            &engine, process.config().enable_bgpsec
+            &engine,
+            process.config().unsafe_vrps.log(),
+            process.config().enable_bgpsec,
         )?;
         let snapshot = PayloadSnapshot::from_report(
             report,
@@ -1343,7 +1347,9 @@ impl Update {
         engine.ignite()?;
         process.switch_logging(false, false)?;
         let (_, metrics) = ValidationReport::process(
-            &engine, process.config().enable_bgpsec
+            &engine,
+            process.config().unsafe_vrps.log(),
+            process.config().enable_bgpsec,
         )?;
         if self.complete && !metrics.rsync_complete() {
             Err(ExitError::IncompleteUpdate)

--- a/src/output.rs
+++ b/src/output.rs
@@ -1040,9 +1040,8 @@ impl Summary {
                 tal.publication.valid_roas
             ))?;
             line(format_args!(
-                "            VRPs: {:7} verified, {:7} unsafe, {:7} final;",
+                "            VRPs: {:7} verified, {:7} final;",
                 tal.payload.vrps().valid,
-                tal.payload.vrps().marked_unsafe,
                 tal.payload.vrps().contributed
             ))?;
             line(format_args!(
@@ -1061,9 +1060,8 @@ impl Summary {
             metrics.publication.valid_roas
         ))?;
         line(format_args!(
-            "            VRPs: {:7} verified, {:7} unsafe, {:7} final;",
+            "            VRPs: {:7} verified, {:7} final;",
             metrics.payload.vrps().valid,
-            metrics.payload.vrps().marked_unsafe,
             metrics.payload.vrps().contributed
         ))?;
         line(format_args!(


### PR DESCRIPTION
This PR changes the default configuration option for unsafe-vrps to accept and removes all logging or mentioning of unsafe VRPs in this case. It also adds a pointer to the manual page for unsafe VRPs if any are logged.

Fixes #536.