### PR TITLE
Introduce WriteOrPanic trait for write!-ing without unwrap.

### DIFF
--- a/src/http/delta.rs
+++ b/src/http/delta.rs
@@ -1,7 +1,6 @@
 //! Handles endpoints related to output of payload deltas.
 
 use std::convert::Infallible;
-use std::io::Write;
 use std::str::FromStr;
 use std::sync::Arc;
 use futures::stream;
@@ -11,6 +10,7 @@ use rpki::rtr::payload::Payload;
 use crate::payload::{
     PayloadDelta, PayloadSnapshot, SharedHistory, SnapshotArcIter
 };
+use crate::utils::fmt::WriteOrPanic;
 use super::response::{ContentType, Response, ResponseBuilder};
 
 //------------ handle_get ----------------------------------------------------
@@ -169,7 +169,7 @@ impl DeltaStream {
             \n  \"fromSerial\": {},\
             \n  \"announced\": [",
             session, to_serial, from_serial
-        ).unwrap()
+        )
     }
 
     /// Appends the separator between announced and withdrawn to the vec.
@@ -179,7 +179,7 @@ impl DeltaStream {
         write!(vec, "\
             \n  ],\
             \n  \"withdrawn\": [",
-        ).unwrap()
+        )
     }
 
     /// Appends an origin to the vec.
@@ -203,7 +203,7 @@ impl DeltaStream {
                     origin.asn,
                     origin.prefix.addr(), origin.prefix.prefix_len(),
                     origin.prefix.resolved_max_len()
-                ).unwrap()
+                )
             },
             Payload::RouterKey(ref key) => {
                 write!(vec, "\
@@ -216,7 +216,7 @@ impl DeltaStream {
                     key.key_identifier,
                     key.asn,
                     key.key_info,
-                ).unwrap()
+                )
             }
         }
     }
@@ -316,7 +316,7 @@ impl SnapshotStream {
             \n  \"serial\": {},\
             \n  \"announced\": [",
             session, to_serial,
-        ).unwrap()
+        )
     }
 }
 

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -1,7 +1,6 @@
 //! Handling of endpoints related to the status.
 
 use std::cmp;
-use std::fmt::Write;
 use chrono::{Duration, Utc};
 use clap::{crate_name, crate_version};
 use hyper::{Body, Method, Request};
@@ -10,6 +9,7 @@ use crate::metrics::{
     SharedRtrServerMetrics, VrpMetrics,
 };
 use crate::payload::SharedHistory;
+use crate::utils::fmt::WriteOrPanic;
 use crate::utils::json::JsonBuilder;
 use super::response::{ContentType, Response, ResponseBuilder};
 
@@ -74,123 +74,123 @@ async fn handle_status(
     // version
     writeln!(res,
         concat!("version: ", crate_name!(), "/", crate_version!())
-    ).unwrap();
+    );
 
     // serial
-    writeln!(res, "serial: {}", serial).unwrap();
+    writeln!(res, "serial: {}", serial);
 
     // last-update-start-at and -ago
-    writeln!(res, "last-update-start-at:  {}", now - start).unwrap();
-    writeln!(res, "last-update-start-ago: {}", start).unwrap();
+    writeln!(res, "last-update-start-at:  {}", now - start);
+    writeln!(res, "last-update-start-ago: {}", start);
 
     // last-update-done-at and -ago
     if let Some(done) = done {
-        writeln!(res, "last-update-done-at:   {}", now - done).unwrap();
-        writeln!(res, "last-update-done-ago:  {}", done).unwrap();
+        writeln!(res, "last-update-done-at:   {}", now - done);
+        writeln!(res, "last-update-done-ago:  {}", done);
     }
     else {
-        writeln!(res, "last-update-done-at:   -").unwrap();
-        writeln!(res, "last-update-done-ago:  -").unwrap();
+        writeln!(res, "last-update-done-at:   -");
+        writeln!(res, "last-update-done-ago:  -");
     }
 
     // last-update-duration
     if let Some(duration) = duration {
-        writeln!(res, "last-update-duration:  {}", duration).unwrap();
+        writeln!(res, "last-update-duration:  {}", duration);
     }
     else {
-        writeln!(res, "last-update-duration:  -").unwrap();
+        writeln!(res, "last-update-duration:  -");
     }
 
     // valid-roas
     writeln!(
         res, "valid-roas: {}", metrics.publication.valid_roas
-    ).unwrap();
+    );
 
     // valid-roas-per-tal
