### PR TITLE
Remove cargo deb version hold

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: 1.34.2 # Newer cargo-deb fails to compile with --no-default-features, see https://github.com/kornelski/cargo-deb/issues/43.
+      CARGO_DEB_VER: 1.38.3
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: ec4e00358bc3cc1abc6d3dd10f9bbf58f31a2cf5
+      CARGO_DEB_VER: 1.38.4
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.
@@ -209,7 +209,7 @@ jobs:
             else
               EXTRA_CARGO_INSTALL_ARGS=""
             fi
-            cargo install cargo-deb --git https://github.com/kornelski/cargo-deb.git --rev ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
+            cargo install cargo-deb --version ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
           ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -97,7 +97,7 @@ jobs:
           - image: 'debian:buster'
             target: 'aarch64-unknown-linux-musl'
     env:
-      CARGO_DEB_VER: 1.38.3
+      CARGO_DEB_VER: ec4e00358bc3cc1abc6d3dd10f9bbf58f31a2cf5
       CARGO_GENERATE_RPM_VER: 0.6.0
       # A Routinator version of the form 'x.y.z-dev' denotes a dev build that is
       # newer than the released x.y.z version but is not yet a new release.
@@ -199,17 +199,17 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            if [[ "${OS_REL}" == "xenial" ]]; then
-              # Disable use of the default lzma feature which causes XZ compression to be used
-              # which then causes Lintian to fail with error:
-              #   E: krill: malformed-deb-archive newer compressed control.tar.xz
-              # Passing --fast to cargo-deb to disable use of XZ compression didn't help.
-              # See: https://github.com/kornelski/cargo-deb/issues/12
-              EXTRA_CARGO_INSTALL_ARGS="--no-default-features"
-            else
+            #if [[ "${OS_REL}" == "xenial" ]]; then
+            #  # Disable use of the default lzma feature which causes XZ compression to be used
+            #  # which then causes Lintian to fail with error:
+            #  #   E: krill: malformed-deb-archive newer compressed control.tar.xz
+            #  # Passing --fast to cargo-deb to disable use of XZ compression didn't help.
+            #  # See: https://github.com/kornelski/cargo-deb/issues/12
+            #  EXTRA_CARGO_INSTALL_ARGS="--no-default-features"
+            #else
               EXTRA_CARGO_INSTALL_ARGS=""
-            fi
-            cargo install cargo-deb --version ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
+            #fi
+            cargo install cargo-deb --git https://github.com/kornelski/cargo-deb.git --rev ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
           ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -199,16 +199,16 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            #if [[ "${OS_REL}" == "xenial" ]]; then
-            #  # Disable use of the default lzma feature which causes XZ compression to be used
-            #  # which then causes Lintian to fail with error:
-            #  #   E: krill: malformed-deb-archive newer compressed control.tar.xz
-            #  # Passing --fast to cargo-deb to disable use of XZ compression didn't help.
-            #  # See: https://github.com/kornelski/cargo-deb/issues/12
-            #  EXTRA_CARGO_INSTALL_ARGS="--no-default-features"
-            #else
+            if [[ "${OS_REL}" == "xenial" ]]; then
+              # Disable use of the default lzma feature which causes XZ compression to be used
+              # which then causes Lintian to fail with error:
+              #   E: krill: malformed-deb-archive newer compressed control.tar.xz
+              # Passing --fast to cargo-deb to disable use of XZ compression didn't help.
+              # See: https://github.com/kornelski/cargo-deb/issues/12
+              EXTRA_CARGO_INSTALL_ARGS="--no-default-features"
+            else
               EXTRA_CARGO_INSTALL_ARGS=""
-            #fi
+            fi
             cargo install cargo-deb --git https://github.com/kornelski/cargo-deb.git --rev ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
           ;;
         esac


### PR DESCRIPTION
The version of [cargo-deb](https://github.com/kornelski/cargo-deb/) used to create DEB packages was held at 1.34.2 because newer versions produced packages that were deemed invalid by Lintian on Ubuntu Xenial.

The underlying cause was [fixed yesterday](https://github.com/kornelski/cargo-deb/commit/ec4e00358bc3cc1abc6d3dd10f9bbf58f31a2cf5) and the [upstream issue](https://github.com/kornelski/cargo-deb/issues/12) was resolved. The new commit of cargo-deb `main` was then tested in [this Routinator `pkg` workflow run](https://github.com/NLnetLabs/routinator/actions/runs/2863785101).

The root cause was use of LZMA compression via O/S provided `xz` binary while older `dpkg` lacks support for LZMA compression. The fix was to not use O/S provided LZMA compression when the `lzma` feature of cargo-deb is disabled (which until now only disabled LZMA compression via cargo-deb Rust code but did not disable LZMA compression via O/S provided `xz` binary, if available).

This DRAFT PR is a placeholder to upgrade cargo-deb in our `pkg` workflow so that we are not held back to an old version which may cause much more work when we in future try and upgrade, and prevents us taking bug fixes and improvements from the cargo-deb project, or even raising issues against the project.

Once a new release of cargo-deb is made this PR can be updated to use it and this PR can be promoted from DRAFT to READY.