### PR TITLE
Set TCP keepalive for the RRDP HTTP client.

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -261,6 +261,12 @@ The available options are:
       Sets the timeout in seconds for RRDP connect requests. If omitted, the
       general timeout will be used.
 
+.. option:: --rrdp-tcp-keepalive=seconds
+
+      Sets the value of the TCP keepalive duration in seconds for RRDP
+      connections. The default if this option is omitted is 60 seconds. Set
+      the option to 0 to disable the use of TCP keepalives.
+
 .. option:: --rrdp-local-addr=addr
 
       If present, sets the local address that the RRDP client should bind to
@@ -1103,6 +1109,12 @@ All values can be overridden via the command line options.
       rrdp-connect-timeout
             An integer value that, if present, sets a separate timeout in
             seconds for RRDP connect requests only.
+
+      rrdp-tcp-keepalive
+            An integer value that provides the duration in seconds for the
+            TCP keepalive option on RRDP connections. If the value is missing,
+            a duration of 60 seconds is used. Set the value to 0 to disable
+            the use of TCP keepalive for RRDP connections.
 
       rrdp-local-addr
             A string value that provides the local address to be used by RRDP

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -1309,6 +1309,7 @@ impl HttpClient {
 
         let mut builder = create_builder();
         builder = builder.user_agent(&config.rrdp_user_agent);
+        builder = builder.tcp_keepalive(config.rrdp_tcp_keepalive);
         builder = builder.timeout(None); // Set per request.
         if let Some(timeout) = config.rrdp_connect_timeout {
             builder = builder.connect_timeout(timeout);


### PR DESCRIPTION
This PR enables TCP keepalives for RRDP connections. The duration can be set via the new `rrdp-tcp-keepalive` command line and config file option. Setting this value to 0 disables TCP keepalives.

Fixes #751.