### PR TITLE
Drop dependency on routecore.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,17 +1091,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "routecore"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e2f02d8dd21010b44bf2ca4502cca2fbb2a8ddfd982a18feff149279dc236c"
-dependencies = [
- "arbitrary",
- "bcder",
- "serde",
-]
-
-[[package]]
 name = "routinator"
 version = "0.13.0-dev"
 dependencies = [
@@ -1125,7 +1114,6 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
- "routecore",
  "routinator-ui",
  "rpki",
  "rustls-pemfile",
@@ -1154,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.16.2-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#068b448eebe1b1d44402ee228b534fe15275ad73"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=no-more-routecore#81e1e4e0882ac891a5724bcadcf85ba302c8d68a"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1165,7 +1153,6 @@ dependencies = [
  "log",
  "quick-xml",
  "ring",
- "routecore",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.16.12"
-routecore       = "0.3.1"
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "no-more-routecore", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "1"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/src/http/validity.rs
+++ b/src/http/validity.rs
@@ -3,8 +3,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 use hyper::{Body, Method, Request};
-use routecore::addr::Prefix;
-use rpki::repository::resources::Asn;
+use rpki::resources::{Asn, Prefix};
 use crate::payload::{PayloadSnapshot, SharedHistory};
 use crate::validity::RouteValidity;
 use super::response::{ContentType, Response, ResponseBuilder};

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -23,8 +23,7 @@ use std::time::{Duration, Instant};
 #[cfg(feature = "rta")] use bytes::Bytes;
 use clap::{Arg, Args, ArgAction, ArgMatches, FromArgMatches, Parser};
 use log::{error, info};
-use routecore::addr;
-use rpki::repository::resources::{Asn};
+use rpki::resources::{Asn, Prefix};
 #[cfg(feature = "rta")] use rpki::repository::rta::Rta;
 use rpki::rtr::server::NotifySender;
 use tempfile::NamedTempFile;
@@ -433,7 +432,7 @@ struct VrpsArgs {
         long, alias = "filter-prefix",
         value_name = "PREFIX"
     )]
-    select_prefix: Option<Vec<addr::Prefix>>,
+    select_prefix: Option<Vec<Prefix>>,
 
     /// Only include records for the given AS number
     #[arg(
