### PR TITLE
Do not exit on malformed RRDP Base 64 data.

### DIFF
--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -986,18 +986,18 @@ impl<'a> ProcessSnapshot for SnapshotUpdate<'a> {
         data: &mut rrdp::ObjectReader,
     ) -> Result<(), Self::Err> {
         let path = self.repository.tmp_object_path(&uri);
-        let mut data = MaxSizeRead::new(data, self.collector.max_object_size);
-        if RepositoryObject::create(&path, &mut data).is_err() {
-            if data.was_triggered() {
-                Err(SnapshotError::LargeObject(uri))
+        let mut data = MaxSizeRead::new(
+            data, &uri, self.collector.max_object_size
+        );
+        RepositoryObject::create(&path, &mut data).map_err(|io_err| {
+            match data.take_err() {
+                Some(data_err) => data_err.into(),
+                None => {
+                    error!("{}", io_err);
+                    SnapshotError::Fatal
+                }
             }
-            else {
-                Err(SnapshotError::Fatal)
-            }
-        }
-        else {
-            Ok(())
-        }
+        })
     }
 }
 
@@ -1227,16 +1227,19 @@ impl<'a> ProcessDelta for DeltaUpdate<'a> {
         data: &mut rrdp::ObjectReader<'_>
     ) -> Result<(), Self::Err> {
         self.check_hash(&uri, hash)?;
-        let mut data = MaxSizeRead::new(data, self.collector.max_object_size);
+        let mut data = MaxSizeRead::new(
+            data, &uri, self.collector.max_object_size
+        );
         let path = self.repository.tmp_object_path(&uri);
-        if RepositoryObject::create(&path, &mut data).is_err() {
-            if data.was_triggered() {
-                return Err(DeltaError::LargeObject(uri))
+        RepositoryObject::create(&path, &mut data).map_err(|io_err| {
+            match data.take_err() {
+                Some(data_err) => data_err.into(),
+                None => {
+                    error!("{}", io_err);
+                    DeltaError::Fatal
+                }
             }
-            else {
-                return Err(DeltaError::Fatal)
-            }
-        }
+        })?;
         if !self.publish.insert(uri.clone()) {
             return Err(DeltaError::ObjectRepeated { uri })
         }
@@ -1949,32 +1952,46 @@ impl RepositoryObject {
     }
 
     /// Writes a new object using everything from reader.
+    ///
+    /// This function returns an `io::Error` since the caller needs to be
+    /// able to suppress any error resulting from reading from `data` as
+    /// these are not in fact fatal. Any errors occurring while trying to
+    /// open the file and actually writing to it are still fatal. The
+    /// distinction is made by the caller by keeping track of what `data`
+    /// does.
     pub fn create(
         path: &Path, data: &mut impl io::Read
-    ) -> Result<(), Failed> {
+    ) -> Result<(), io::Error> {
         if let Some(parent) = path.parent() {
             if let Err(err) = fs::create_dir_all(parent) {
-                error!(
-                    "Fatal: failed to create directory {}: {}.",
-                    parent.display(), err
-                );
-                return Err(Failed)
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "Fatal: failed to create directory {}: {}.",
+                        parent.display(), err
+                    )
+                ))
             }
         }
         let mut target = match File::create(&path) {
             Ok(target) => target,
             Err(err) => {
-                error!(
-                    "Fatal: failed to open file {}: {}", path.display(), err
-                );
-                return Err(Failed)
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "Fatal: failed to open file {}: {}",
+                        path.display(), err
+                    )
+                ))
             }
         };
         Self::_create(data, &mut target).map_err(|err| {
-            error!(
-                "Fatal: failed to write file {}: {}", path.display(), err
-            );
-            Failed
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "Fatal: failed to write file {}: {}", path.display(), err
+                )
+            )
         })
     }
 