-    write!(res, "valid-roas-per-tal: ").unwrap();
+    write!(res, "valid-roas-per-tal: ");
     for tal in &metrics.tals {
-        write!(res, "{}={} ", tal.name(), tal.publication.valid_roas).unwrap();
+        write!(res, "{}={} ", tal.name(), tal.publication.valid_roas);
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // vrps
-    writeln!(res, "vrps: {}", metrics.payload.vrps().valid).unwrap();
+    writeln!(res, "vrps: {}", metrics.payload.vrps().valid);
 
     // vrps-per-tal
-    write!(res, "vrps-per-tal: ").unwrap();
+    write!(res, "vrps-per-tal: ");
     for tal in &metrics.tals {
-        write!(res, "{}={} ", tal.name(), tal.payload.vrps().valid).unwrap();
+        write!(res, "{}={} ", tal.name(), tal.payload.vrps().valid);
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // unsafe-filtered-vrps
     writeln!(res,
         "unsafe-vrps: {}",
         metrics.payload.vrps().marked_unsafe
-    ).unwrap();
+    );
 
     // unsafe-vrps-per-tal
-    write!(res, "unsafe-filtered-vrps-per-tal: ").unwrap();
+    write!(res, "unsafe-filtered-vrps-per-tal: ");
     for tal in &metrics.tals {
         write!(res,
             "{}={} ",
             tal.name(),
             tal.payload.vrps().marked_unsafe
-        ).unwrap();
+        );
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // locally-filtered-vrps
     writeln!(res,
         "locally-filtered-vrps: {}",
         metrics.payload.vrps().locally_filtered
-    ).unwrap();
+    );
 
     // locally-filtered-vrps-per-tal
-    write!(res, "locally-filtered-vrps-per-tal: ").unwrap();
+    write!(res, "locally-filtered-vrps-per-tal: ");
     for tal in &metrics.tals {
         write!(res, "{}={} ",
             tal.name(), tal.payload.vrps().locally_filtered
-        ).unwrap();
+        );
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // duplicate-vrps-per-tal
-    write!(res, "duplicate-vrps-per-tal: ").unwrap();
+    write!(res, "duplicate-vrps-per-tal: ");
     for tal in &metrics.tals {
         write!(
             res, "{}={} ", tal.name(), tal.payload.vrps().duplicate
-        ).unwrap();
+        );
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // locally-added-vrps
     writeln!(
         res, "locally-added-vrps: {}", metrics.local.vrps().contributed
-    ).unwrap();
+    );
 
     // final-vrps
     writeln!(res,
         "final-vrps: {}",
         metrics.payload.vrps().contributed
-    ).unwrap();
+    );
 
     // final-vrps-per-tal
-    write!(res, "final-vrps-per-tal: ").unwrap();
+    write!(res, "final-vrps-per-tal: ");
     for tal in &metrics.tals {
         write!(
             res, "{}={} ", tal.name(), tal.payload.vrps().contributed
-        ).unwrap();
+        );
     }
-    writeln!(res).unwrap();
+    writeln!(res);
 
     // stale-count
     writeln!(
         res, "stale-count: {}", metrics.publication.stale_objects()
-    ).unwrap();
+    );
 
     // rsync_status
-    writeln!(res, "rsync-durations:").unwrap();
+    writeln!(res, "rsync-durations:");
     for metrics in &metrics.rsync {
         write!(
             res,
@@ -200,22 +200,22 @@ async fn handle_status(
                 Ok(status) => status.code().unwrap_or(-1),
                 Err(_) => -1
             }
-        ).unwrap();
+        );
         if let Ok(duration) = metrics.duration {
             writeln!(
                 res,
                 ", duration={:.3}s",
                 duration.as_secs() as f64
                 + f64::from(duration.subsec_millis()) / 1000.
-            ).unwrap();
+            );
         }
         else {
-            writeln!(res).unwrap()
+            writeln!(res)
         }
     }
 
     // rrdp_status
-    writeln!(res, "rrdp-durations:").unwrap();
+    writeln!(res, "rrdp-durations:");
     for metrics in &metrics.rrdp {
         write!(
             res,
@@ -226,19 +226,19 @@ async fn handle_status(
             metrics.payload_status.map(|status| {
                 status.into_i16()
             }).unwrap_or(0),
-        ).unwrap();
+        );
         if let Ok(duration) = metrics.duration {
             write!(
                 res,
                 ", duration={:.3}s",
                 duration.as_secs_f64()
                 + f64::from(duration.subsec_millis()) / 1000.
-            ).unwrap();
+            );
         }
         if let Some(serial) = metrics.serial {
-            write!(res, ", serial={}", serial).unwrap()
+            write!(res, ", serial={}", serial)
         }
