### PR TITLE
Switch to rpki-rs 0.16.1 and downgrade to Rust 1.63.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,8 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "routecore"
-version = "0.2.1-dev"
-source = "git+https://github.com/NLnetLabs/routecore.git#9f621f81293fcb30d13fa976515b44666053f313"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e2f02d8dd21010b44bf2ca4502cca2fbb2a8ddfd982a18feff149279dc236c"
 dependencies = [
  "arbitrary",
  "bcder",
@@ -1251,8 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.16.1-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#89739f30054ac711d745162304481e390d5a8163"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207f773b99ae73e14f8e8ab0f789a5892fc46548b1b79caccec8f33e2d303c40"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "routinator"
 version = "0.13.0-dev"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.63"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "An RPKI relying party software."
 repository = "https://github.com/NLnetLabs/routinator"
@@ -34,8 +34,8 @@ pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.16.12"
-routecore       = { git = "https://github.com/NLnetLabs/routecore.git" }
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+routecore       = "0.3.1"
+rpki            = { version = "0.16.1", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "1"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"


### PR DESCRIPTION
This PR switches the dependencies on rpki-rs to the released 0.16.1 and on routecore to 0.3.1. As a consequence, the minimum required Rust version can be lowered to 1.63.