### PR TITLE
RPM (un)install fixes for #773 and #774

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -654,3 +654,25 @@ jobs:
 
         echo -e "\nROUTINATOR RPKI CACHE DIR (first 20 lines of ls output only):"
         sg lxd -c "lxc exec testcon -- ls -ltR /var/lib/routinator/rpki-cache/ | head -n 20"
+
+    - name: Test uninstall (without purge)
+      run: |
+        case ${OS_NAME} in
+          debian|ubuntu)
+            sg lxd -c "lxc exec testcon -- apt-get -y remove routinator"
+            ;;
+          centos)
+            sg lxd -c "lxc exec testcon -- yum remove routinator"
+            ;;
+        esac
+
+    - name: Test re-install
+      run: |
+        case ${OS_NAME} in
+          debian|ubuntu)
+            sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/${PKG_FILE}"
+            ;;
+          centos)
+            sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}"
+            ;;
+        esac

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -662,7 +662,9 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-get -y remove routinator"
             ;;
           centos)
-            sg lxd -c "lxc exec testcon -- yum remove -y routinator"
+            sg lxd -c "lxc exec testcon -- yum remove -y routinator" 2>&1 | tee remove.log
+            # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
+            grep -qE '(err|warn|fail)' remove.log && exit 1
             ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -343,7 +343,22 @@ jobs:
             mkdir -p target/rpm
             cp pkg/common/${SYSTEMD_SERVICE_UNIT_FILE} target/rpm/routinator.service
     
-            cargo generate-rpm --set-metadata "version=\"${PKG_ROUTINATOR_VER}\"" ${EXTRA_CARGO_GENERATE_RPM_ARGS}
+            # https://github.com/NLnetLabs/routinator/issues/773
+            # cargo-generate-rpm doesn't support setting scripts to files, and we can't refer to a file that we
+            # installed such as /usr/share/routinator/rpm/postuninst because 'yum remove' removes the file
+            # before it can be executed (hence post-uninstall rather than pre-uninstall...). So instead embed
+            # the entire uninstall script in the TOML settings using the cargo-generate-rpm --set-metadata (aka
+            # -s) command line argument.
+            POSTINST="post_install_script = \"\"\"$(cat pkg/rpm/postinst)\"\"\""
+            PREUNINST="pre_uninstall_script = \"\"\"$(cat pkg/rpm/preuninst)\"\"\""
+            POSTUNINST="post_uninstall_script = \"\"\"$(cat pkg/rpm/postuninst)\"\"\""
+
+            cargo generate-rpm \
+                -s "version=\"${PKG_ROUTINATOR_VER}\"" \
+                -s "$POSTINST" \
+                -s "$PREUNINST" \
+                -s "$POSTUNINST" \
+                ${EXTRA_CARGO_GENERATE_RPM_ARGS}
             ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -662,7 +662,7 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-get -y remove routinator"
             ;;
           centos)
-            sg lxd -c "lxc exec testcon -- yum remove routinator"
+            sg lxd -c "lxc exec testcon -- yum remove -y routinator"
             ;;
         esac
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -679,7 +679,7 @@ jobs:
           centos)
             sg lxd -c "lxc exec testcon -- yum remove -y routinator" 2>&1 | tee remove.log
             # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
-            grep -qE '(err|warn|fail)' remove.log && exit 1
+            ! grep -qE '(err|warn|fail)' remove.log
             ;;
         esac
 
@@ -692,6 +692,6 @@ jobs:
           centos)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}" 2>&1 | tee reinstall.log
             # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
-            grep -qE '(err|warn|fail)' reinstall.log && exit 1
+            ! grep -qE '(err|warn|fail)' reinstall.log
             ;;
         esac

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -690,6 +690,8 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/${PKG_FILE}"
             ;;
           centos)
-            sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}"
+            sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}" 2>&1 | tee reinstall.log
+            # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
+            grep -qE '(err|warn|fail)' reinstall.log && exit 1
             ;;
         esac

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,10 @@ assets = [
     { source = "pkg/rpm/preuninst", dest = "/usr/share/routinator/rpm/preuninst", mode = "755" },
     { source = "pkg/rpm/postuninst", dest = "/usr/share/routinator/rpm/postuninst", mode = "755" },
 ]
-post_install_script = "/usr/share/routinator/rpm/postinst $*"
-pre_uninstall_script = "/usr/share/routinator/rpm/preuninst $*"
-post_uninstall_script = "/usr/share/routinator/rpm/postuninst $*"
+# These get set using cargo-generate-rpm --set-metadata at package build time.
+#post_install_script = ...
+#pre_uninstall_script = ...
+#post_uninstall_script = 
 
 # ensure that the useradd and rsync tools are present by installing their respective packages
 [package.metadata.generate-rpm.requires]

--- a/pkg/rpm/postinst
+++ b/pkg/rpm/postinst
@@ -15,10 +15,13 @@ if [ $1 -eq 1 ] ; then
     R_HOME_DIR=/var/lib/routinator
     R_HOME_DIR_PERMS=700
 
-    # According to the CentOS 7 useradd man page:
-    # --user-group causes a group by the same name as the user to be created
-    # --create-home should force creation of a home dir even for a system account.
-    useradd --home-dir ${R_HOME_DIR} --system --create-home --user-group ${R_USER}
+    # https://github.com/NLnetLabs/routinator/issues/774
+    if ! id ${R_USER} > /dev/null 2>&1; then
+        # According to the CentOS 7 useradd man page:
+        # --user-group causes a group by the same name as the user to be created
+        # --create-home should force creation of a home dir even for a system account.
+        useradd --home-dir ${R_HOME_DIR} --system --create-home --user-group ${R_USER}
+    fi
 
     # Ensure that the home directory has the correct ownership
     chown -R ${R_USER}:${R_GROUP} ${R_HOME_DIR}


### PR DESCRIPTION
This PR:
- Extends the packaging GitHub Actions workflow to attempt uninstallation and re-installation and to detect any occurrences of strings in the output of the install and uninstall processes that contain "err"(or), "warn"(ing) or "fail".
- Embeds RPM scriptlets in the RPM package directly so that on uninstall the script commands are available to run whereas previously it attempted to run a script stored on disk which had already been removed (#773).
- Doesn't try and create the `routinator` user on installation if the user already exists, which should be the case if Routinator was previously installed and uninstalled (as it is considered best practice to leave a package specific user account behind when uninstalling the package in case there are still files owned by that user) (#774).

The changes can be seen working in [this packaging workflow run](https://github.com/NLnetLabs/routinator/actions/runs/2921327622).