### PR TITLE
Allow excluding certain types in payload output.

### DIFF
--- a/doc/manual/source/advanced-features.rst
+++ b/doc/manual/source/advanced-features.rst
@@ -25,7 +25,7 @@ You can let Routinator process ASPA objects and include them in the published
 dataset, as well as the metrics, using the :option:`--enable-aspa` option
 or by setting ``enable-aspa`` to True in the :doc:`configuration
 file<configuration>`. ASPA information will be exposed via RTR, as well as
-in the :term:`jsonext` output format, e.g.: 
+in the :term:`json` and :term:`jsonext` output formats, e.g.: 
 
 .. code-block:: json
 
@@ -96,7 +96,7 @@ You can let Routinator process router keys and include them in the published
 dataset, as well as the metrics, using the :option:`--enable-bgpsec` option
 or by setting ``enable-bgpsec`` to True in the :doc:`configuration
 file<configuration>`. BGPsec information will be exposed via RTR, as well as
-in the :term:`SLURM` and :term:`jsonext` output format, e.g.: 
+in the :term:`SLURM`, :term:`json` and :term:`jsonext` output formats, e.g.: 
 
 .. code-block:: json 
 

--- a/doc/manual/source/http-service.rst
+++ b/doc/manual/source/http-service.rst
@@ -52,7 +52,7 @@ This will produce the following output:
     }
 
 The query parameter ``exclude`` can be used to exclude certain payload types
-from the response. The values ``origins``, ``routerKeys``, and ``aspa``
+from the response. The values ``routeOrigins``, ``routerKeys``, and ``aspas``
 disable inclusion of route origins, router keys, and ASPAs, respectively. The
 values can either be given in separate ``exclude`` parameters or included in
 one separated by commas.

--- a/doc/manual/source/http-service.rst
+++ b/doc/manual/source/http-service.rst
@@ -52,7 +52,7 @@ This will produce the following output:
     }
 
 The query parameter ``exclude`` can be used to exclude certain payload types
-from the response. The values ``origins``, ``routerkeys``, and ``aspa``
+from the response. The values ``origins``, ``routerKeys``, and ``aspa``
 disable inclusion of route origins, router keys, and ASPAs, respectively. The
 values can either be given in separate ``exclude`` parameters or included in
 one separated by commas.

--- a/doc/manual/source/http-service.rst
+++ b/doc/manual/source/http-service.rst
@@ -51,6 +51,15 @@ This will produce the following output:
       ]
     }
 
+The query parameter ``exclude`` can be used to exclude certain payload types
+from the response. The values ``origins``, ``routerkeys``, and ``aspa``
+disable inclusion of route origins, router keys, and ASPAs, respectively. The
+values can either be given in separate ``exclude`` parameters or included in
+one separated by commas.
+
+.. versionadded:: 0.13.0
+   Allow excluding specific data from the output
+
 More Specific Prefixes
 """"""""""""""""""""""
 

--- a/doc/manual/source/interactive.rst
+++ b/doc/manual/source/interactive.rst
@@ -28,6 +28,15 @@ error. You can influence the amount of details returned with the
 :option:`--verbose` and :option:`--quiet` options. To learn more about what kind
 of information returned, refer to the :doc:`logging` section.
 
+If you have enabled :ref:`advanced-features:bgpsec` and/or
+:ref:`advanced-features:aspa` validation, in some output formats the amount
+data can be quite overwhelming. You can exclude specific data types for the
+output with the :option:`--no-route-origins`, :option:`--no-router-keys` and
+the :option:`--noaspas` options.
+
+.. versionchanged:: 0.13.0
+   Allow excluding specific data from the output.
+
 Query Options
 -------------
 
@@ -128,7 +137,19 @@ You will now see that a more specific /23 prefix is returned as well:
          will get a list of all more specific VRPs covered by the prefix you
          supplied in the query.
 
+Exclude Specific Data Types
+"""""""""""""""""""""""""""
+
+If you have enabled :ref:`advanced-features:bgpsec` and/or
+:ref:`advanced-features:aspa` validation, in some output formats the amount
+data can be quite overwhelming. You can exclude specific payload types with
+the :option:`--no-route-origins`, :option:`--no-router-keys` and
+:option:`--noaspas` options to disable inclusion of route origins, router
+keys, and ASPAs, respectively.
+
 .. deprecated:: 0.9.0
    ``--filter-asn`` and ``--filter-prefix``   
 .. versionchanged:: 0.11.0
    Add the :option:`--more-specifics` option
+.. versionadded:: 0.13.0
+   Allow excluding specific data from the output

