### PR TITLE
Document default Docker `server` subcmd and show how to listen on IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,12 +160,19 @@ RUN mkdir -p /home/${RUN_USER}/.rpki-cache/repository && \
 USER $RUN_USER_UID
 
 # Hint to operators the TCP port that the application in this image listens on
-# (by default).
+# (by default). Routinator documentation and DEB/RPM packages configure
+# Routinator to listen for HTTP requests on port 8323. For consistency we do
+# the same, but for backward compatibility with earlier versions of this file
+# we still also listen for HTTP requests on port 9556, the port number
+# allocated by the Prometheus project [1] for Routinator metric publication.
+#
+# [1]: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 EXPOSE 3323/tcp
+EXPOSE 8323/tcp
 EXPOSE 9556/tcp
 
 # Use Tini to ensure that our application responds to CTRL-C when run in the
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).
 ENTRYPOINT ["/sbin/tini", "--", "routinator"]
-CMD ["server", "--rtr", "0.0.0.0:3323", "--http", "0.0.0.0:9556"]
+CMD ["server", "--rtr", "0.0.0.0:3323", "--http", "0.0.0.0:8323", "--http", "0.0.0.0:9556"]

--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -247,7 +247,16 @@ to get started.
               -p 3323:3323 \
               -p 8323:8323 \
               nlnetlabs/routinator
-               
+
+       .. tip:: If no arguments are supplied the Routinator Docker image
+                configures Routinator to run in :subcmd:`server` mode, with
+                :option:`--rtr` 3323 and :option:`--http` 8323.
+
+                For backward compatibility with earlier releases it also
+                configures Routinator with :option:`--http` 9556, the port
+                number `allocated by the Prometheus project <https://github.com/prometheus/prometheus/wiki/Default-port-allocations>`_
+                for Routinator metric publication.
+
        The Routinator container is known to run successfully run under 
        `gVisor <https://gvisor.dev/>`_ for additional isolation.
 

--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -266,6 +266,18 @@ to get started.
        the container using ``-v host/path/to/routinator.conf:/etc/routinator.conf``
        and passing ``--config /etc/routinator.conf`` when running the container).
 
+       For example in an IPv6 only network you could invoke Routinator like so to
+       have it listen on IPv6 as well as IPv4:
+
+       .. code-block:: bash
+          sudo docker run <your usual arguments> \
+              server --rtr [::]:3323 --http [::]:8323
+
+       Note the :subcmd:`server` command passed to Routinator. When you override the
+       default arguments passed to Routinator by the Docker image you must provide
+       all of the arguments required by Routinator. See the :doc:`manual-page` for
+       more information.
+
        To persist the RPKI cache data you can create a separate Docker volume
        and mount it into the container like so:
 


### PR DESCRIPTION
Triggered by #805.

Split out from PR #809.