### PR TITLE
Refer to (standalone) EE certs as router certs.

### DIFF
--- a/doc/manual/source/prometheus-metrics.rst
+++ b/doc/manual/source/prometheus-metrics.rst
@@ -69,7 +69,7 @@ file of the RRDP repository, or the base URI of the rsync repository.
         manifest’s own CRL is considered a *stray*.
       * ``ca_cert`` - The number of Certificate Authority (CA) certificates with 
         the state *valid*.
-      * ``router_cert`` - The number of End Entity (EE) certificates found to be
+      * ``router_cert`` - The number of router certificates found to be
         present and *valid*. This only refers to such certificates included as 
         stand-alone files which are BGPsec router certificates.
       * ``roa`` - The number of :term:`Route Origin Attestations <Route Origin 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1262,7 +1262,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             self.process_ca_cer(uri, cert, manifest, ca_task)
         }
         else {
-            self.process_ee_cer(uri, cert, manifest)
+            self.process_router_cert(uri, cert, manifest)
         }
     }
 
@@ -1335,8 +1335,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         Ok(())
     }
 
-    /// Processes an EE certificate.
-    fn process_ee_cer(
+    /// Processes a router certificate.
+    fn process_router_cert(
         &mut self, uri: &uri::Rsync, cert: Cert,
         manifest: &mut ValidPointManifest,
     ) -> Result<(), Failed> {
@@ -1352,8 +1352,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             manifest.metrics.invalid_certs += 1;
             return Ok(())
         }
-        manifest.metrics.valid_ee_certs += 1;
-        self.processor.process_ee_cert(uri, cert, self.cert)?;
+        manifest.metrics.valid_router_certs += 1;
+        self.processor.process_router_cert(uri, cert, self.cert)?;
         Ok(())
     }
 
@@ -1932,11 +1932,11 @@ pub trait ProcessPubPoint: Sized + Send + Sync {
         &mut self, uri: &uri::Rsync, cert: &CaCert,
     ) -> Result<Option<Self>, Failed>;
 
-    /// Process the content of a validated EE certificate.
+    /// Process the content of a validated router certificate.
     ///
     /// The method is given both the URI and the certificate. If it
     /// returns an error, the entire processing run will be aborted.
-    fn process_ee_cert(
+    fn process_router_cert(
         &mut self, uri: &uri::Rsync, cert: Cert, ca_cert: &CaCert,
     ) -> Result<(), Failed> {
         let _ = (uri, cert, ca_cert);

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -241,7 +241,7 @@ fn object_metrics<'a>(
         target.multi(metric).label(group.label(), name)
             .label("type", "router_cert")
             .label("state", "valid")
-            .value(metrics.valid_ee_certs);
+            .value(metrics.valid_router_certs);
         target.multi(metric).label(group.label(), name)
             .label("type", "cert")
             .label("state", "invalid")

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -587,7 +587,11 @@ fn json_publication_metrics(
     target.member_raw("staleCRLs", metrics.stale_crls);
     target.member_raw("strayCRLs", metrics.stray_crls);
     target.member_raw("validCACerts", metrics.valid_ca_certs);
-    target.member_raw("validEECerts", metrics.valid_ee_certs);
+
+    // XXX This is deprecated and should probably be removed at some point.
+    target.member_raw("validEECerts", metrics.valid_router_certs);
+
+    target.member_raw("validRouterCerts", metrics.valid_router_certs);
     target.member_raw("invalidCerts", metrics.invalid_certs);
     target.member_raw("validROAs", metrics.valid_roas);
     target.member_raw("invalidROAs", metrics.invalid_roas);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -292,8 +292,8 @@ pub struct PublicationMetrics {
     /// The number of valid CA certificates.
     pub valid_ca_certs: u32,
 
-    /// The number of valid EE certificates.
-    pub valid_ee_certs: u32,
+    /// The number of valid router certificates.
+    pub valid_router_certs: u32,
 
     /// The number of invalid certificates.
     pub invalid_certs: u32,
@@ -352,7 +352,7 @@ impl<'a> ops::AddAssign<&'a Self> for PublicationMetrics {
         self.stray_crls += other.stray_crls;
 
         self.valid_ca_certs += other.valid_ca_certs;
-        self.valid_ee_certs += other.valid_ee_certs;
+        self.valid_router_certs += other.valid_router_certs;
         self.invalid_certs += other.invalid_certs;
         self.valid_roas += other.valid_roas;
         self.invalid_roas += other.invalid_roas;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1157,7 +1157,7 @@ impl Summary {
             ))?;
             line(format_args!(
                 "    router certs: {:7} verified;",
-                tal.publication.valid_ee_certs,
+                tal.publication.valid_router_certs,
             ))?;
             line(format_args!(
                 "     router keys: {:7} verified, {:7} final.",
@@ -1182,7 +1182,7 @@ impl Summary {
         ))?;
         line(format_args!(
             "    router certs: {:7} verified;",
-            metrics.publication.valid_ee_certs,
+            metrics.publication.valid_router_certs,
         ))?;
         line(format_args!(
             "     router keys: {:7} verified, {:7} final.",

--- a/src/payload/info.rs
+++ b/src/payload/info.rs
@@ -159,7 +159,9 @@ impl PublishInfo {
         }
     }
 
-    pub fn ee_cert(cert: &Cert, uri: &uri::Rsync, ca_cert: &CaCert) -> Self {
+    pub fn router_cert(
+        cert: &Cert, uri: &uri::Rsync, ca_cert: &CaCert
+    ) -> Self {
         PublishInfo {
             tal: ca_cert.cert().tal().clone(),
             uri: Some(uri.clone()),

--- a/src/payload/validation.rs
+++ b/src/payload/validation.rs
@@ -189,7 +189,7 @@ impl<'a> ProcessPubPoint for PubPointProcessor<'a> {
         ))
     }
 
-    fn process_ee_cert(
+    fn process_router_cert(
         &mut self, uri: &uri::Rsync, cert: Cert, ca_cert: &CaCert,
     ) -> Result<(), Failed> {
         if !self.report.enable_bgpsec {
@@ -233,7 +233,8 @@ impl<'a> ProcessPubPoint for PubPointProcessor<'a> {
         };
         self.pub_point.update_refresh(cert.validity().not_after());
         self.pub_point.add_router_key(
-            asns, id, key, Arc::new(PublishInfo::ee_cert(&cert, uri, ca_cert))
+            asns, id, key,
+            Arc::new(PublishInfo::router_cert(&cert, uri, ca_cert)),
         );
         Ok(())
     }


### PR DESCRIPTION
This PR changes renames functions and attributes etc. that refer to standalone end-entity certificates to refer to them as ‘router certs’ to better distinguish them from EE certificates that are part of signed objects.

The only external change is in the HTTP status API where the `validEECerts` member has been renamed to `validRouterCerts` but the old name has been retained for now.

This is a breaking change.

Fixes #701.