### PR TITLE
Add package for RHEL 9 like O/S's (fixes #806)

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@64-verify-add-support-for-rhel-9-and-derivatives
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v6
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v6
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@support-testing-in-other-images
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@support-testing-in-other-images
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v6
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@64-verify-add-support-for-rhel-9-and-derivatives
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -59,6 +59,7 @@ test-mode:
   - 'fresh-install'
   - 'upgrade-from-published'
 
+# Disable upgrade testing on Rocky Linux 9 as we haven't published any packages for the 9 release yet.
 test-exclude:
   - pkg: 'routinator'
     image: 'rockylinux:9'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -13,6 +13,7 @@ image:
   - "debian:bullseye" # debian/11
   - 'centos:7'
   - 'rockylinux:8'    # compatible with EOL centos:8
+  - 'rockylinux:9'
 target:
   - 'x86_64'
 include:
@@ -30,7 +31,9 @@ include:
   # image we are building it in.
   - image: 'rockylinux:8'
     systemd_service_unit_file: pkg/common/routinator.routinator.service
-    os: 'centos:8'
+
+  - image: 'rockylinux:9'
+    systemd_service_unit_file: pkg/common/routinator.routinator.service
 
   # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which
   # Raspbian 11 is based.

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -67,7 +67,7 @@ include:
   - pkg: 'routinator'
     image: 'rockylinux:9'
     target: 'x86_64'
-    test-image: 'almalinux:8'
+    test-image: 'almalinux:9'
 
   - pkg: 'routinator'
     image: 'rockylinux:9'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -58,3 +58,8 @@ include:
 mode:   
   - 'fresh-install'
   - 'upgrade-from-published'
+
+exclude:
+  - pkg: 'routinator'
+    image: 'rockylinux:9'
+    mode: 'upgrade-from-published'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -59,7 +59,7 @@ mode:
   - 'fresh-install'
   - 'upgrade-from-published'
 
-test-exclude:
+testexclude:
   - pkg: 'routinator'
     image: 'rockylinux:9'
     mode: 'upgrade-from-published'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -16,6 +16,14 @@ image:
   - 'rockylinux:9'
 target:
   - 'x86_64'
+test-image:
+  # Set 'test-image' to the empty string for all matrix permutations so that the default ('image') will be used
+  # to launch an LXC container to test the created packages in. Why explicitly set what is already the default?
+  # If this isn't present, later entries in the include set below will overwrite earlier entries that differ
+  # only by their 'test-image' value. If however 'test-image' is present in the original matrix by defining it
+  # here, then 'included' entries will no longer overwrite each other because they alter a key that is present
+  # in the original matrix. This is just how GitHub Actions matrix include rules work.
+  - ""
 include:
   - image: "centos:7"
     systemd_service_unit_file: pkg/common/routinator-minimal.routinator.service
@@ -51,6 +59,20 @@ include:
   - pkg: 'routinator'
     image: 'debian:buster'
     target: 'aarch64-unknown-linux-musl'
+
+  # the include entries below will not cause additional packages to be built because they specify combinations
+  # of matrix keys and values as already exist elsewhere in the matrix, but they will cause an additional tests
+  # to be run in the package testing phase, which will install the package in an LXC container running the 
+  # specified 'test-image' instead of the 'image' it was built in.
+  - pkg: 'routinator'
+    image: 'rockylinux:9'
+    target: 'x86_64'
+    test-image: 'almalinux:8'
+
+  - pkg: 'routinator'
+    image: 'rockylinux:9'
+    target: 'x86_64'
+    test-image: 'centos:9-Stream'
 
 # 'mode' is not used by the package building workflow job, but is used by the package testing workflow job.
 # Ploutos will not include this key when using this matrix definition to generate package building matrix

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -55,11 +55,11 @@ include:
 # 'mode' is not used by the package building workflow job, but is used by the package testing workflow job.
 # Ploutos will not include this key when using this matrix definition to generate package building matrix
 # permutations but will use it when generating package testing permutations.
-mode:   
+test-mode:   
   - 'fresh-install'
   - 'upgrade-from-published'
 
-testexclude:
+test-exclude:
   - pkg: 'routinator'
     image: 'rockylinux:9'
     mode: 'upgrade-from-published'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -59,7 +59,7 @@ mode:
   - 'fresh-install'
   - 'upgrade-from-published'
 
-exclude:
+test-exclude:
   - pkg: 'routinator'
     image: 'rockylinux:9'
     mode: 'upgrade-from-published'


### PR DESCRIPTION
A [test run of the packaging workflow](https://github.com/NLnetLabs/routinator/actions/runs/4320929890) using this PR branch successfully built a Rocky Linux 9 package and shows it working in Rocky Linux 9, Alma Linux 9 and CentOS Stream 9 LXC containers.