-        writeln!(res).unwrap()
+        writeln!(res)
     }
 
     let detailed_rtr = rtr_metrics.detailed();
@@ -248,16 +248,16 @@ async fn handle_status(
     writeln!(res,
         "rtr-connections: {} current",
         rtr_metrics.current_connections(),
-    ).unwrap();
+    );
     writeln!(res,
         "rtr-data: {} bytes sent, {} bytes received",
         rtr_metrics.bytes_written(),
         rtr_metrics.bytes_read()
-    ).unwrap();
+    );
 
     if detailed_rtr {
         // rtr-clients
-        writeln!(res, "rtr-clients:").unwrap();
+        writeln!(res, "rtr-clients:");
         rtr_metrics.fold_clients(
             // connections, serial, update, read, written
             (0, None, None, 0, 0),
@@ -283,12 +283,12 @@ async fn handle_status(
                 data.4 += client.bytes_written();
             }
         ).for_each(|(addr, (conns, serial, update, read, written))| {
-            write!(res, "    {}: connections={}, ", addr, conns).unwrap();
+            write!(res, "    {}: connections={}, ", addr, conns);
             if let Some(serial) = serial {
-                write!(res, "serial={}, ", serial).unwrap();
+                write!(res, "serial={}, ", serial);
             }
             else {
-                write!(res, "serial=N/A, ").unwrap();
+                write!(res, "serial=N/A, ");
             }
             if let Some(update) = update {
                 let update = Utc::now() - update;
@@ -296,12 +296,12 @@ async fn handle_status(
                     res,
                     "updated-ago={}.{:03}s, ",
                     update.num_seconds(), update.num_milliseconds() % 1000
-                ).unwrap();
+                );
             }
             else {
-                write!(res, "updated=N/A, ").unwrap();
+                write!(res, "updated=N/A, ");
             }
-            writeln!(res, "read={}, written={}", read, written).unwrap();
+            writeln!(res, "read={}, written={}", read, written);
         });
     }
 
@@ -310,16 +310,16 @@ async fn handle_status(
         "http-connections: {} current, {} total",
         server_metrics.conn_open() - server_metrics.conn_close(),
         server_metrics.conn_open()
-    ).unwrap();
+    );
     writeln!(res,
         "http-data: {} bytes sent, {} bytes received",
         server_metrics.bytes_written(),
         server_metrics.bytes_read()
-    ).unwrap();
+    );
     writeln!(res,
         "http-requests: {} ",
         server_metrics.requests()
-    ).unwrap();
+    );
 
     ResponseBuilder::ok().content_type(ContentType::TEXT).body(res)
 }

--- a/src/utils/fmt.rs
+++ b/src/utils/fmt.rs
@@ -1,0 +1,27 @@
+//! Tools for formatting.
+
+use std::fmt;
+
+//------------ WriteOrPanic --------------------------------------------------
+
+/// A target for writing formatted data into without error.
+///
+/// This provides a method `write_fmt` for use with the `write!` macro and
+/// friends that does not return a result. Rather, it panics if an error
+/// occurs.
+pub trait WriteOrPanic {
+    fn write_fmt(&mut self, args: fmt::Arguments);
+}
+
+impl WriteOrPanic for Vec<u8> {
+    fn write_fmt(&mut self, args: fmt::Arguments) {
+        std::io::Write::write_fmt(self, args).expect("formatting failed");
+    }
+}
+
+impl WriteOrPanic for String {
+    fn write_fmt(&mut self, args: fmt::Arguments) {
+        std::fmt::Write::write_fmt(self, args).expect("formatting failed");
+    }
+}
+

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod binio;
 pub mod date;
 pub mod dump;
 pub mod fatal;
+pub mod fmt;
 pub mod json;
 pub mod net;
 pub mod str;


### PR DESCRIPTION
This PR introduces a new utility trait `WriteOrPanic` which provides the method `write_fmt` that is used by `write!` macro and friends. But because it doesn’t return a result, it allows using the macro without unwrap or question mark.

The trait is implemented for `String` and `Vec<u8>` and used where needed.

Much like the trait’s name suggests, these implementations panic if formatting fails. That’s fine, as we only use with data that can be formatted and with types where writing itself can never fail (which I _think_ is the actual reason for returning a result). Also, we’ve been unwrapping for quite some time so, clearly, this is working.

This fixes #450.