### PR TITLE
Allow limiting the prefix length of included VRPs.

### DIFF
--- a/doc/manual/source/local-exceptions.rst
+++ b/doc/manual/source/local-exceptions.rst
@@ -75,3 +75,33 @@ run, so you can simply update the file whenever your exceptions change.
 In the metrics Routinator provides, there are counters indicating how many
 VRPs are added and excluded from the final data set as a result of your
 exceptions. 
+
+Limiting Prefix Length
+----------------------
+
+It's possible to set the maximum length of IPv4 and IPv6 prefixes that will
+be included in the VRP data set. You can set this with the
+:option:`--limit-v4-len` and :option:`--limit-v6-len` options, respectively.
+
+To illustrate this option we'll use an extreme example:
+
+.. code-block:: text
+
+    routinator --limit-v4-len=8 --limit-v6-len=19 vrps
+
+Now, VRPs for prefixes with a longer prefix length than /8 IPv4 and /19 IPv6
+will be ignored:
+
+.. code-block:: text
+
+    ASN,IP Prefix,Max Length,Trust Anchor
+    AS6253,48.0.0.0/8,24,arin
+    AS31399,53.0.0.0/8,8,ripe
+    AS7922,73.0.0.0/8,8,arin
+    AS3320,2003::/19,19,ripe
+    AS5511,2a01:c000::/19,48,ripe
+
+Note that only the prefix length itself and not the maximum prefix length
+value of the ROA is considered.
+
+.. versionadded:: 0.12.0

--- a/doc/manual/source/local-exceptions.rst
+++ b/doc/manual/source/local-exceptions.rst
@@ -89,8 +89,8 @@ To illustrate this option we'll use an extreme example:
 
     routinator --limit-v4-len=8 --limit-v6-len=19 vrps
 
-Now, VRPs for prefixes with a longer prefix length than /8 IPv4 and /19 IPv6
-will be ignored:
+Now, all VRPs will be ignored that have a prefix with a length that is longer
+than /8 IPv4 and /19 IPv6:
 
 .. code-block:: text
 

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -166,6 +166,16 @@ The available options are:
       in the manifest. If the hash does not match, the CA and all its objects
       are still rejected.
 
+.. option:: --limit-v4-len=length, --limit-v6-len=length
+
+      If present, defines the maximum length of IPv4 prefixes or IPv6
+      prefixes, respectively, that will be included in the VRP data set. All
+      VRPs for prefixes with a longer prefix length will be ignored. Note that
+      only the prefix length itself, not the max length is considered.
+
+      If either option is missing, VRPs for all prefixes of that particular
+      address family are included.
+
 .. option:: --allow-dubious-hosts
 
       As a precaution, Routinator will reject rsync and HTTPS URIs from RPKI
@@ -1042,6 +1052,16 @@ All values can be overridden via the command line options.
 
             accept
                   Quietly ignore the object and accept the issuing CA.
+
+      limit-v4-len
+            An integer value which, if present, limits the length of IPv4
+            prefixes for which VPRs are included in the data set to the given
+            value.
+
+      limit-v6-len
+            An integer value which, if present, limits the length of IPv6
+            prefixes for which VPRs are included in the data set to the given
+            value.
 
       allow-dubious-hosts
             A boolean value that, if present and true, disables Routinator's

--- a/src/config.rs
+++ b/src/config.rs
@@ -1672,7 +1672,7 @@ struct GlobalArgs {
     #[arg(
         long,
         value_name = "LENGTH",
-        value_parser = clap::value_parser!(u8).range(..32)
+        value_parser = clap::value_parser!(u8).range(..=32)
     )]
     limit_v4_len: Option<u8>,
 
