### PR TITLE
Enable building multi-architecture docker images

### DIFF
--- a/.github/workflows/pkg-docker.yml
+++ b/.github/workflows/pkg-docker.yml
@@ -21,7 +21,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: nlnetlabs/routinator
+          images: ${{ secrets.DOCKER_HUB_ID }}/routinator
           flavor: |
             latest=false
           tags: |
@@ -34,44 +34,21 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      # Build the image and tag it with a test tag we can use in the subsequent step when we invoke 'docker run'.
-      - name: Build Docker image
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build the image and push it.
+      - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: nlnetlabs/routinator:sanitycheck
-
-      # Do a basic sanity check of the created image using the test tag to select the image to run.
-      - name: Sanity check
-        run: |
-          docker run --rm nlnetlabs/routinator:sanitycheck --version
-
-      # Push the image and tags to Docker Hub.
-      # The build uses the cached build outputs from the step above so we don't have to wait for the build again.
-      #
-      # On push of a tag to refs/tags/v1.2.3 the Docker tags will be 'v1.2.3' and 'latest' because of:
-      #   type=semver,pattern={{version}},prefix=v
-      #   type=raw,value=latest,enable=${{ github.ref != 'refs/heads/main' && !contains(github.ref, '-') }}
-      #                                    ^^^^^^^^^^^^^ true, not main       ^^^^^^^^^ true, no dash found
-      #
-      #   Note: we don't use semver,pattern={{raw}} because while that preserves the leading v in v1.2.3 it
-      #   discards the leading v in v1.2.3-rc4.
-      #
-      # On push of a tag to refs/tags/v1.2.3-rc1 the Docker tags will be 'v1.2.3' but NOT 'latest' because of:
-      #   type=semver,pattern={{raw}}
-      #   type=raw,value=latest,enable=${{ github.ref != 'refs/heads/main' && !contains(github.ref, '-') }}
-      #                                    ^^^^^^^^^^^^^ true, not main       ^^^^^^^^^ false, dash found
-      #
-      # On push to refs/heads/main the Docker tag will be 'unstable' because of:
-      #   type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/main' }}
-      - name: Push built Docker image to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Use QEMU to enable building containers for the ARM platform.  

This will increase the build time due to the emulation.

The testing step was removed as the load command did not work.