### PR TITLE
Deal more graciously with broken files in the store.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use bytes::Bytes;
 use crossbeam_queue::{ArrayQueue, SegQueue};
 use crossbeam_utils::thread;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use rpki::crypto::keys::KeyIdentifier;
 use rpki::repository::cert::{Cert, KeyUsage, ResourceCert};
 use rpki::repository::crl::Crl;
@@ -1015,6 +1015,11 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                         return Err(Failed)
                     }
                     else {
+                        info!(
+                            "Ignoring invalid stored publication point \
+                             at {}: {}",
+                            store.path().display(), err
+                        );
                         self.reject_point(metrics);
                         return Ok(Vec::new())
                     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -68,7 +68,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use rand::random;
 use rpki::crypto::digest::DigestAlgorithm;
 use rpki::repository::cert::Cert;
@@ -691,6 +691,10 @@ impl<'a> StoredPoint<'a> {
                     return Err(Failed)
                 }
                 else {
+                    info!(
+                        "Ignoring invalid stored publication point at {}: {}",
+                        path.display(), err
+                    );
                     None
                 }
             }


### PR DESCRIPTION
This PR changes the behavior of Routinator when files are encountered in the store that cannot be parsed (as opposed to reading failing for other reasons). Now Routinator will just assume that the publication point stored in that file doesn’t exist in the store and continue.

Fixes #770.