@@ -1680,7 +1680,7 @@ struct GlobalArgs {
     #[arg(
         long,
         value_name = "LENGTH",
-        value_parser = clap::value_parser!(u8).range(..128)
+        value_parser = clap::value_parser!(u8).range(..=128)
     )]
     limit_v6_len: Option<u8>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,12 @@ pub struct Config {
     /// How to deal with unknown RPKI object types.
     pub unknown_objects: FilterPolicy,
 
+    /// The maximum length of IPv4 prefixes included in the VRP set.
+    pub limit_v4_len: Option<u8>,
+
+    /// The maximum length of IPv6 prefixes included in the VRP set.
+    pub limit_v6_len: Option<u8>,
+
     /// Allow dubious host names.
     pub allow_dubious_hosts: bool,
 
@@ -440,6 +446,16 @@ impl Config {
         // unknown_objects
         if let Some(value) = args.unknown_objects {
             self.unknown_objects = value
+        }
+
+        // limit_v4_len
+        if let Some(value) = args.limit_v4_len {
+            self.limit_v4_len = Some(value)
+        }
+
+        // limit_v6_len
+        if let Some(value) = args.limit_v6_len {
+            self.limit_v6_len = Some(value)
         }
 
         // allow_dubious_hosts
@@ -818,6 +834,8 @@ impl Config {
                 file.take_from_str("unknown-objects")?
                     .unwrap_or(DEFAULT_UNKNOWN_OBJECTS_POLICY)
             },
+            limit_v4_len: file.take_limited_u8("limit-v4-len", 32)?,
+            limit_v6_len: file.take_limited_u8("limit-v6-len", 128)?,
             allow_dubious_hosts:
                 file.take_bool("allow-dubious-hosts")?.unwrap_or(false),
             fresh: false,
@@ -1048,6 +1066,8 @@ impl Config {
             stale: DEFAULT_STALE_POLICY,
             unsafe_vrps: DEFAULT_UNSAFE_VRPS_POLICY,
             unknown_objects: DEFAULT_UNKNOWN_OBJECTS_POLICY,
+            limit_v4_len: None,
+            limit_v6_len: None,
             allow_dubious_hosts: false,
             fresh: false,
             disable_rsync: false,
@@ -1185,8 +1205,15 @@ impl Config {
             "unsafe-vrps".into(), format!("{}", self.unsafe_vrps).into()
         );
         res.insert(
-            "unknown-objects".into(), format!("{}", self.unknown_objects).into()
+            "unknown-objects".into(),
+            format!("{}", self.unknown_objects).into(),
         );
+        if let Some(value) = self.limit_v4_len {
+            res.insert("limit-v4-len".into(), value.into());
+        }
+        if let Some(value) = self.limit_v6_len {
+            res.insert("limit-v6-len".into(), value.into());
+        }
         res.insert(
             "allow-dubious-hosts".into(), self.allow_dubious_hosts.into()
         );
@@ -1641,6 +1668,22 @@ struct GlobalArgs {
     #[arg(long, value_name = "POLICY")]
     unknown_objects: Option<FilterPolicy>,
 
+    /// Maximum length of IPv4 prefixes included in output
+    #[arg(
+        long,
+        value_name = "LENGTH",
+        value_parser = clap::value_parser!(u8).range(..32)
+    )]
+    limit_v4_len: Option<u8>,
+
+    /// Maximum length of IP64 prefixes included in output
+    #[arg(
+        long,
+        value_name = "LENGTH",
+        value_parser = clap::value_parser!(u8).range(..128)
+    )]
+    limit_v6_len: Option<u8>,
+
     /// Allow dubious host names in rsync and HTTPS URIs
     #[arg(long)]
     allow_dubious_hosts: bool,
@@ -1930,6 +1973,40 @@ impl ConfigFile {
                     error!(
                         "Failed in config file {}: \
                          '{}' expected to be a boolean.",
+                        self.path.display(), key
+                    );
+                    Err(Failed)
+                }
+            }
+            None => Ok(None)
+        }
+    }
+
+    /// Takes a limited unsigned 8-bit integer value from the config file.
+    ///
+    /// The value is taken from the given `key`. Returns `Ok(None)` if there
+    /// is no such key. Returns an error if the key exists but the value
+    /// isn’t an integer, is larger than `limit` or is negative.
+    fn take_limited_u8(
+        &mut self, key: &str, limit: u8,
+    ) -> Result<Option<u8>, Failed> {
+        match self.content.remove(key) {
+            Some(value) => {
+                if let toml::Value::Integer(res) = value {
+                    if res < 0 || res > limit as i64 {
+                        error!(
+                            "Failed in config file {}: \
+                            '{}' expected integer between 0 and {}.",
+                            self.path.display(), key, limit,
+                        );
+                        return Err(Failed)
+                    }
+                    Ok(Some(res as u8))
+                }
+                else {
+                    error!(
+                        "Failed in config file {}: \
+                         '{}' expected to be an integer.",
                         self.path.display(), key
                     );
                     Err(Failed)

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -633,9 +633,7 @@ impl Server {
     ) -> Result<(), Failed> {
         info!("Starting a validation run.");
         history.mark_update_start();
-        let (report, metrics) = ValidationReport::process(
-            engine, config.unsafe_vrps.log(), config.enable_bgpsec
-        )?;
+        let (report, metrics) = ValidationReport::process(engine, config)?;
         let must_notify = history.update(
             report, &exceptions, metrics,
         );
@@ -804,9 +802,7 @@ impl Vrps {
         process.switch_logging(false, false)?;
         let exceptions = LocalExceptions::load(process.config(), true)?;
         let (report, mut metrics) = ValidationReport::process(
-            &engine,
-            process.config().unsafe_vrps.log(),
-            process.config().enable_bgpsec,
+            &engine, process.config(),
         )?;
         let vrps = PayloadSnapshot::from_report(
             report,
@@ -1059,9 +1055,7 @@ impl Validate {
         engine.ignite()?;
         process.switch_logging(false, false)?;
         let (report, mut metrics) = ValidationReport::process(
-            &engine,
-            process.config().unsafe_vrps.log(),
-            process.config().enable_bgpsec,
+            &engine, process.config(),
         )?;
         let snapshot = PayloadSnapshot::from_report(
             report,
@@ -1302,9 +1296,7 @@ impl Update {
         engine.ignite()?;
         process.switch_logging(false, false)?;
         let (_, metrics) = ValidationReport::process(
-            &engine,
-            process.config().unsafe_vrps.log(),
-            process.config().enable_bgpsec,
+            &engine, process.config(),
         )?;
         if self.complete && !metrics.rsync_complete() {
             Err(ExitError::IncompleteUpdate)


### PR DESCRIPTION
This PR adds two new command line and config file options, `limit-v4-len` and `limit-v6-len`, that allow limiting the prefix length of IPv4 or IPv6 prefixes, respectively, for which VRPs are to be included in the output data set. By default, all valid VRPs are included.

Fixes #234.