### PR TITLE
Wrong HTTP port publish argument shown in Docker docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,12 +160,19 @@ RUN mkdir -p /home/${RUN_USER}/.rpki-cache/repository && \
 USER $RUN_USER_UID
 
 # Hint to operators the TCP port that the application in this image listens on
-# (by default).
+# (by default). Routinator documentation and DEB/RPM packages configure
+# Routinator to listen for HTTP requests on port 8323. For consistency we do
+# the same, but for backward compatibility with earlier versions of this file
+# we still also listen for HTTP requests on port 9556, the port number
+# allocated by the Prometheus project [1] for Routinator metric publication.
+#
+# [1]: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 EXPOSE 3323/tcp
+EXPOSE 8323/tcp
 EXPOSE 9556/tcp
 
 # Use Tini to ensure that our application responds to CTRL-C when run in the
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).
 ENTRYPOINT ["/sbin/tini", "--", "routinator"]
-CMD ["server", "--rtr", "0.0.0.0:3323", "--http", "0.0.0.0:9556"]
+CMD ["server", "--rtr", "0.0.0.0:3323", "--http", "0.0.0.0:8323", "--http", "0.0.0.0:9556"]

--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -247,7 +247,16 @@ to get started.
               -p 3323:3323 \
               -p 8323:8323 \
               nlnetlabs/routinator
-               
+
+       .. tip:: If no arguments are supplied the Routinator Docker image
+                configures Routinator to run in :subcmd:`server` mode, with
+                :option:`--rtr` 3323 and :option:`--http` 8323.
+
+                For backward compatibility with earlier releases it also
+                configures Routinator with :option:`--http` 9556, the port
+                number `allocated by the Prometheus project <https://github.com/prometheus/prometheus/wiki/Default-port-allocations>`_
+                for Routinator metric publication.
+
        The Routinator container is known to run successfully run under 
        `gVisor <https://gvisor.dev/>`_ for additional isolation.
 


### PR DESCRIPTION
This PR builds on the Docker documentation changes made in PR #796 and aims to resolve issue #808.

The rendered changes can be seen here: https://routinator--809.org.readthedocs.build/en/809/installation.html

As port 8323 is used throughout the documentation and by both the DEB and RPM packages changing that would be very impacting. Changing from port 9956 to port 8323 in the Docker image would also be impacting. Thus the change made is to add HTTP listen port 8323 as well as HTTP listen port 9556 to the Docker image, and clarify the documentation.