### PR TITLE
Add an rrdp-fallback option to configure fallback to rsync.

### DIFF
--- a/doc/manual/source/data-processing.rst
+++ b/doc/manual/source/data-processing.rst
@@ -6,8 +6,9 @@ Fetching
 
 There are two protocols in use to transport RPKI data: rsync and the :term:`RPKI
 Repository Delta Protocol (RRDP)`, which relies on HTTPS. RRDP was designed to
-be the successor to rsync in the RPKI. As almost all RPKI repositories currently
-support both protocols, Routinator will prefer RRDP if available. 
+be the successor to rsync in the RPKI. As all RPKI repositories currently
+advertise support for both protocols, Routinator will prefer RRDP if 
+available. 
 
 In the RPKI, the certificate hierarchy follows the same structure as the
 Internet number resource allocation hierarchy. Routinator starts traversing the
@@ -35,16 +36,29 @@ RRDP Fallback
 """""""""""""
 
 If an RRDP endpoint is unavailable but it has worked in the past, Routinator
-will assume this is a transient problem. It will retry using RRDP for up to 60
-minutes since the last successful update, during which it will rely on the
-locally cached data for this repository. After this time, Routinator will try to
-use rsync to fetch the data instead. To spread out load on the rsync server, the
-exact moment fallback happens is picked randomly between the refresh time and
-the :option:`--rrdp-fallback-time` value. If rsync communication is
-unsuccessful too, the local cache is used until the objects go stale and
-ultimately expire. 
+will assume this is a transient problem. What action is taken is determined
+by the :option:`--rrdp-fallback` option. The default policy is *stale*. This
+means Routinator will retry using RRDP for up to 60 minutes since the last
+successful update, during which it will rely on the locally cached data for
+this repository. After this time, Routinator will try to use rsync to fetch
+the data instead. To spread out load on the rsync server, the exact moment
+fallback happens is picked randomly between the refresh time and the
+:option:`--rrdp-fallback-time` value. If rsync communication is unsuccessful
+too, the local cache is used until the objects go stale and ultimately
+expire. 
+
+Another policy for :option:`--rrdp-fallback` is *never*. This means that
+rsync is never tried for a CA that advertises the availability of RRDP.
+Lastly, the policy *new* means that rsync is tried if an update via RRDP
+fails and there is no local copy of the RRDP repository at all. In other
+words, an update via RRDP has never succeeded for the repository. Choosing
+this policy allows a repository operator some leeway when first enabling RRDP
+support.
 
 .. versionadded:: 0.9.0