@@ -627,7 +626,7 @@ pub struct Validate {
 /// What route(s) should we validate, please?
 enum ValidateWhat {
     /// Validate a single route with the given prefix and ASN.
-    Single(addr::Prefix, Asn),
+    Single(Prefix, Asn),
 
     /// Validate the routes provided in the given file.
     File(PathBuf),
@@ -641,7 +640,7 @@ enum ValidateWhat {
 struct ValidateArgs {
     /// Address prefix of the announcement
     #[arg(short, long, requires = "asn", conflicts_with = "input")]
-    prefix: Option<addr::Prefix>,
+    prefix: Option<Prefix>,
 
     /// Origin AS number of the announcement
     #[arg(short, long, requires = "prefix", conflicts_with = "input")]

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use chrono::Utc;
 use chrono::format::{Item, Numeric, Pad};
 use log::{error, info};
-use routecore::addr;
-use rpki::repository::resources::Asn;
+use rpki::resources::{Asn, Prefix};
+use rpki::resources::addr::ParsePrefixError;
 use rpki::rtr::payload::{Aspa, RouteOrigin, RouterKey};
 use crate::config::Config;
 use crate::error::Failed;
@@ -201,7 +201,7 @@ impl Selection {
     }
 
     /// Add a origin prefix to select.
-    pub fn push_prefix(&mut self, prefix: addr::Prefix) {
+    pub fn push_prefix(&mut self, prefix: Prefix) {
         self.resources.push(SelectResource::Prefix(prefix))
     }
 
@@ -257,7 +257,7 @@ enum SelectResource {
     Asn(Asn),
 
     /// Include resources related to the given prefix.
-    Prefix(addr::Prefix),
+    Prefix(Prefix),
 }
 
 impl SelectResource {
@@ -355,7 +355,7 @@ impl Output {
         for (key, value) in form_urlencoded::parse(query.as_ref()) {
             if key == "select-prefix" || key == "filter-prefix" {
                 selection.resources.push(
-                    SelectResource::Prefix(addr::Prefix::from_str(&value)?)
+                    SelectResource::Prefix(Prefix::from_str(&value)?)
                 );
             }
             else if key == "select-asn" || key == "filter-asn" {
@@ -667,8 +667,8 @@ impl Iterator for OutputStream<Vec<u8>> {
 #[derive(Debug)]
 pub struct QueryError;
 
-impl From<addr::ParsePrefixError> for QueryError {
-    fn from(_: addr::ParsePrefixError) -> Self {
+impl From<ParsePrefixError> for QueryError {
+    fn from(_: ParsePrefixError) -> Self {
         QueryError
     }
 }

--- a/src/payload/validation.rs
+++ b/src/payload/validation.rs
@@ -19,10 +19,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use crossbeam_queue::SegQueue;
 use log::{info, warn};
-use routecore::addr;
-use routecore::asn::{Asn, SmallAsnSet};
-use routecore::bgpsec::KeyIdentifier;
 use rpki::uri;
+use rpki::crypto::keys::KeyIdentifier;
 use rpki::repository::aspa::AsProviderAttestation;
 use rpki::repository::cert::{Cert, ResourceCert};
 use rpki::repository::resources::{
@@ -31,6 +29,7 @@ use rpki::repository::resources::{
 use rpki::repository::roa::RouteOriginAttestation;
 use rpki::repository::tal::{Tal, TalUri};
 use rpki::repository::x509::{Time, Validity};
+use rpki::resources::{Asn, Prefix, SmallAsnSet};
 use rpki::rtr::payload::{Afi, Aspa, RouteOrigin, RouterKey};
 use rpki::rtr::pdu::{ProviderAsns, RouterKeyInfo};
 use crate::config::{Config, FilterPolicy};
@@ -524,7 +523,7 @@ pub struct RejectedResources {
 
 impl RejectedResources {
     /// Checks whether a prefix should be kept.
-    pub fn keep_prefix(&self, prefix: addr::Prefix) -> bool {
+    pub fn keep_prefix(&self, prefix: Prefix) -> bool {
         let raw = rpki::repository::resources::Prefix::new(
             prefix.addr(), prefix.len()
         );

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -3,8 +3,7 @@
 use std::{fmt, io};
 use std::str::FromStr;
 use chrono::{DateTime, Utc};
-use routecore::addr;
-use rpki::repository::resources::Asn;
+use rpki::resources::{Asn, Prefix};
 use rpki::rtr::payload::RouteOrigin;
 use serde::Deserialize;
 use crate::payload::{PayloadInfo, PayloadSnapshot};
@@ -69,7 +68,7 @@ impl<'a> RouteValidityList<'a> {
 
     pub fn iter_state(
         &self
-    ) -> impl Iterator<Item = (addr::Prefix, Asn, RouteState)> + '_ {
+    ) -> impl Iterator<Item = (Prefix, Asn, RouteState)> + '_ {
         self.routes.iter().map(|route| {
             (route.prefix, route.asn, route.state())
         })
@@ -83,7 +82,7 @@ impl<'a> RouteValidityList<'a> {
 #[derive(Clone, Debug)]
 pub struct RouteValidity<'a> {
     /// The address prefix of the route announcement.
-    prefix: addr::Prefix,
+    prefix: Prefix,
 
     /// The origin AS number of the route announcement.
     asn: Asn,
@@ -100,7 +99,7 @@ pub struct RouteValidity<'a> {
 
 impl<'a> RouteValidity<'a> {
     pub fn new(
-        prefix: addr::Prefix,
+        prefix: Prefix,
         asn: Asn,
         snapshot: &'a PayloadSnapshot
     ) -> Self {
@@ -123,7 +122,7 @@ impl<'a> RouteValidity<'a> {
         RouteValidity { prefix, asn, matched, bad_asn, bad_len }
     }
 
-    pub fn prefix(&self) -> addr::Prefix {
+    pub fn prefix(&self) -> Prefix {
         self.prefix
     }
 
@@ -382,7 +381,7 @@ impl RequestList {
 
             let prefix = match tokens.next() {
                 Some(prefix) => {
-                    match addr::Prefix::from_str(prefix) {
+                    match Prefix::from_str(prefix) {
                         Ok(prefix) => prefix,
                         Err(_) => {
                             return Err(io::Error::new(
@@ -473,7 +472,7 @@ impl RequestList {
     }
 
     /// Creates a request list with a single entry.
-    pub fn single(prefix: addr::Prefix, asn: Asn) -> Self {
+    pub fn single(prefix: Prefix, asn: Asn) -> Self {
         RequestList {
             routes: vec![Request { prefix, asn }]
         }
@@ -495,7 +494,7 @@ impl RequestList {
 #[derive(Clone, Debug, Deserialize)]
 struct Request {
     /// The address prefix of the route announcement.
-    prefix: addr::Prefix,
+    prefix: Prefix,
 
     /// The origin AS number of the route announcement.
     #[serde(deserialize_with = "Asn::deserialize_from_any")]


### PR DESCRIPTION
This PR removes the dependency on _routecore_ and uses the types defined in _rpki-rs_ instead. 