### PR TITLE
Don’t print error on EPIPE in vrps to stdout.

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -838,10 +838,16 @@ impl Vrps {
             }
         };
         if let Err(err) = res {
-            error!(
-                "Failed to output result: {}",
-                err
-            );
+            // Surpress an error message for broken pipe on stdout.
+            if 
+                self.output.is_some() ||
+                err.kind() != io::ErrorKind::BrokenPipe
+            {
+                error!(
+                    "Failed to output result: {}",
+                    err
+                );
+            }
             Err(ExitError::Generic)
         }
         else if self.complete && !metrics.rsync_complete() {


### PR DESCRIPTION
This PR suppresses the error message when the `vrps` command is outputting the data set to stdout and receives a broken pipe error.