### PR TITLE
Only set extra-tals-dir command line option if present.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -433,7 +433,9 @@ impl Config {
         }
 
         // extra_tals_dir
-        self.extra_tals_dir = args.extra_tals_dir.map(|dir| cur_dir.join(dir));
+        if let Some(dir) = args.extra_tals_dir {
+            self.extra_tals_dir = Some(cur_dir.join(dir));
+        }
 
         // exceptions
         if let Some(list) = args.exceptions {


### PR DESCRIPTION
This PR fixes a mistake where a missing `--extra-tals-dir` command line option would clear any value set via a config file.

Fixes #820.