### PR TITLE
Gracefully deal with failing timestamp conversions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [ ".github" ]
 [dependencies]
 base64          = "0.13.0"
 bytes           = "1.0.0"
-chrono          = "0.4.11"
+chrono          = "0.4.23"
 clap            = { version = "4", features = [ "wrap_help", "cargo", "derive" ] }
 crossbeam-queue = "0.3.1"
 crossbeam-utils = "0.8.1"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -912,7 +912,7 @@ impl RtrClientMetrics {
             None
         }
         else {
-            Some(Utc.timestamp(updated, 0))
+            Utc.timestamp_opt(updated, 0).single()
         }
     }
 
@@ -925,7 +925,7 @@ impl RtrClientMetrics {
             None
         }
         else {
-            Some(Utc.timestamp(updated, 0))
+            Utc.timestamp_opt(updated, 0).single()
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -909,7 +909,16 @@ impl StoredManifest {
             ))
         }
 
-        let not_after = Utc.timestamp(i64::parse(reader)?, 0).into();
+        let not_after = match Utc.timestamp_opt(
+            i64::parse(reader)?, 0
+        ).single() {
+            Some(not_after) => not_after.into(),
+            None => {
+                return Err(ParseError::format(
+                    String::from("invalid not_after time")
+                ))
+            }
+        };
         let rpki_notify = Option::parse(reader)?;
         let ca_repository = uri::Rsync::parse(reader)?;
         let manifest_uri = uri::Rsync::parse(reader)?;

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -133,9 +133,9 @@ mod test {
     #[test]
     fn test_parse_http_date() {
         let date = DateTime::<Utc>::from_utc(
-            chrono::naive::NaiveDate::from_ymd(
+            chrono::naive::NaiveDate::from_ymd_opt(
                 1994, 11, 6
-            ).and_hms(8, 49, 37),
+            ).unwrap().and_hms_opt(8, 49, 37).unwrap(),
             Utc
         );
 


### PR DESCRIPTION
This PR switches to using the non-panicking versions of chrono’s timestamp conversion methods introduced in 0.4.23.