@@ -2105,32 +2122,43 @@ impl<R: io::Read> io::Read for HashRead<R> {
 //------------ MaxSizeRead ---------------------------------------------------
 
 /// A reader that reads until a certain limit is exceeded.
-struct MaxSizeRead<R> {
+struct MaxSizeRead<'a, R> {
     /// The wrapped reader.
     reader: R,
+
+    /// The URI of the object we are reading.
+    uri: &'a uri::Rsync,
 
     /// The number of bytes left to read.
     ///
     /// If this is `None` we are allowed to read an unlimited amount.
     left: Option<u64>,
 
-    /// Did we trigger?
-    triggered: bool,
+    /// The last error that happend.
+    err: Option<MaxSizeReadError>,
 }
 
-impl<R> MaxSizeRead<R> {
-    pub fn new(reader: R, max_size: Option<u64>) -> Self {
-        MaxSizeRead { reader, left: max_size, triggered: false }
+impl<'a, R> MaxSizeRead<'a, R> {
+    pub fn new(reader: R, uri: &'a uri::Rsync, max_size: Option<u64>) -> Self {
+        MaxSizeRead { reader, uri, left: max_size, err: None }
     }
 
-    pub fn was_triggered(&self) -> bool {
-        self.triggered
+    pub fn take_err(&mut self) -> Option<MaxSizeReadError> {
+        self.err.take()
     }
 }
 
-impl<R: io::Read> io::Read for MaxSizeRead<R> {
+impl<'a, R: io::Read> io::Read for MaxSizeRead<'a, R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
-        let res = self.reader.read(buf)?;
+        let res = match self.reader.read(buf) {
+            Ok(res) => res,
+            Err(err) => {
+                self.err = Some(MaxSizeReadError::Read(err));
+                return Err(io::Error::new(
+                    io::ErrorKind::Other, "reading data failed",
+                ))
+            }
+        };
         if let Some(left) = self.left {
             let res64 = match u64::try_from(res) {
                 Ok(res) => res,
@@ -2138,7 +2166,9 @@ impl<R: io::Read> io::Read for MaxSizeRead<R> {
                     // If the usize doesn’t fit into a u64, things are
                     // definitely way too big.
                     self.left = Some(0);
-                    self.triggered = true;
+                    self.err = Some(
+                        MaxSizeReadError::LargeObject(self.uri.clone())
+                    );
                     return Err(io::Error::new(
                         io::ErrorKind::Other, "size limit exceeded"
                     ))
@@ -2146,7 +2176,9 @@ impl<R: io::Read> io::Read for MaxSizeRead<R> {
             };
             if res64 > left {
                 self.left = Some(0);
-                self.triggered = true;
+                self.err = Some(
+                    MaxSizeReadError::LargeObject(self.uri.clone())
+                );
                 Err(io::Error::new(
                     io::ErrorKind::Other, "size limit exceeded")
                 )
@@ -2252,6 +2284,20 @@ impl From<StatusCode> for HttpStatus {
 
 //============ Errors ========================================================
 
+//------------ MaxSizeReadError ----------------------------------------------
+
+/// An error happened while `MaxSizeRead` read data.
+///
+/// This covers both the case where the maximum allowed file size was
+/// exhausted as well as where reading data failed. Neither of them is fatal,
+/// so we need to process them.
+#[derive(Debug)]
+enum MaxSizeReadError {
+    LargeObject(uri::Rsync),
+    Read(io::Error),
+}
+
+
 //------------ SnapshotError -------------------------------------------------
 
 /// An error happened during snapshot processing.
@@ -2291,6 +2337,19 @@ impl From<rrdp::ProcessError> for SnapshotError {
 impl From<io::Error> for SnapshotError {
     fn from(err: io::Error) -> Self {
         SnapshotError::Rrdp(err.into())
+    }
+}
+
+impl From<MaxSizeReadError> for SnapshotError {
+    fn from(err: MaxSizeReadError) -> Self {
+        match err {
+            MaxSizeReadError::LargeObject(uri) => {
+                SnapshotError::LargeObject(uri)
+            }
+            MaxSizeReadError::Read(err) => {
+                SnapshotError::Rrdp(err.into())
+            }
+        }
     }
 }
 
@@ -2386,6 +2445,19 @@ impl From<rrdp::ProcessError> for DeltaError {
 impl From<io::Error> for DeltaError {
     fn from(err: io::Error) -> Self {
         DeltaError::Rrdp(err.into())
+    }
+}
+
+impl From<MaxSizeReadError> for DeltaError {
+    fn from(err: MaxSizeReadError) -> Self {
+        match err {
+            MaxSizeReadError::LargeObject(uri) => {
+                DeltaError::LargeObject(uri)
+            }
+            MaxSizeReadError::Read(err) => {
+                DeltaError::Rrdp(err.into())
+            }
+        }
     }
 }
 

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -986,7 +986,7 @@ impl<'a> ProcessSnapshot for SnapshotUpdate<'a> {
         data: &mut rrdp::ObjectReader,
     ) -> Result<(), Self::Err> {
         let path = self.repository.tmp_object_path(&uri);
-        let mut data = MaxSizeRead::new(
+        let mut data = RrdpDataRead::new(
             data, &uri, self.collector.max_object_size
         );
         RepositoryObject::create(&path, &mut data).map_err(|io_err| {
@@ -1227,7 +1227,7 @@ impl<'a> ProcessDelta for DeltaUpdate<'a> {
         data: &mut rrdp::ObjectReader<'_>
     ) -> Result<(), Self::Err> {
         self.check_hash(&uri, hash)?;
-        let mut data = MaxSizeRead::new(
+        let mut data = RrdpDataRead::new(
             data, &uri, self.collector.max_object_size
         );
         let path = self.repository.tmp_object_path(&uri);
@@ -2142,7 +2142,7 @@ struct RrdpDataRead<'a, R> {
     err: Option<RrdpDataReadError>,
 }
 
-impl<'a, R> MaxSizeRead<'a, R> {
+impl<'a, R> RrdpDataRead<'a, R> {
     /// Creates a new read from necessary information.
     ///
     /// The returned value will wrap `reader`. The `uri` should be the rsync
@@ -2151,7 +2151,7 @@ impl<'a, R> MaxSizeRead<'a, R> {
     /// will be limited to that value in bytes. Larger objects lead to an
     /// error.
     pub fn new(reader: R, uri: &'a uri::Rsync, max_size: Option<u64>) -> Self {
-        MaxSizeRead { reader, uri, left: max_size, err: None }
+        RrdpDataRead { reader, uri, left: max_size, err: None }
     }
 
     /// Returns a stored error if available.
@@ -2166,7 +2166,7 @@ impl<'a, R> MaxSizeRead<'a, R> {
     }
 }
 
-impl<'a, R: io::Read> io::Read for MaxSizeRead<'a, R> {
+impl<'a, R: io::Read> io::Read for RrdpDataRead<'a, R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         let res = match self.reader.read(buf) {
             Ok(res) => res,


### PR DESCRIPTION
This PR fixes an oversight in error handling in the RRDP collector that cause Routinator to exit if it encountered malformed Base 64 in RRDP snapshot and delta files.

It does this by re-appropriating the existing exception in MaxSizeRead to not exit when data was too large and extending it to all other read errors happening. This is fine because the encoded data is currently collected into a vec before any of this happens, so reading cannot fail other than from malformed Base 64 data.

This PR can be tested by using the TAL currently available at https://routinator.do.nlnetlabs.nl/test/rrdp/ta.tal.

This is the same PR as #781 accept applied to the main branch. It fixes CVE-2022-3029.