--- a/doc/manual/source/interactive.rst
+++ b/doc/manual/source/interactive.rst
@@ -141,7 +141,7 @@ Exclude Specific Data Types
 """""""""""""""""""""""""""
 
 If you have enabled :ref:`advanced-features:bgpsec` and/or
-:ref:`advanced-features:aspa` validation, in some output formats the amount
+:ref:`advanced-features:aspa` validation, in some output formats the amount of
 data can be quite overwhelming. You can exclude specific payload types with
 the :option:`--no-route-origins`, :option:`--no-router-keys` and
 :option:`--noaspas` options to disable inclusion of route origins, router

--- a/doc/manual/source/interactive.rst
+++ b/doc/manual/source/interactive.rst
@@ -30,7 +30,7 @@ of information returned, refer to the :doc:`logging` section.
 
 If you have enabled :ref:`advanced-features:bgpsec` and/or
 :ref:`advanced-features:aspa` validation, in some output formats the amount
-data can be quite overwhelming. You can exclude specific data types for the
+of data can be quite overwhelming. You can exclude specific data types for the
 output with the :option:`--no-route-origins`, :option:`--no-router-keys` and
 the :option:`--noaspas` options.
 

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1420,7 +1420,7 @@ In addition, the query parameter ``include=more-specifics`` will cause the
 inclusion of VRPs for more specific prefixes of prefixes given via
 ``select-prefix``.
 
-Finally, the query parameters ``exclude`` can be used to exclude certain
+Finally, the query parameter ``exclude`` can be used to exclude certain
 payload types from the response. The values ``origins``, ``routerkeys``, and
 ``aspa`` disable inclusion of route origins, router keys, and ASPAs,
 respectively. The values can either be given in separate ``exclude``

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -504,7 +504,7 @@ These can be requested by providing different commands on the command line.
                   dedicated name for each.
 
            jsonext
-                  The list is placed into a JSON object with upt to four
+                  The list is placed into a JSON object with up to four
                   members: *roas* contains the validated route origin
                   authorizations, *routerKeys* contains the validated 
                   BGPsec router keys, *aspas* contains the validated
@@ -1421,8 +1421,8 @@ inclusion of VRPs for more specific prefixes of prefixes given via
 ``select-prefix``.
 
 Finally, the query parameter ``exclude`` can be used to exclude certain
-payload types from the response. The values ``origins``, ``routerkeys``, and
-``aspa`` disable inclusion of route origins, router keys, and ASPAs,
+payload types from the response. The values ``routeOrigins``, ``routerKeys``,
+and ``aspas`` disable inclusion of route origins, router keys, and ASPAs,
 respectively. The values can either be given in separate ``exclude``
 parameters or included in one separated by commas.
 

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -458,18 +458,35 @@ These can be requested by providing different commands on the command line.
                   be in one single output file.
 
            json
-                  The list is placed into a JSON object with a single element
-                  *roas* which contains an array of objects with four
+                  The list is placed into a JSON object with up to four
+                  members: *roas* contains the validated route origin
+                  authorizations, *routerKeys* contains the validated 
+                  BGPsec router keys, *aspas* contains the validated
+                  ASPA payload, and *metadata* contains some information
+                  about the validation run itself. Of the first three, only
+                  those members are present that have not been disabled or
+                  excluded.
+
+                  The *roas* member contains an array of objects with four
                   elements each: The autonomous system number of the network
                   authorized to originate a prefix in *asn*, the prefix in
                   slash notation in *prefix*, the maximum prefix length of
                   the announced route in *maxLength*, and the trust anchor
-                  from which the authorization was derived in *ta*. This
-                  format is identical to that produced by the RIPE NCC RPKI
-                  Validator except for different naming of the trust anchor.
-                  Routinator uses the name of the TAL file without the
-                  extension *.tal* whereas the RIPE NCC Validator has a
-                  dedicated name for each.
+                  from which the authorization was derived in *ta*.
+
+                  The *routerKeys* member contains an array of objects with
+                  four elements each: The autonomous system using the router
+                  key is given in *asn*, the key identifier as a string of
+                  hexadecimal digits in *SKI*, the actual public key as a
+                  Base 64 encoded string in *routerPublicKey*, and the trust
+                  anchor from which the authorization was derived in *ta*.
+
+                  The *aspa* member contains an array of objects with four
+                  members each: The *customer* member contains the customer
+                  ASN, *afi* the address family as either "ipv4" or "ipv6",
+                  *providers* contains the provider ASN set as an array, and
+                  the trust anchor from which the authorization was derived
+                  in *ta*.
 
                   The output object also includes a member named *metadata*
                   which provides additional information. Currently, this is a
@@ -478,16 +495,23 @@ These can be requested by providing different commands on the command line.
                   which provides the same time but in the standard ISO date
                   format.
 
-           jsonext
-                  The list is placed into a JSON object with three members:
-                  *roas* contains the validated route origin
-                  authorizations, *routerKeys* contains the validated 
-                  BGPsec router keys, and *metadata* contains some information
-                  about the validation run itself.
+                  If only route origins are included, this format is identical
+                  to that produced by the RIPE NCC
+                  RPKI Validator except for different naming of the trust
+                  anchor.
+                  Routinator uses the name of the TAL file without the
+                  extension *.tal* whereas the RIPE NCC Validator has a
+                  dedicated name for each.
 
-                  All three members are always present, even if BGPsec has
-                  not been enabled. In this case, *routerKeys* will simply
-                  be empty.
+           jsonext
+                  The list is placed into a JSON object with upt to four
+                  members: *roas* contains the validated route origin
+                  authorizations, *routerKeys* contains the validated 
+                  BGPsec router keys, *aspas* contains the validated
+                  ASPA payload, and *metadata* contains some information
+                  about the validation run itself. Of the first three, only
+                  those members are present that have not been disabled or
+                  excluded.
 
                   The *roas* member contains an array of objects with four
                   elements each: The autonomous system number of the network
@@ -618,7 +642,12 @@ These can be requested by providing different commands on the command line.
            Note that VRPs with more specific prefixes have no influence on
            whether a route is RPKI valid or invalid and therefore these VRPs
            are of an informational nature only.
-        
+    
+    .. option:: --no-route-origins, --no-router-keys, --no-aspas
+
+           These three options can be used to exclude the various payload
+           types from being included in the output.
+
 
 .. subcmd:: validate
 
@@ -1390,6 +1419,12 @@ fields can be repeated multiple times.
 In addition, the query parameter ``include=more-specifics`` will cause the
 inclusion of VRPs for more specific prefixes of prefixes given via
 ``select-prefix``.
+
+Finally, the query parameters ``exclude`` can be used to exclude certain
+payload types from the response. The values ``origins``, ``routerkeys``, and
+``aspa`` disable inclusion of route origins, router keys, and ASPAs,
+respectively. The values can either be given in separate ``exclude``
+parameters or included in one separated by commas.
 
 These parameters work in the same way as the options of the same name to the
 :subcmd:`vrps` command.

--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -68,9 +68,19 @@ generated in a wide range of output formats for various use cases.
             rsync://rpki.ripe.net/repository/DEFAULT/73/fe2d72-c2dd-46c1-9429-e66369649411/1/49sMtcwyAuAW2lVDSQBGhOHd9og.roa,AS196615,93.175.147.0/24,24,2021-05-03 14:51:30,2022-07-01 00:00:00
               
     json
-          The output is in JSON format. The list is placed into a member
-          named *roas* which contains an array of objects with four elements
-          each: 
+          The list is placed into a JSON object with up to four members:
+
+            - *roas* contains the validated route origin authorisations, 
+            - *routerKeys* contains the validated BGPsec router keys, 
+            - *aspas* contains the validated ASPA payload, and 
+            - *metadata* contains some information about the validation run 
+              itself. 
+              
+          Of the first three, only those members are present that have not 
+          been disabled or excluded. 
+          
+          The *roas* member contains an array of objects with four elements 
+          each:
           
             - *asn* lists the Autonomous System Number of the network
               authorised to originate a prefix,
@@ -80,9 +90,25 @@ generated in a wide range of output formats for various use cases.
             - *ta* has the trust anchor from which the authorisation was
               derived. 
           
-          This format of the *roas* element is identical to that produced by
-          the RIPE NCC RPKI Validator except for different naming of the
-          trust anchor. 
+          The *routerKeys* member contains an array of objects with four 
+          elements each: 
+          
+            - *asn* contains the autonomous system using the router key,
+            - *SKI* lists the key identifier as a string of hexadecimal 
+              digits,
+            - *routerPublicKey* contains the actual public key as a Base 64 
+              encoded string, and 
+            - *ta* has the trust anchor from which the authorisation was
+              derived.
+
+          The *aspa* member contains an array of objects with four members 
+          each: 
+          
+            - *customer* contains the customer ASN,
+            - *afi* lists the address family as either "ipv4" or "ipv6",
+            - *providers* contains the provider ASN set as an array, and
+            - *ta* has the trust anchor from which the authorisation was
+              derived.
           
           The output object also includes a member named *metadata* which
           provides additional information. Currently, this is a member
@@ -106,9 +132,11 @@ generated in a wide range of output formats for various use cases.
 
           .. versionchanged:: 0.10.0
              Add the *metadata* member
+          .. versionchanged:: 0.13.0
+             Add the *routerKeys* and *aspas* members
 
     jsonext
-          The list is placed into a JSON object with four members:
+          The list is placed into a JSON object with up to four members:
 
             - *roas* contains the validated route origin authorisations,
             - *routerKeys* contains the validated
@@ -118,10 +146,8 @@ generated in a wide range of output formats for various use cases.
             - *metadata* contains some information about the validation run
               itself.
 
-          All four members are always present, even if
-          :ref:`advanced-features:bgpsec` and/or
-          :ref:`advanced-features:aspa` have not been enabled. In this case,
-          *routerKeys* and *aspas* will simply be empty.
+          Of the first three, only those members are present that have not 
+          been disabled or excluded.
 
           The *roas* member contains an array of objects with four elements
           each: 
@@ -252,6 +278,8 @@ generated in a wide range of output formats for various use cases.
              Add :ref:`advanced-features:bgpsec` information
           .. versionchanged:: 0.13.0
              Add :ref:`advanced-features:aspa` information
+          .. versionchanged:: 0.13.0
+             Only include members that have not been disabled or excluded
 
     slurm
           The list is formatted as locally added assertions of a :doc:`local

--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -71,8 +71,10 @@ generated in a wide range of output formats for various use cases.
           The list is placed into a JSON object with up to four members:
 
             - *roas* contains the validated route origin authorisations, 
-            - *routerKeys* contains the validated BGPsec router keys, 
-            - *aspas* contains the validated ASPA payload, and 
+            - *routerKeys* contains the validated
+              :ref:`advanced-features:bgpsec` router keys,
+            - *aspas* contains the validated :ref:`advanced-features:aspa` 
+              payload, and
             - *metadata* contains some information about the validation run 
               itself. 
               

--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -120,14 +120,28 @@ generated in a wide range of output formats for various use cases.
             
             {
               "metadata": {
-                "generated": 1626853335,
-                "generatedTime": "2021-07-21T07:42:15Z"
+                "generated": 1685455841,
+                "generatedTime": "2023-05-30T14:10:41Z"
               },
-              "roas": [
-                { "asn": "AS196615", "prefix": "2001:7fb:fd03::/48", "maxLength": 48, "ta": "ripe" },
-                { "asn": "AS196615", "prefix": "2001:7fb:fd04::/48", "maxLength": 48, "ta": "ripe" },
-                { "asn": "AS196615", "prefix": "93.175.147.0/24", "maxLength": 24, "ta": "ripe" }
-              ]
+              "roas": [{
+                "asn": "AS196615",
+                "prefix": "93.175.147.0/24",
+                "maxLength": 24,
+                "ta": "ripe"
+                }
+              ],
+              "routerKeys": [{
+                "asn": "AS211321",
+                "SKI": "17316903F0671229E8808BA8E8AB0105FA915A07",
+                "routerPublicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET10FMBxP6P3r6aG_ICpfsktp7X6ylJIY8Kye6zkQhNOt0y-cRzYngH8MGzY3cXNvZ64z4CpZ22gf4teybGq8ow",
+                "ta": "ripe"
+              }],
+              "aspas": [{
+                "customer": "AS64496",
+                "afi": "ipv6",
+                "providers": ["AS64499", "AS64511", "AS65551"],
+                "ta": "ripe"
+              }]
             }
 
           .. versionchanged:: 0.10.0

--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -395,45 +395,53 @@ generated in a wide range of output formats for various use cases.
           provide numbers for the complete repository. 
           
           For each trust anchor, it will print the number of verified ROAs
-          and VRPs, as well as router certificates and keys. Note that router
-          keys will only be verified and included in the totals if you have
-          enabled :ref:`advanced-features:bgpsec`.
+          and VRPs, router certificates and keys, as well as ASPAs. Note that
+          router keys and ASPAs will only be verified and included in the
+          totals if you have enabled :ref:`advanced-features:bgpsec` and
+          :ref:`advanced-features:aspa`, respectively.
                 
           .. code-block:: text
           
-            Summary at 2022-01-28 08:37:27.046365 UTC
+            Summary at 2023-05-30 16:22:27.060940 UTC
             afrinic: 
-                        ROAs:    3587 verified;
-                        VRPs:    4545 verified,       3 unsafe,    4466 final;
+                        ROAs:    4896 verified;
+                        VRPs:    6248 verified,    5956 final;
                 router certs:       0 verified;
                  router keys:       0 verified,       0 final.
+                       ASPAs:       0 verified,       0 final.
             apnic: 
-                        ROAs:   18612 verified;
-                        VRPs:   85992 verified,       0 unsafe,   85711 final;
+                        ROAs:   25231 verified;
+                        VRPs:  109978 verified,  109717 final;
                 router certs:       0 verified;
                  router keys:       0 verified,       0 final.
+                       ASPAs:       2 verified,       2 final.
             arin: 
-                        ROAs:   41500 verified;
-                        VRPs:   50495 verified,       5 unsafe,    1812 final;
-                router certs:       0 verified;
-                 router keys:       0 verified,       0 final.
+                        ROAs:   63188 verified;
+                        VRPs:   78064 verified,   76941 final;
+                router certs:       1 verified;
+                 router keys:       1 verified,       1 final.
+                       ASPAs:       7 verified,       7 final.
             lacnic: 
-                        ROAs:   11744 verified;
-                        VRPs:   23628 verified,       0 unsafe,   21235 final;
+                        ROAs:   18036 verified;
+                        VRPs:   32565 verified,   30929 final;
                 router certs:       0 verified;
                  router keys:       0 verified,       0 final.
+                       ASPAs:       0 verified,       0 final.
             ripe: 
-                        ROAs:   27195 verified;
-                        VRPs:  149164 verified,      17 unsafe,  149162 final;
+                        ROAs:   39081 verified;
+                        VRPs:  211048 verified,  211043 final;
                 router certs:       2 verified;
                  router keys:       2 verified,       2 final.
-
+                       ASPAs:      57 verified,      57 final.
             total: 
-                        ROAs:  141922 verified;
-                        VRPs:  361536 verified,      25 unsafe,  307434 final;
-                router certs:       2 verified;
-                 router keys:       2 verified,       2 final.
+                        ROAs:  150432 verified;
+                        VRPs:  437903 verified,  434586 final;
+                router certs:       3 verified;
+                 router keys:       3 verified,       3 final.
+                       ASPAs:      66 verified,      66 final.
 
           .. versionchanged:: 0.11.0
              Reformat, sort alphabetically and add 
              :ref:`advanced-features:bgpsec` information
+          .. versionadded:: 0.13.0
+             Include ASPAs

--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -396,8 +396,8 @@ generated in a wide range of output formats for various use cases.
           
           For each trust anchor, it will print the number of verified ROAs
           and VRPs, router certificates and keys, as well as ASPAs. Note that
-          router keys and ASPAs will only be verified and included in the
-          totals if you have enabled :ref:`advanced-features:bgpsec` and
+          router keys and ASPAs will only be included in the totals if you
+          have enabled :ref:`advanced-features:bgpsec` and
           :ref:`advanced-features:aspa`, respectively.
                 
           .. code-block:: text
@@ -444,4 +444,4 @@ generated in a wide range of output formats for various use cases.
              Reformat, sort alphabetically and add 
              :ref:`advanced-features:bgpsec` information
           .. versionadded:: 0.13.0
-             Include ASPAs
+             Include :ref:`advanced-features:aspa`

--- a/src/http/dispatch.rs
+++ b/src/http/dispatch.rs
@@ -1,0 +1,87 @@
+//! Rules on how to dispatch a request.
+
+use std::sync::Arc;
+use hyper::{Body, Method, Request};
+use crate::config::Config;
+use crate::metrics::{HttpServerMetrics, SharedRtrServerMetrics};
+use crate::payload::SharedHistory;
+use crate::process::LogOutput;
+use super::{delta, log, metrics, payload, status, validity};
+use super::response::Response;
+
+//------------ State ---------------------------------------------------------
+
+pub struct State {
+    payload: payload::State,
+    log: log::State,
+    history: SharedHistory,
+    metrics: Arc<HttpServerMetrics>,
+    rtr_metrics: SharedRtrServerMetrics,
+}
+
+impl State {
+    pub fn new(
+        config: &Config,
+        history: SharedHistory,
+        rtr_metrics: SharedRtrServerMetrics,
+        log: Option<Arc<LogOutput>>
+    ) -> Self {
+        Self {
+            payload: payload::State::new(config),
+            log: log::State::new(log),
+            history,
+            metrics: Arc::new(HttpServerMetrics::default()),
+            rtr_metrics,
+        }
+    }
+    
+    pub fn metrics(&self) -> &Arc<HttpServerMetrics> {
+        &self.metrics
+    }
+
+    pub async fn handle_request(
+        &self,
+        req: Request<Body>,
+    ) -> Response {
+        self.metrics.inc_requests();
+        if *req.method() != Method::GET && *req.method() != Method::HEAD {
+            return Response::method_not_allowed()
+        }
+
+        if let Some(response) = self.payload.handle_get_or_head(
+            &req, &self.history
+        ) {
+            return response
+        }
+        if let Some(response) = delta::handle_get_or_head(
+            &req, &self.history
+        ) {
+            return response
+        }
+        if let Some(response) = self.log.handle_get_or_head(&req) {
+            return response
+        }
+        if let Some(response) = metrics::handle_get_or_head(
+            &req, &self.history, &self.metrics, &self.rtr_metrics
+        ).await {
+            return response
+        }
+        if let Some(response) = status::handle_get_or_head(
+            &req, &self.history, &self.metrics, &self.rtr_metrics
+        ).await {
+            return response
+        }
+        if let Some(response) = validity::handle_get_or_head(
+            &req, &self.history) {
+            return response
+        }
+
+        #[cfg(feature = "ui")]
+        if let Some(response) = super::ui::handle_get_or_head(&req) {
+            return response
+        }
+        
+        Response::not_found()
+    }
+}
+

--- a/src/http/log.rs
+++ b/src/http/log.rs
@@ -1,30 +1,40 @@
 //! Handles endpoints related to the log.
 
+use std::sync::Arc;
 use hyper::{Body, Method, Request};
 use crate::process::LogOutput;
 use super::response::{ContentType, Response, ResponseBuilder};
 
+//------------ State ---------------------------------------------------------
 
-//------------ handle_get ----------------------------------------------------
+pub struct State {
+    log: Option<Arc<LogOutput>>,
+}
 
-pub fn handle_get_or_head(
-    req: &Request<Body>,
-    log: Option<&LogOutput>,
-) -> Option<Response> {
-    if req.uri().path() == "/log" {
-        let res = ResponseBuilder::ok().content_type(ContentType::TEXT);
-        if *req.method() == Method::HEAD {
-            Some(res.empty())
-        }
-        else {
-            match log {
-                Some(log) => Some(res.body(log.get_output())),
-                None => Some(res.empty())
+impl State {
+    pub fn new(log: Option<Arc<LogOutput>>) -> Self {
+        Self { log }
+    }
+
+    pub fn handle_get_or_head(
+        &self,
+        req: &Request<Body>,
+    ) -> Option<Response> {
+        if req.uri().path() == "/log" {
+            let res = ResponseBuilder::ok().content_type(ContentType::TEXT);
+            if *req.method() == Method::HEAD {
+                Some(res.empty())
+            }
+            else {
+                match self.log.as_ref() {
+                    Some(log) => Some(res.body(log.get_output())),
+                    None => Some(res.empty())
+                }
             }
         }
-    }
-    else {
-        None
+        else {
+            None
+        }
     }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,8 +8,8 @@
 pub use self::listener::http_listener;
 pub use self::response::ContentType;
 
-// First, a bit of scaffolding. `dispatch` contains the state needs is
-// necessary for answering requests and dispatches to the specific handlers.
+// First, a bit of scaffolding. `dispatch` contains the state necessary for
+// answering requests and dispatches to the specific handlers.
 // `listener` contains all the logic to actually handle connections etc.
 mod dispatch;
 mod listener;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4,72 +4,25 @@
 //! those interested. The only public item, [`http_listener`] creates all
 //! necessary networking services based on the current configuration and
 //! returns a future that drives the server.
-//!
-//! [`http_listener`]: fn.http_listener.html
 
 pub use self::listener::http_listener;
 pub use self::response::ContentType;
 
-mod delta;
+// First, a bit of scaffolding. `dispatch` contains the state needs is
+// necessary for answering requests and dispatches to the specific handlers.
+// `listener` contains all the logic to actually handle connections etc.
+mod dispatch;
 mod listener;
+
+// The following module helps making responses.
+mod response;
+
+// Finally, these modules actually handle requests.
+mod delta;
 mod log;
 mod metrics;
 mod payload;
-mod response;
 mod status;
 mod ui;
 mod validity;
-
-
-//------------ handle_request ------------------------------------------------
-
-use hyper::{Body, Method, Request};
-use crate::metrics::{HttpServerMetrics, SharedRtrServerMetrics};
-use crate::payload::SharedHistory;
-use crate::process::LogOutput;
-use self::response::Response;
-
-
-async fn handle_request(
-    req: Request<Body>,
-    origins: &SharedHistory,
-    metrics: &HttpServerMetrics,
-    rtr_metrics: &SharedRtrServerMetrics,
-    log: Option<&LogOutput>,
-) -> Response {
-    metrics.inc_requests();
-    if *req.method() != Method::GET && *req.method() != Method::HEAD {
-        return Response::method_not_allowed()
-    }
-
-    if let Some(response) = payload::handle_get_or_head(&req, origins) {
-        return response
-    }
-    if let Some(response) = delta::handle_get_or_head(&req, origins) {
-        return response
-    }
-    if let Some(response) = log::handle_get_or_head(&req, log) {
-        return response
-    }
-    if let Some(response) = metrics::handle_get_or_head(
-        &req, origins, metrics, rtr_metrics
-    ).await {
-        return response
-    }
-    if let Some(response) = status::handle_get_or_head(
-        &req, origins, metrics, rtr_metrics
-    ).await {
-        return response
-    }
-    if let Some(response) = validity::handle_get_or_head(&req, origins) {
-        return response
-    }
-
-    #[cfg(feature = "ui")]
-    if let Some(response) = ui::handle_get_or_head(&req) {
-        return response
-    }
-    
-    Response::not_found()
-}
 

--- a/src/http/payload.rs
+++ b/src/http/payload.rs
@@ -3,65 +3,80 @@
 use std::convert::Infallible;
 use futures::stream;
 use hyper::{Body, Method, Request};
-use crate::output;
-use crate::output::OutputFormat;
+use crate::config::Config;
+use crate::output::{Output, OutputFormat};
 use crate::payload::SharedHistory;
 use super::response::{Response, ResponseBuilder};
 
 
-//------------ Request Handlers ----------------------------------------------
+//------------ State ---------------------------------------------------------
 
-pub fn handle_get_or_head(
-    req: &Request<Body>,
-    history: &SharedHistory,
-) -> Option<Response> {
-    let path = req.uri().path();
-    let format = if path == "/api/v1/origins/" {
-        OutputFormat::Json
-    }
-    else {
-        OutputFormat::from_path(req.uri().path())?
-    };
+pub struct State {
+    output: Output,
+}
 
-    let selection = match output::Selection::from_query(req.uri().query()) {
-        Ok(selection) => selection,
-        Err(_) => return Some(Response::bad_request()),
-    };
-
-    let (session, serial, created, snapshot, metrics) = {
-        let history = history.read();
-        (
-            history.session(),
-            history.serial(),
-            history.created(),
-            history.current(),
-            history.metrics()
-        )
-    };
-    let (snapshot, metrics, created) = match (snapshot, metrics, created) {
-        (Some(snapshot), Some(metrics), Some(created)) => {
-            (snapshot, metrics, created)
+impl State {
+    pub fn new(config: &Config) -> Self {
+        Self {
+            output: Output::from_config(config),
         }
-        _ => return Some(Response::initial_validation()),
-    };
-
-    let etag = format!("\"{:x}-{}\"", session, serial);
-
-    if let Some(response) = Response::maybe_not_modified(req, &etag, created) {
-        return Some(response)
     }
 
-    let res = ResponseBuilder::ok()
-        .content_type(format.content_type())
-        .etag(&etag).last_modified(created);
-    if *req.method() == Method::HEAD {
-        Some(res.empty())
-    }
-    else {
-        Some(res.body(Body::wrap_stream(stream::iter(
-            format.stream(snapshot, selection, metrics)
-                .map(Result::<_, Infallible>::Ok)
-        ))))
+    pub fn handle_get_or_head(
+        &self,
+        req: &Request<Body>,
+        history: &SharedHistory,
+    ) -> Option<Response> {
+        let path = req.uri().path();
+        let format = if path == "/api/v1/origins/" {
+            OutputFormat::Json
+        }
+        else {
+            OutputFormat::from_path(req.uri().path())?
+        };
+
+        let mut output = self.output.clone();
+        if output.update_from_query(req.uri().query()).is_err() {
+            return Some(Response::bad_request())
+        };
+
+        let (session, serial, created, snapshot, metrics) = {
+            let history = history.read();
+            (
+                history.session(),
+                history.serial(),
+                history.created(),
+                history.current(),
+                history.metrics()
+            )
+        };
+        let (snapshot, metrics, created) = match (snapshot, metrics, created) {
+            (Some(snapshot), Some(metrics), Some(created)) => {
+                (snapshot, metrics, created)
+            }
+            _ => return Some(Response::initial_validation()),
+        };
+
+        let etag = format!("\"{:x}-{}\"", session, serial);
+
+        if let Some(response) = Response::maybe_not_modified(
+            req, &etag, created
+        ) {
+            return Some(response)
+        }
+
+        let res = ResponseBuilder::ok()
+            .content_type(format.content_type())
+            .etag(&etag).last_modified(created);
+        if *req.method() == Method::HEAD {
+            Some(res.empty())
+        }
+        else {
+            Some(res.body(Body::wrap_stream(stream::iter(
+                output.stream(snapshot, metrics, format)
+                    .map(Result::<_, Infallible>::Ok)
+            ))))
+        }
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -35,7 +35,7 @@ use crate::config::Config;
 use crate::error::{ExitError, Failed};
 use crate::http::http_listener;
 use crate::metrics::{SharedRtrServerMetrics};
-use crate::output::OutputFormat;
+use crate::output::{Output, OutputFormat};
 use crate::payload::{PayloadSnapshot, SharedHistory, ValidationReport};
 use crate::process::Process;
 use crate::engine::Engine;
@@ -375,13 +375,13 @@ pub struct Vrps {
     ///
     /// If this is some path, then we print the list into that file.
     /// Otherwise we just dump it to stdout.
-    output: Option<PathBuf>,
+    path: Option<PathBuf>,
 
     /// The desired output format.
     format: OutputFormat,
 
-    /// Optional output filters.
-    selection: Option<output::Selection>,
+    /// Configuration of the output.
+    output: Output,
 
     /// Don’t update the repository.
     noupdate: bool,
@@ -424,6 +424,18 @@ struct VrpsArgs {
     #[arg(short, long)]
     more_specifics: bool,
 
+    /// Don’t include route origins in output
+    #[arg(long)]
+    no_route_origins: bool,
+
+    /// Don’t include router keys in output
+    #[arg(long)]
+    no_router_keys: bool,
+
+    /// Don’t include ASPA in output
+    #[arg(long)]
+    no_aspas: bool,
+
     /// Don't update the local cache
     #[arg(short, long)]
     noupdate: bool,
@@ -459,19 +471,16 @@ impl Vrps {
             }
         };
 
-        let output = if args.output == Path::new("-") {
+        let path = if args.output == Path::new("-") {
             None
         }
         else {
             Some(args.output)
         };
 
-        let selection = if
-            args.select_prefix.is_none() && args.select_asn.is_none()
-        {
-            None
-        }
-        else {
+        let mut output = Output::new();
+
+        if args.select_prefix.is_some() || args.select_asn.is_some() {
             let mut selection = output::Selection::new();
             if let Some(list) = args.select_prefix {
                 for value in list {
@@ -484,26 +493,37 @@ impl Vrps {
                 }
             }
             selection.set_more_specifics(args.more_specifics);
-            Some(selection)
+            output.set_selection(selection);
         };
 
+        if args.no_route_origins {
+            output.no_route_origins();
+        }
+        if args.no_router_keys {
+            output.no_router_keys();
+        }
+        if args.no_aspas{
+            output.no_aspas();
+        }
+
         Ok(Vrps {
-            output,
+            path,
             format,
+            output,
             noupdate: args.noupdate,
             complete: args.complete,
-            selection,
         })
     }
 
     /// Produces a list of Validated ROA Payload.
     ///
-    /// The list will be written to the file identified by `output` or
+    /// The list will be written to the file identified by `path` or
     /// stdout if that is `None`. The format is determined by `format`.
     /// If `noupdate` is `false`, the local repository will be updated first
     /// and rsync will be enabled during validation to sync any new
     /// publication points.
-    fn run(self, process: Process) -> Result<(), ExitError> {
+    fn run(mut self, process: Process) -> Result<(), ExitError> {
+        self.output.update_from_config(process.config());
         let mut engine = Engine::new(process.config(), !self.noupdate)?;
         engine.ignite()?;
         process.switch_logging(false, false)?;
@@ -511,8 +531,10 @@ impl Vrps {
         let (report, mut metrics) = ValidationReport::process(
             &engine, process.config(),
         )?;
-        let vrps = report.into_snapshot( &exceptions, &mut metrics);
-        let res = match self.output {
+        let vrps = Arc::new(report.into_snapshot(&exceptions, &mut metrics));
+        let rsync_complete = metrics.rsync_complete();
+        let metrics = Arc::new(metrics);
+        let res = match self.path {
             Some(ref path) => {
                 let mut file = match fs::File::create(path) {
                     Ok(file) => file,
@@ -524,21 +546,18 @@ impl Vrps {
                         return Err(Failed.into())
                     }
                 };
-                self.format.output_snapshot(
-                    &vrps, self.selection.as_ref(), &metrics, &mut file)
+                self.output.write(vrps, metrics, self.format, &mut file)
             }
             None => {
                 let out = io::stdout();
                 let mut out = out.lock();
-                self.format.output_snapshot(
-                    &vrps, self.selection.as_ref(), &metrics, &mut out
-                )
+                self.output.write(vrps, metrics, self.format, &mut out)
             }
         };
         if let Err(err) = res {
             // Surpress an error message for broken pipe on stdout.
             if 
-                self.output.is_some() ||
+                self.path.is_some() ||
                 err.kind() != io::ErrorKind::BrokenPipe
             {
                 error!(
@@ -548,7 +567,7 @@ impl Vrps {
             }
             Err(ExitError::Generic)
         }
-        else if self.complete && !metrics.rsync_complete() {
+        else if self.complete && !rsync_complete {
             Err(ExitError::IncompleteUpdate)
         }
         else {

--- a/src/output.rs
+++ b/src/output.rs
@@ -10,6 +10,7 @@ use log::{error, info};
 use routecore::addr;
 use rpki::repository::resources::Asn;
 use rpki::rtr::payload::{Aspa, RouteOrigin, RouterKey};
+use crate::config::Config;
 use crate::error::Failed;
 use crate::http::ContentType;
 use crate::payload::{
@@ -138,76 +139,6 @@ impl OutputFormat {
         }
     }
 
-    /// Outputs a payload snapshot to a writer.
-    pub fn output_snapshot<W: io::Write>(
-        self,
-        snapshot: &PayloadSnapshot,
-        selection: Option<&Selection>,
-        metrics: &Metrics,
-        target: &mut W,
-    ) -> Result<(), io::Error> {
-        let formatter = self.formatter();
-        let mut first = true;
-        formatter.header(snapshot, metrics, target)?;
-        for (origin, info) in snapshot.origins() {
-            if let Some(selection) = selection {
-                if !selection.include_origin(origin) {
-                    continue
-                }
-            }
-            if first {
-                first = false;
-            }
-            else {
-                formatter.origin_delimiter(target)?;
-            }
-            formatter.origin(origin, info, target)?;
-        }
-        formatter.after_origins(target)?;
-        let mut first = true;
-        for (key, info) in snapshot.router_keys() {
-            if let Some(selection) = selection {
-                if !selection.include_router_key(key) {
-                    continue
-                }
-            }
-            if first {
-                first = false;
-            }
-            else {
-                formatter.router_key_delimiter(target)?;
-            }
-            formatter.router_key(key, info, target)?;
-        }
-        formatter.after_router_keys(target)?;
-        let mut first = true;
-        for (aspa, info) in snapshot.aspas() {
-            if let Some(selection) = selection {
-                if !selection.include_aspa(aspa) {
-                    continue
-                }
-            }
-            if first {
-                first = false;
-            }
-            else {
-                formatter.aspa_delimiter(target)?;
-            }
-            formatter.aspa(aspa, info, target)?;
-        }
-        formatter.footer(metrics, target)
-    }
-
-    /// Creates an output stream for this format.
-    pub fn stream(
-        self,
-        snapshot: Arc<PayloadSnapshot>,
-        selection: Option<Selection>,
-        metrics: Arc<Metrics>,
-    ) -> impl Iterator<Item = Vec<u8>> {
-        OutputStream::new(self, snapshot, selection, metrics)
-    }
-
     fn formatter<W: io::Write>(self) -> Box<dyn Formatter<W> + Send> {
         match self {
             OutputFormat::Csv => Box::new(Csv),
@@ -264,44 +195,6 @@ impl Selection {
         self.more_specifics = more_specifics
     }
 
-    /// Creates a selection from a HTTP query string.
-    pub fn from_query(query: Option<&str>) -> Result<Option<Self>, QueryError> {
-        let query = match query {
-            Some(query) => query,
-            None => return Ok(None)
-        };
-
-        let mut res = Self::default();
-        for (key, value) in form_urlencoded::parse(query.as_ref()) {
-            if key == "select-prefix" || key == "filter-prefix" {
-                res.resources.push(
-                    SelectResource::Prefix(addr::Prefix::from_str(&value)?)
-                );
-            }
-            else if key == "select-asn" || key == "filter-asn" {
-                res.resources.push(
-                    SelectResource::Asn(
-                        Asn::from_str(&value).map_err(|_| QueryError)?
-                    )
-                );
-            }
-            else if key == "include" {
-                for value in value.split(',') {
-                    #[allow(clippy::single_match)]
-                    match value {
-                        "more-specifics" => res.more_specifics = true,
-                        _ => { }
-                    }
-                }
-            }
-            else {
-                return Err(QueryError)
-            }
-        }
-
-        Ok(Some(res))
-    }
-
     /// Add an origin ASN to select.
     pub fn push_asn(&mut self, asn: Asn) {
         self.resources.push(SelectResource::Asn(asn))
@@ -310,6 +203,11 @@ impl Selection {
     /// Add a origin prefix to select.
     pub fn push_prefix(&mut self, prefix: addr::Prefix) {
         self.resources.push(SelectResource::Prefix(prefix))
+    }
+
+    /// Returns whether there are any resources.
+    pub fn has_resources(&self) -> bool {
+        !self.resources.is_empty()
     }
 
     /// Returns whether an origin should be included in output.
@@ -392,14 +290,188 @@ impl SelectResource {
 }
 
 
+//------------ Output --------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct Output {
+    /// Limiting data to be included.
+    ///
+    /// If this is `None`, all data is potentially included.
+    selection: Option<Selection>,
+
+    /// Should we include route origins?
+    route_origins: bool,
+
+    /// Should we include router keys?
+    router_keys: bool,
+
+    /// Should we include ASPA data?
+    aspas: bool,
+}
+
+impl Output {
+    /// Creates new default output
+    pub fn new() -> Self {
+        Self {
+            selection: None,
+            route_origins: true,
+            router_keys: true,
+            aspas: true
+        }
+    }
+
+    /// Creates a new output based on the config.
+    pub fn from_config(config: &Config) -> Self {
+        let mut res = Self::new();
+        res.update_from_config(config);
+        res
+    }
+
+    pub fn from_query(query: Option<&str>) -> Result<Self, QueryError> {
+        let mut res = Self::new();
+        res.update_from_query(query)?;
+        Ok(res)
+    }
+
+    pub fn update_from_config(&mut self, config: &Config) {
+        if !config.enable_bgpsec {
+            self.no_router_keys();
+        }
+        if !config.enable_aspa {
+            self.no_aspas();
+        }
+    }
+
+    /// Updates the output value from query parameters.
+    pub fn update_from_query(
+        &mut self, query: Option<&str>
+    ) -> Result<(), QueryError> {
+        let query = match query {
+            Some(query) => query,
+            None => return Ok(())
+        };
+
+        let mut selection = Selection::new();
+        for (key, value) in form_urlencoded::parse(query.as_ref()) {
+            if key == "select-prefix" || key == "filter-prefix" {
+                selection.resources.push(
+                    SelectResource::Prefix(addr::Prefix::from_str(&value)?)
+                );
+            }
+            else if key == "select-asn" || key == "filter-asn" {
+                selection.resources.push(
+                    SelectResource::Asn(
+                        Asn::from_str(&value).map_err(|_| QueryError)?
+                    )
+                );
+            }
+            else if key == "include" {
+                for value in value.split(',') {
+                    #[allow(clippy::single_match)]
+                    match value {
+                        "more-specifics" => selection.more_specifics = true,
+                        _ => { }
+                    }
+                }
+            }
+            else if key == "exclude" {
+                for value in value.split(',') {
+                    match value {
+                        "origins" => self.route_origins = false,
+                        "routerKeys" => self.router_keys = false,
+                        "aspa" => self.aspas = false,
+                        _ => { }
+                    }
+                }
+            }
+            else {
+                return Err(QueryError)
+            }
+        }
+
+        if selection.has_resources() {
+            self.set_selection(selection)
+        }
+
+        Ok(())
+    }
+
+    pub fn set_selection(&mut self, selection: Selection) {
+        self.selection = Some(selection)
+    }
+
+    pub fn no_route_origins(&mut self) {
+        self.route_origins = false
+    }
+
+    pub fn no_router_keys(&mut self) {
+        self.router_keys = false
+    }
+
+    pub fn no_aspas(&mut self) {
+        self.aspas = false
+    }
+
+    /// Outputs the payload snapshot to the target in the given format.
+    pub fn write<W: io::Write>(
+        self,
+        snapshot: Arc<PayloadSnapshot>,
+        metrics: Arc<Metrics>,
+        format: OutputFormat,
+        target: &mut W,
+    ) -> Result<(), io::Error> {
+        let mut stream = OutputStream::new(self, snapshot, metrics, format);
+        while stream.write_next(target)? { }
+        Ok(())
+    }
+
+    /// Creates an output stream for the given format.
+    pub fn stream(
+        self,
+        snapshot: Arc<PayloadSnapshot>,
+        metrics: Arc<Metrics>,
+        format: OutputFormat,
+    ) -> impl Iterator<Item = Vec<u8>> {
+        OutputStream::new(self, snapshot, metrics, format)
+    }
+
+    fn include_origin(&self, origin: RouteOrigin) -> bool {
+        match self.selection.as_ref() {
+            Some(selection) => selection.include_origin(origin),
+            None => true
+        }
+    }
+
+    fn include_router_key(&self, key: &RouterKey) -> bool {
+        match self.selection.as_ref() {
+            Some(selection) => selection.include_router_key(key),
+            None => true
+        }
+    }
+
+    fn include_aspa(&self, aspa: &Aspa) -> bool {
+        match self.selection.as_ref() {
+            Some(selection) => selection.include_aspa(aspa),
+            None => true
+        }
+    }
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
 //------------ OutputStream --------------------------------------------------
 
 struct OutputStream<Target> {
+    output: Output,
     snapshot: Arc<PayloadSnapshot>,
+    metrics: Arc<Metrics>,
     state: StreamState,
     formatter: Box<dyn Formatter<Target> + Send>,
-    selection: Option<Selection>,
-    metrics: Arc<Metrics>,
 }
 
 enum StreamState {
@@ -413,17 +485,15 @@ enum StreamState {
 impl<Target: io::Write> OutputStream<Target> {
     /// Creates a new output stream.
     fn new(
-        format: OutputFormat,
+        output: Output,
         snapshot: Arc<PayloadSnapshot>,
-        selection: Option<Selection>,
         metrics: Arc<Metrics>,
+        format: OutputFormat,
     ) -> Self {
         OutputStream {
-            snapshot,
+            output, snapshot, metrics,
             state: StreamState::Header,
             formatter: format.formatter(),
-            selection,
-            metrics,
         }
     }
 
@@ -432,16 +502,15 @@ impl<Target: io::Write> OutputStream<Target> {
     /// Returns `Ok(true)` if something was written and there may be more
     /// data. Returns `Ok(false)` if nothing was written and there also is
     /// no more data.
-    fn write_next(&mut self, target: &mut Target) -> Result<bool, io::Error> {
+    pub fn write_next(
+        &mut self, target: &mut Target
+    ) -> Result<bool, io::Error> {
         let next = match self.state {
             StreamState::Header => {
                 self.formatter.header(
                     &self.snapshot, &self.metrics, target
                 )?;
-                StreamState::Origin {
-                    iter: self.snapshot.clone().arc_origin_iter(),
-                    first: true,
-                }
+                self.progress_header(target)?
             }
             StreamState::Origin { ref mut iter, ref mut first } => {
                 loop {
@@ -452,10 +521,8 @@ impl<Target: io::Write> OutputStream<Target> {
                             break
                         }
                     };
-                    if let Some(selection) = self.selection.as_ref() {
-                        if !selection.include_origin(origin) {
-                            continue
-                        }
+                    if !self.output.include_origin(origin) {
+                        continue
                     }
                     if *first {
                         *first = false;
@@ -466,10 +533,7 @@ impl<Target: io::Write> OutputStream<Target> {
                     self.formatter.origin(origin, info, target)?;
                     return Ok(true)
                 }
-                StreamState::Key {
-                    iter: self.snapshot.clone().arc_router_key_iter(),
-                    first: true
-                }
+                self.progress_origin(target)?
             }
             StreamState::Key { ref mut iter, ref mut first } => {
                 loop {
@@ -480,10 +544,8 @@ impl<Target: io::Write> OutputStream<Target> {
                             break
                         }
                     };
-                    if let Some(selection) = self.selection.as_ref() {
-                        if !selection.include_router_key(key) {
-                            continue
-                        }
+                    if !self.output.include_router_key(key) {
+                        continue
                     }
                     if *first {
                         *first = false;
@@ -494,26 +556,19 @@ impl<Target: io::Write> OutputStream<Target> {
                     self.formatter.router_key(key, info, target)?;
                     return Ok(true)
                 }
-                StreamState::Aspa {
-                    iter: self.snapshot.clone().arc_aspa_iter(),
-                    first: true
-                }
+                self.progress_key(target)?
             }
             StreamState::Aspa { ref mut iter, ref mut first } => {
                 loop {
                     let (aspa, info) = match iter.next_with_info() {
                         Some((aspa, info)) => (aspa, info),
                         None => {
-                            self.formatter.footer(
-                                self.metrics.as_ref(), target
-                            )?;
+                            self.formatter.after_aspas(target)?;
                             break
                         }
                     };
-                    if let Some(selection) = self.selection.as_ref() {
-                        if !selection.include_aspa(aspa) {
-                            continue
-                        }
+                    if !self.output.include_aspa(aspa) {
+                        continue
                     }
                     if *first {
                         *first = false;
@@ -528,8 +583,62 @@ impl<Target: io::Write> OutputStream<Target> {
             }
             StreamState::Done => return Ok(false)
         };
+
+        if matches!(next, StreamState::Done) {
+            self.formatter.footer(
+                self.metrics.as_ref(), target
+            )?;
+        }
         self.state = next;
         Ok(true)
+    }
+
+    /// Progresses from the header state to the next state.
+    fn progress_header(
+        &self, target: &mut Target
+    ) -> Result<StreamState, io::Error> {
+        if self.output.route_origins {
+            self.formatter.before_origins(target)?;
+            Ok(StreamState::Origin {
+                iter: self.snapshot.clone().arc_origin_iter(),
+                first: true,
+            })
+        }
+        else {
+            self.progress_origin(target)
+        }
+    }
+
+    /// Progresses from the origin state to the next state.
+    fn progress_origin(
+        &self, target: &mut Target
+    ) -> Result<StreamState, io::Error> {
+        if self.output.router_keys {
+            self.formatter.before_router_keys(target)?;
+            Ok(StreamState::Key {
+                iter: self.snapshot.clone().arc_router_key_iter(),
+                first: true
+            })
+        }
+        else {
+            self.progress_key(target)
+        }
+    }
+
+    /// Progresses from the origin state to the next state.
+    fn progress_key(
+        &self, target: &mut Target
+    ) -> Result<StreamState, io::Error> {
+        if self.output.aspas {
+            self.formatter.before_aspas(target)?;
+            Ok(StreamState::Aspa {
+                iter: self.snapshot.clone().arc_aspa_iter(),
+                first: true
+            })
+        }
+        else {
+            Ok(StreamState::Done)
+        }
     }
 }
 
@@ -583,11 +692,28 @@ trait Formatter<W> {
         Ok(())
     }
 
+    fn before_origins(
+        &self, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+
     fn origin(
         &self, origin: RouteOrigin, info: &PayloadInfo, target: &mut W
     ) -> Result<(), io::Error>;
 
+    fn origin_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
+        let _ = target;
+        Ok(())
+    }
+
     fn after_origins(
+        &self, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn before_router_keys(
         &self, _target: &mut W
     ) -> Result<(), io::Error> {
         Ok(())
@@ -599,7 +725,18 @@ trait Formatter<W> {
         Ok(())
     }
 
+    fn router_key_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
+        let _ = target;
+        Ok(())
+    }
+
     fn after_router_keys(
+        &self, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn before_aspas(
         &self, _target: &mut W
     ) -> Result<(), io::Error> {
         Ok(())
@@ -611,25 +748,21 @@ trait Formatter<W> {
         Ok(())
     }
 
+    fn aspa_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
+        let _ = target;
+        Ok(())
+    }
+
+    fn after_aspas(
+        &self, _target: &mut W
+    ) -> Result<(), io::Error> {
+        Ok(())
+    }
+
     fn footer(
         &self, metrics: &Metrics, target: &mut W
     ) -> Result<(), io::Error> {
         let _ = (metrics, target);
-        Ok(())
-    }
-
-    fn origin_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
-        let _ = target;
-        Ok(())
-    }
-
-    fn router_key_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
-        let _ = target;
-        Ok(())
-    }
-
-    fn aspa_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
-        let _ = target;
         Ok(())
     }
 }
@@ -759,12 +892,6 @@ impl<W: io::Write> Formatter<W> for Json {
         )
     }
 
-    fn footer(
-        &self, _metrics: &Metrics, target: &mut W
-    ) -> Result<(), io::Error> {
-        writeln!(target, "\n  ]\n}}")
-    }
-
     fn origin(
         &self, origin: RouteOrigin, info: &PayloadInfo, target: &mut W
     ) -> Result<(), io::Error> {
@@ -780,6 +907,12 @@ impl<W: io::Write> Formatter<W> for Json {
 
     fn origin_delimiter(&self, target: &mut W) -> Result<(), io::Error> {
         writeln!(target, ",")
+    }
+
+    fn footer(
+        &self, _metrics: &Metrics, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target, "\n  ]\n}}")
     }
 }
 
@@ -854,15 +987,23 @@ impl<W: io::Write> Formatter<W> for ExtendedJson {
     fn header(
         &self, _snapshot: &PayloadSnapshot, metrics: &Metrics, target: &mut W
     ) -> Result<(), io::Error> {
-        writeln!(target,
+        write!(target,
             "{{\
             \n  \"metadata\": {{\
             \n    \"generated\": {},\
             \n    \"generatedTime\": \"{}\"\
-            \n  }},\
-            \n  \"roas\": [",
+            \n  }}",
             metrics.time.timestamp(),
             format_iso_date(metrics.time)
+        )
+    }
+
+    fn before_origins(
+        &self, target: &mut W
+    ) -> Result<(), io::Error> {
+        writeln!(target,
+            ",\
+            \n  \"roas\": ["
         )
     }
 
@@ -881,7 +1022,11 @@ impl<W: io::Write> Formatter<W> for ExtendedJson {
     }
 
     fn after_origins(&self, target: &mut W) -> Result<(), io::Error> {
-        writeln!(target, "\n  ],\n  \"routerKeys\": [")
+        write!(target, "\n  ]")
+    }
+
+    fn before_router_keys(&self, target: &mut W) -> Result<(), io::Error> {
+        writeln!(target, ",\n  \"routerKeys\": [")
     }
 
     fn router_key(
@@ -899,7 +1044,11 @@ impl<W: io::Write> Formatter<W> for ExtendedJson {
     }
 
     fn after_router_keys(&self, target: &mut W) -> Result<(), io::Error> {
-        writeln!(target, "\n  ],\n  \"aspas\": [")
+        write!(target, "\n  ]")
+    }
+
+    fn before_aspas(&self, target: &mut W) -> Result<(), io::Error> {
+        writeln!(target, ",\n  \"aspas\": [")
     }
 
     fn aspa(
@@ -928,10 +1077,14 @@ impl<W: io::Write> Formatter<W> for ExtendedJson {
         write!(target, "] }}")
     }
 
+    fn after_aspas(&self, target: &mut W) -> Result<(), io::Error> {
+        write!(target, "\n  ]")
+    }
+
     fn footer(
         &self, _metrics: &Metrics, target: &mut W
     ) -> Result<(), io::Error> {
-        writeln!(target, "\n  ]\n}}")
+        writeln!(target, "\n}}")
     }
 
     fn origin_delimiter(&self, target: &mut W) -> Result<(), io::Error> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -625,7 +625,7 @@ impl<Target: io::Write> OutputStream<Target> {
         }
     }
 
-    /// Progresses from the origin state to the next state.
+    /// Progresses from the router key state to the next state.
     fn progress_key(
         &self, target: &mut Target
     ) -> Result<StreamState, io::Error> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -379,7 +379,7 @@ impl Output {
                     match value {
                         "origins" => self.route_origins = false,
                         "routerKeys" => self.router_keys = false,
-                        "aspa" => self.aspas = false,
+                        "aspas" => self.aspas = false,
                         _ => { }
                     }
                 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -377,7 +377,7 @@ impl Output {
             else if key == "exclude" {
                 for value in value.split(',') {
                     match value {
-                        "origins" => self.route_origins = false,
+                        "routeOrigins" => self.route_origins = false,
                         "routerKeys" => self.router_keys = false,
                         "aspas" => self.aspas = false,
                         _ => { }


### PR DESCRIPTION
This PR add support for excluding certain payload types from output both in the `vrps` command and the HTTP server. With this in place, the PR also adds router key and ASPA to the standard `json` output format.

For the `vrps` command, new command line options `--no-route-origins`, `--no-router-keys`, and `--no-aspas` have been added. For the payload output endpoints of the HTTP server, a new `excludes` query parameter can be used to exclude `routeOrigins`, `routerKeys`, or `aspas`. 

These flags are available even for formats that don’t actually support outputting all these payload types.

When router keys or aspa has not been disabled, those payload types are now properly excluded rather than adding empty sections for them.

Fixes #852.