+
+.. versionchanged:: 0.12.0
+   The :option:`--rrdp-fallback` option
 
 Update Interval
 """""""""""""""

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -207,6 +207,31 @@ The available options are:
       If this option is present, RRDP is disabled and only rsync will be
       used.
 
+.. option:: --rrdp-fallback=policy
+
+      Defines the circumstance when access via rsync should be tried for a
+      CA that announces it can be updated via RRDP. In general, access via
+      RRDP is less resource intensive and more secure than rsync and will
+      therefore be preferred. This option specifies what to do when access
+      to an RRDP repository fails.
+
+      The policy ``never`` means that rsync is never tried for a CA that
+      announces RRDP.
+
+      The policy ``stale`` means that rsync is tried if an update via RRDP
+      fails and there is no current local copy of the RRDP repository. A
+      local copy is considered current if it was last updated within a
+      time span chosen on a per-repository basis between the
+      :option:`--refresh` time and :option:`--rrdp-fallback-time`.
+
+      The policy ``new`` means that rsync is tried if an update via RRDP
+      fails and there is no local copy of the RRDP repository at all. In
+      other words, an update via RRDP has never succeeded for the repository.
+      Choosing this policy allows a repository operator some leeway when
+      first enabling RRDP support.
+
+      The default policy if this option is not given is ``stale``.
+
 .. option:: --rrdp-fallback-time=seconds
 
       Sets the maximum time in seconds since a last successful update of an
@@ -1048,6 +1073,11 @@ All values can be overridden via the command line options.
       disable-rrdp
             A boolean value that, if present and true, turns off the use of
             RRDP.
+
+      rrdp-fallback
+            A string value specifying the circumstances under which an update
+            via rsync is tried if an update via RRDP fails. See
+            :option:`--rrdp-fallback` for details on the available policies.
 
       rrdp-fallback-time
             An integer value specifying the maximum number of seconds since a

--- a/src/collector/base.rs
+++ b/src/collector/base.rs
@@ -216,9 +216,9 @@ impl<'a> Run<'a> {
                         // Update failed and data is now stale. Only
                         // "stale" wants us to fall back, "never" and "new"
                         // want us to fail.
-                        if matches!(
+                        if !matches!(
                             self.collector.rrdp_fallback,
-                            FallbackPolicy::Never | FallbackPolicy::New
+                            FallbackPolicy::Stale
                         ) {
                             return Ok(None)
                         }

--- a/src/collector/base.rs
+++ b/src/collector/base.rs
@@ -6,7 +6,7 @@ use std::{fs, io};
 use std::collections::HashSet;
 use std::path::Path;
 use bytes::Bytes;
-use log::error;
+use log::{error, info};
 use rpki::repository::tal::TalUri;
 use rpki::uri;
 use crate::config::{Config, FallbackPolicy};
@@ -232,6 +232,10 @@ impl<'a> Run<'a> {
                         // Hurrah!
                         return Ok(Some(Repository::rrdp(repo)))
                     }
+                }
+
+                if self.rsync.is_some() {
+                    info!("RRDP {}: Falling back to rsync.", rrdp_uri);
                 }
             }
         }

--- a/src/collector/base.rs
+++ b/src/collector/base.rs
@@ -129,7 +129,7 @@ impl Collector {
 /// [crossbeam’s](https://github.com/crossbeam-rs/crossbeam) scoped threads.
 #[derive(Debug)]
 pub struct Run<'a> {
-    /// The collector we are base off of.
+    /// The collector we are based off of.
     collector: &'a Collector,
 
     /// The runner for rsync if this transport is enabled.

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -285,9 +285,6 @@ pub struct Run<'a> {
     collector: &'a Collector,
 
     /// A set of the repositories we have updated already.
-    ///
-    /// If there is some value for a repository, it is available and current.
-    /// If there is a `None`, the repository is not available or outdated.
     updated: RwLock<HashMap<uri::Https, LoadResult>>,
 
     /// The modules that are currently being updated.
@@ -574,9 +571,6 @@ impl Repository {
 ///
 impl Repository {
     /// Creates the repository by trying to update it.
-    ///
-    /// Returns `Ok(None)` if the update fails and there is no already
-    /// downloaded version that hasn’t expired yet.
     fn try_update(
         run: &Run, rpki_notify: uri::Https
     ) -> Result<LoadResult, Failed> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,9 @@ const DEFAULT_HISTORY_SIZE: usize = 10;
 /// The default for the RRDP timeout.
 const DEFAULT_RRDP_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// The default for the RRDP fallback policy.
+const DEFAULT_RRDP_FALLBACK: FallbackPolicy = FallbackPolicy::Stale;
+
 /// The default for the RRDP fallback time.
 const DEFAULT_RRDP_FALLBACK_TIME: Duration = Duration::from_secs(3600);
 
@@ -181,6 +184,9 @@ pub struct Config {
 
     /// Whether to disable RRDP.
     pub disable_rrdp: bool,
+
+    /// The policy for when to fall back from RRDP to rsync.
+    pub rrdp_fallback: FallbackPolicy,
 
     /// Time since last update of an RRDP repository before fallback to rsync.
     pub rrdp_fallback_time: Duration,
@@ -462,6 +468,11 @@ impl Config {
         // disable_rrdp
         if args.disable_rrdp {
             self.disable_rrdp = true
+        }
+
+        // rrdp_fallback
+        if let Some(value) = args.rrdp_fallback {
+            self.rrdp_fallback = value
         }
 
         // rrdp_fallback_time
@@ -816,6 +827,10 @@ impl Config {
                 )
             },
             disable_rrdp: file.take_bool("disable-rrdp")?.unwrap_or(false),
+            rrdp_fallback: {
+                file.take_from_str("rrdp-fallback")?
+                    .unwrap_or(DEFAULT_RRDP_FALLBACK)
+            },
             rrdp_fallback_time: {
                 file.take_u64("rrdp-fallback-time")?
                 .map(Duration::from_secs)
@@ -1032,6 +1047,7 @@ impl Config {
             rsync_args: None,
             rsync_timeout: Duration::from_secs(DEFAULT_RSYNC_TIMEOUT),
             disable_rrdp: false,
+            rrdp_fallback: DEFAULT_RRDP_FALLBACK,
             rrdp_fallback_time: DEFAULT_RRDP_FALLBACK_TIME,
             rrdp_max_delta_count: DEFAULT_RRDP_MAX_DELTA_COUNT,
             rrdp_timeout: Some(DEFAULT_RRDP_TIMEOUT), 
@@ -1181,6 +1197,10 @@ impl Config {
             (self.rsync_timeout.as_secs() as i64).into()
         );
         res.insert("disable-rrdp".into(), self.disable_rrdp.into());
+        res.insert(
+            "rrdp-fallback".into(),
+            self.rrdp_fallback.to_string().into(),
+        );
         res.insert(
             "rrdp-fallback-time".into(),
             (self.rrdp_fallback_time.as_secs() as i64).into()
@@ -1520,6 +1540,53 @@ impl fmt::Display for FilterPolicy {
 }
 
 
+//------------ FallbackPolicy ------------------------------------------------
+
+/// The policy for fallback to rsync.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FallbackPolicy {
+    /// Never fall back to rsync.
+    ///
+    /// If a CA promises to be available via RRDP, fail if that doesn’t work.
+    Never,
+
+    /// Fall back if access fails and a local copy is too old.
+    ///
+    /// If access to a CA via RRDP doesn’t work, use an existing local copy
+    /// if it is available and not too old.
+    Stale,
+
+    /// Only fall back for new repositories.
+    ///
+    /// If access to a CA via RRDP doesn’t work, fall back to rsync if RRDP
+    /// has never worked before.
+    New,
+}
+
+impl FromStr for FallbackPolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "never" => Ok(FallbackPolicy::Never),
+            "stale" => Ok(FallbackPolicy::Stale),
+            "new" => Ok(FallbackPolicy::New),
+            _ => Err(format!("invalid policy '{}'", s))
+        }
+    }
+}
+
+impl fmt::Display for FallbackPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match *self {
+            FallbackPolicy::Never => "never",
+            FallbackPolicy::Stale => "stale",
+            FallbackPolicy::New => "new",
+        })
+    }
+}
+
+
 //------------ GlobalArgs ----------------------------------------------------
 
 /// The global command line arguments.
@@ -1588,6 +1655,10 @@ struct GlobalArgs {
     /// Maximum number of RRDP deltas before using snapshot
     #[arg(long, value_name = "COUNT")]
     rrdp_max_delta_count: Option<usize>,
+
+    /// When to fall back to rsync if RRDP fails
+    #[arg(long, value_name = "POLICY")]
+    rrdp_fallback: Option<FallbackPolicy>,
 
     /// Maximum time since last update before fallback to rsync
     #[arg(long, value_name = "SECONDS")]


### PR DESCRIPTION
This PR introduces a new command line and config option `rrdp-fallback` that decides when to fall back to rsync for a failed RRDP update. The available policies are `never` for never, `stale` for fallback after a certain time of falling the RRDP update, and `new` for fallback when RRDP has never succeeded. The default is `stale` which reflects the current behavior.

Fixes #730.