### PR TITLE
Add missing rsync install-time dependency for cross-compiled DEBs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ systemd-units = { unit-name = "routinator", unit-scripts = "pkg/common", enable 
 # on the target platform and so it cannot determine the dependencies correctly
 # for us.
 [package.metadata.deb.variants.minimal-cross]
-depends = "adduser, passwd"
+depends = "adduser, passwd, rsync"
 
 [package.metadata.generate-rpm]
 # "BSD" alone is the 3-clause license. Inheriting "license" from above causes rpmlint to


### PR DESCRIPTION
Fixes #817.

Note that the latest 0.12.0-dev DEB does **NOT** have this problem because there are [bugs in the reusable packaging workflow](https://github.com/NLnetLabs/.github/issues/55) concerning minimal and cross cargo-deb variant selection when building DEBs, so this "fix" doesn't actually fix anything because by accident it isn't currently broken. When the reusable packaging workflow bugs are fixed, then this fix will be needed.