### PR TITLE
Rewrite logging.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,15 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,7 +1184,6 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "dirs",
- "fern",
  "form_urlencoded",
  "futures",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,17 +830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log-reroute"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741a3ba679a9a1d331319dda1c7d8f204e9f6760fd867e28576a45d17048bc02"
-dependencies = [
- "arc-swap",
- "log",
- "once_cell",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,9 +1199,9 @@ dependencies = [
  "hyper",
  "listenfd",
  "log",
- "log-reroute",
  "nix",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ futures         = "0.3.4"
 hyper           = { version = "0.14", features = [ "server", "stream" ] }
 listenfd        = "1"
 log             = "0.4.8"
-log-reroute     = "0.1.5"
 num_cpus        = "1.12.0"
+once_cell       = "1"
 pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ clap            = { version = "4", features = [ "wrap_help", "cargo", "derive" ]
 crossbeam-queue = "0.3.1"
 crossbeam-utils = "0.8.1"
 dirs            = "4.0.0"
-fern            = "0.6.0"
 form_urlencoded = "1.0"
 futures         = "0.3.4"
 hyper           = { version = "0.14", features = [ "server", "stream" ] }

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1534,6 +1534,10 @@ SIGUSR1: Reload TALs and restart validation
    that succeeds, restart validation. If loading the TALs fails, Routinator
    will exit.
 
+SIGUSR2: Re-open log file
+   When receiving SIGUSR2 and logging to a file is enabled, Routinator will
+   re-open the log file. If this fails, Routinator will exit.
+
 Exit Status
 -----------
 

--- a/doc/manual/source/prometheus-metrics.rst
+++ b/doc/manual/source/prometheus-metrics.rst
@@ -69,7 +69,7 @@ file of the RRDP repository, or the base URI of the rsync repository.
         manifest’s own CRL is considered a *stray*.
       * ``ca_cert`` - The number of Certificate Authority (CA) certificates with 
         the state *valid*.
-      * ``router_cert`` - The number of End Entity (EE) certificates found to be
+      * ``router_cert`` - The number of router certificates found to be
         present and *valid*. This only refers to such certificates included as 
         stand-alone files which are BGPsec router certificates.
       * ``roa`` - The number of :term:`Route Origin Attestations <Route Origin 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::sync::mpsc::RecvTimeoutError;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(feature = "rta")] use bytes::Bytes;
 use clap::{Arg, Args, ArgAction, ArgMatches, FromArgMatches, Parser};
 use log::{error, info};
@@ -275,25 +275,46 @@ impl Server {
                 if let Some(log) = log.as_ref() {
                     log.flush();
                 }
-                match sig_rx.recv_timeout(timeout) {
-                    Ok(UserSignal::ReloadTals) => {
-                        match validation.reload_tals() {
-                            Ok(_) => {
-                                info!("Reloaded TALs at user request.");
-                            },
-                            Err(_) => {
-                                error!(
-                                    "Fatal: Reloading TALs failed, \
-                                     shutting down."
-                                );
-                                break Err(Failed);
+
+                // Because we don’t want to restart validation upon
+                // log rotation, we need to loop here. But then we need
+                // to recalculate timeout.
+                let deadline = Instant::now() + timeout;
+                let end = loop {
+                    let timeout = deadline.saturating_duration_since(
+                        Instant::now()
+                    );
+                    match sig_rx.recv_timeout(timeout) {
+                        Ok(UserSignal::ReloadTals) => {
+                            match validation.reload_tals() {
+                                Ok(_) => {
+                                    info!("Reloaded TALs at user request.");
+                                    break None;
+                                },
+                                Err(_) => {
+                                    error!(
+                                        "Fatal: Reloading TALs failed, \
+                                         shutting down."
+                                    );
+                                    break Some(Err(Failed));
+                                }
                             }
                         }
+                        Ok(UserSignal::RotateLog) => {
+                            if process.rotate_log().is_err() {
+                                break Some(Err(Failed));
+                            }
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            break None;
+                        }
+                        Err(RecvTimeoutError::Disconnected) => {
+                            break Some(Ok(()));
+                        }
                     }
-                    Err(RecvTimeoutError::Timeout) => { }
-                    Err(RecvTimeoutError::Disconnected) => {
-                        break Ok(());
-                    }
+                };
+                if let Some(end) = end {
+                    break end;
                 }
             };
             // An error here means the receiver is gone which is fine.
@@ -1219,6 +1240,7 @@ impl Man {
 #[allow(dead_code)]
 enum UserSignal {
     ReloadTals,
+    RotateLog,
 }
 
 /// Wait for the next validation run or a user telling us to quit or reload.
@@ -1227,6 +1249,7 @@ enum UserSignal {
 #[cfg(unix)]
 struct SignalListener {
     usr1: Signal,
+    usr2: Signal,
 }
 
 #[cfg(unix)]
@@ -1239,7 +1262,14 @@ impl SignalListener {
                     error!("Attaching to signal USR1 failed: {}", err);
                     return Err(Failed)
                 }
-            }
+            },
+            usr2: match signal(SignalKind::user_defined2()) {
+                Ok(usr2) => usr2,
+                Err(err) => {
+                    error!("Attaching to signal USR2 failed: {}", err);
+                    return Err(Failed)
+                }
+            },
         })
     }
 
@@ -1247,8 +1277,10 @@ impl SignalListener {
     ///
     /// Returns what to do.
     pub async fn next(&mut self) -> UserSignal {
-        self.usr1.recv().await;
-        UserSignal::ReloadTals
+        tokio::select! {
+            _ = self.usr1.recv() => UserSignal::ReloadTals,
+            _ = self.usr2.recv() => UserSignal::RotateLog,
+        }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -62,7 +62,7 @@ impl Process {
     /// Initialize logging.
     ///
     /// All diagnostic output of Routinator is done via logging, never to
-    /// stderr directly. Thus, it is important to initalize logging before
+    /// stderr directly. Thus, it is important to initialize logging before
     /// doing anything else that may result in such output. This function
     /// does exactly that. It sets a maximum log level of `warn`, leading
     /// only printing important information, and directs all logging to
@@ -288,7 +288,7 @@ impl Logger {
         fs::OpenOptions::new().create(true).append(true).open(path)
     }
 
-    /// Configures the stederr target.
+    /// Configures the stderr target.
     fn new_stderr_target(timestamp: bool) -> LogBackend {
         LogBackend::Stderr {
             stderr: io::stderr(),

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -1,7 +1,7 @@
 //! Utilities for dealing with HTTP.
 
 use std::fmt;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use chrono::format::{Item, Fixed, Numeric, Pad};
 
 
@@ -104,23 +104,42 @@ pub fn format_http_date(date: DateTime<Utc>) -> String {
 
 //------------ Constructing ISO Dates ----------------------------------------
 
-const ISO_DATE: &[Item<'static>] = &[
-    Item::Numeric(Numeric::Year, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Month, Pad::Zero),
-    Item::Literal("-"),
-    Item::Numeric(Numeric::Day, Pad::Zero),
-    Item::Literal("T"),
-    Item::Numeric(Numeric::Hour, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Minute, Pad::Zero),
-    Item::Literal(":"),
-    Item::Numeric(Numeric::Second, Pad::Zero),
-    Item::Literal("Z"),
-];
 
 pub fn format_iso_date(date: DateTime<Utc>) -> impl fmt::Display {
-    date.format_with_items(ISO_DATE.iter())
+    const UTC_ISO_DATE: &[Item<'static>] = &[
+        Item::Numeric(Numeric::Year, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Month, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Day, Pad::Zero),
+        Item::Literal("T"),
+        Item::Numeric(Numeric::Hour, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Minute, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Second, Pad::Zero),
+        Item::Literal("Z"),
+    ];
+
+    date.format_with_items(UTC_ISO_DATE.iter())
+}
+
+pub fn format_local_iso_date(date: DateTime<Local>) -> impl fmt::Display {
+    const LOCAL_ISO_DATE: &[Item<'static>] = &[
+        Item::Numeric(Numeric::Year, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Month, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Day, Pad::Zero),
+        Item::Literal("T"),
+        Item::Numeric(Numeric::Hour, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Minute, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Second, Pad::Zero),
+    ];
+
+    date.format_with_items(LOCAL_ISO_DATE.iter())
 }
 
 


### PR DESCRIPTION
This PR implements all log handling with the exception of actual syslog in Routinator itself. It also implements support for log rotation when logging into files by re-opening the log file when receiving SIGUSR2.

Error handling for logging is now such that if trying to log to file or syslog fails, Routinator will exit. It will also exit if it receives SIGUSR2 and can’t open the log file.

The motivation for this is that the log is used by many people to determine issues with the RPKI repositories, so silently not having logs seems bad. Also, not being able to log is a good indication for bigger problems to come.

Fixes #468. Fixes #732.