### PR TITLE
Print the error type if the RTR server exists.

### DIFF
--- a/src/rtr.rs
+++ b/src/rtr.rs
@@ -122,8 +122,10 @@ async fn single_rtr_listener(
     let listener = TcpListenerStream::new(listener).and_then(|sock| async {
         RtrStream::new(sock, tls.as_ref(), keepalive, server_metrics.clone())
     }).boxed();
-    if Server::new(listener, sender, origins.clone()).run().await.is_err() {
-        error!("Fatal error in RTR server {}.", addr);
+    if let Err(err) = Server::new(
+        listener, sender, origins.clone()
+    ).run().await {
+        error!("Fatal error in RTR server {}: {}", addr, err);
     }
 }
 


### PR DESCRIPTION
This PR adds information about the concrete error to the message logged when an RTR server fails.