### PR TITLE
Move enabling of ASPA behind a feature flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,11 +1095,6 @@ name = "routecore"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e2f02d8dd21010b44bf2ca4502cca2fbb2a8ddfd982a18feff149279dc236c"
-dependencies = [
- "arbitrary",
- "bcder",
- "serde",
-]
 
 [[package]]
 name = "routinator"
@@ -1154,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.16.2-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#068b448eebe1b1d44402ee228b534fe15275ad73"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git#be88ac3f8a341cae68837dd9667715521d4da82f"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1165,7 +1160,6 @@ dependencies = [
  "log",
  "quick-xml",
  "ring",
- "routecore",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ syslog          = "6"
 [features]
 default = [ "socks", "ui"]
 arbitrary = [ "dep:arbitrary", "chrono/arbitrary", "rpki/arbitrary" ]
+aspa = []
 native-tls = [ "reqwest/native-tls", "tls" ]
 rta = []
 socks = [ "reqwest/socks" ]

--- a/doc/manual/source/advanced-features.rst
+++ b/doc/manual/source/advanced-features.rst
@@ -28,10 +28,6 @@ content can be used for detection and mitigation of route leaks.
    without unintended side effects. See 
    :ref:`building:Enabling or Disabling Features` for more information.
 
-building.html#enabling-or-disabling-features
-:ref:`advanced-features:Resource Tagged
-    Attestations`
-
 You can let Routinator process ASPA objects and include them in the published
 dataset, as well as the metrics, using the :option:`--enable-aspa` option
 or by setting ``enable-aspa`` to True in the :doc:`configuration

--- a/doc/manual/source/advanced-features.rst
+++ b/doc/manual/source/advanced-features.rst
@@ -21,6 +21,17 @@ object through which the holder of an Autonomous System (AS) can authorise
 one or more other ASes as its upstream providers. When validated, an ASPA's
 content can be used for detection and mitigation of route leaks.
 
+.. note:: 
+   
+   ASPA support is temporarily behind a feature flag while the draft is under
+   discussion in the IETF. This way operators can gain operational experience
+   without unintended side effects. See 
+   :ref:`building:Enabling or Disabling Features` for more information.
+
+building.html#enabling-or-disabling-features
+:ref:`advanced-features:Resource Tagged
+    Attestations`
+
 You can let Routinator process ASPA objects and include them in the published
 dataset, as well as the metrics, using the :option:`--enable-aspa` option
 or by setting ``enable-aspa`` to True in the :doc:`configuration

--- a/doc/manual/source/building.rst
+++ b/doc/manual/source/building.rst
@@ -154,7 +154,9 @@ Routinator currently has the following features:
 ``rta`` —  *Disabled* by default
     Let Routinator validate :ref:`advanced-features:Resource Tagged
     Attestations`.
-    
+``aspa`` —  *Disabled* by default
+    Let Routinator validate :ref:`advanced-features:ASPA` objects.
+
 To disable the features that are enabled by default, use the
 ``--no-default-features`` option. You can then choose which features you want
 using the ``--features`` option, listing each feature separated by commas. 

--- a/doc/manual/source/building.rst
+++ b/doc/manual/source/building.rst
@@ -155,7 +155,9 @@ Routinator currently has the following features:
     Let Routinator validate :ref:`advanced-features:Resource Tagged
     Attestations`.
 ``aspa`` —  *Disabled* by default
-    Let Routinator validate :ref:`advanced-features:ASPA` objects.
+    Let Routinator validate :ref:`advanced-features:ASPA` objects. *Note that
+    this is a temporary measure while the ASPA draft is under discussion in
+    the IETF.*
 
 To disable the features that are enabled by default, use the
 ``--no-default-features`` option. You can then choose which features you want

--- a/doc/manual/source/building.rst
+++ b/doc/manual/source/building.rst
@@ -155,9 +155,13 @@ Routinator currently has the following features:
     Let Routinator validate :ref:`advanced-features:Resource Tagged
     Attestations`.
 ``aspa`` —  *Disabled* by default
-    Let Routinator validate :ref:`advanced-features:ASPA` objects. *Note that
-    this is a temporary measure while the ASPA draft is under discussion in
-    the IETF.*
+    Let Routinator validate :ref:`advanced-features:ASPA` objects. 
+
+.. note:: 
+   
+   ASPA support is temporarily behind a feature flag while the draft is under
+   discussion in the IETF. This way operators can gain operational experience
+   without unintended side effects.
 
 To disable the features that are enabled by default, use the
 ``--no-default-features`` option. You can then choose which features you want

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -344,11 +344,6 @@ The available options are:
       If this option is present, BGPsec router keys will be processed
       during validation and included in the produced data set.
 
-.. option:: --enable-aspa
-
-      If this option is present, ASPA objects will be processed
-      during validation and included in the produced data set.
-
 .. option:: --dirty
 
       If this option is present, unused files and directories will not be
@@ -1177,11 +1172,6 @@ All values can be overridden via the command line options.
             A boolean value specifying whether BGPsec router keys should be
             included in the published dataset. If false or missing, no router
             keys will be included.
-
-      enable-aspa
-            A boolean value specifying whether ASPA payload should be
-            included in the published dataset. If false or missing, no ASPA
-            payload will be included.
 
       dirty
             A boolean value which, if true, specifies that unused files and

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "ROUTINATOR" "1" "Jan 04, 2023" "0.12.2-dev" "Routinator"
+.TH "ROUTINATOR" "1" "Jun 26, 2023" "0.13.0-dev" "Routinator"
 .SH NAME
 routinator \- RPKI relying party software
 .SH SYNOPSIS
@@ -171,7 +171,7 @@ was \fIwarn\fP\&. In all previous versions \fIwarn\fP was hard\-wired.
 .INDENT 0.0
 .TP
 .B \-\-unsafe\-vrps=policy
-This option defines how to deal with "unsafe VRPs." If the address
+This option defines how to deal with \(dqunsafe VRPs.\(dq If the address
 prefix of a VRP overlaps with any resources assigned to a CA that has
 been rejected because if failed to validate completely, the VRP is said
 to be unsafe since using it may lead to legitimate routes being flagged
@@ -505,7 +505,7 @@ identical to the CSV produced by the RIPE NCC Validator.
 .B csvext
 An extended version of csv each line contains these
 comma\-separated values: the rsync URI of the ROA the line
-is taken from (or "N/A" if it isn\(aqt from a ROA), the
+is taken from (or \(dqN/A\(dq if it isn\(aqt from a ROA), the
 autonomous system number, the prefix in slash notation, the
 maximum prefix length, the not\-before date and not\-after
 date of the validity of the ROA.
@@ -516,18 +516,35 @@ not currently supported by Routinator \-\- all entries will
 be in one single output file.
 .TP
 .B json
-The list is placed into a JSON object with a single element
-\fIroas\fP which contains an array of objects with four
+The list is placed into a JSON object with up to four
+members: \fIroas\fP contains the validated route origin
+authorizations, \fIrouterKeys\fP contains the validated
+BGPsec router keys, \fIaspas\fP contains the validated
+ASPA payload, and \fImetadata\fP contains some information
+about the validation run itself. Of the first three, only
+those members are present that have not been disabled or
+excluded.
+.sp
+The \fIroas\fP member contains an array of objects with four
 elements each: The autonomous system number of the network
 authorized to originate a prefix in \fIasn\fP, the prefix in
 slash notation in \fIprefix\fP, the maximum prefix length of
 the announced route in \fImaxLength\fP, and the trust anchor
-from which the authorization was derived in \fIta\fP\&. This
-format is identical to that produced by the RIPE NCC RPKI
-Validator except for different naming of the trust anchor.
-Routinator uses the name of the TAL file without the
-extension \fI\&.tal\fP whereas the RIPE NCC Validator has a
-dedicated name for each.
+from which the authorization was derived in \fIta\fP\&.
+.sp
+The \fIrouterKeys\fP member contains an array of objects with
+four elements each: The autonomous system using the router
+key is given in \fIasn\fP, the key identifier as a string of
+hexadecimal digits in \fISKI\fP, the actual public key as a
+Base 64 encoded string in \fIrouterPublicKey\fP, and the trust
+anchor from which the authorization was derived in \fIta\fP\&.
+.sp
+The \fIaspa\fP member contains an array of objects with four
+members each: The \fIcustomer\fP member contains the customer
+ASN, \fIafi\fP the address family as either \(dqipv4\(dq or \(dqipv6\(dq,
+\fIproviders\fP contains the provider ASN set as an array, and
+the trust anchor from which the authorization was derived
+in \fIta\fP\&.
 .sp
 The output object also includes a member named \fImetadata\fP
 which provides additional information. Currently, this is a
@@ -535,17 +552,24 @@ member \fIgenerated\fP which provides the time the list was
 generated as a Unix timestamp, and a member \fIgeneratedTime\fP
 which provides the same time but in the standard ISO date
 format.
+.sp
+If only route origins are included, this format is identical
+to that produced by the RIPE NCC
+RPKI Validator except for different naming of the trust
+anchor.
+Routinator uses the name of the TAL file without the
+extension \fI\&.tal\fP whereas the RIPE NCC Validator has a
+dedicated name for each.
 .TP
 .B jsonext
-The list is placed into a JSON object with three members:
-\fIroas\fP contains the validated route origin
+The list is placed into a JSON object with up to four
+members: \fIroas\fP contains the validated route origin
 authorizations, \fIrouterKeys\fP contains the validated
-BGPsec router keys, and \fImetadata\fP contains some information
-about the validation run itself.
-.sp
-All three members are always present, even if BGPsec has
-not been enabled. In this case, \fIrouterKeys\fP will simply
-be empty.
+BGPsec router keys, \fIaspas\fP contains the validated
+ASPA payload, and \fImetadata\fP contains some information
+about the validation run itself. Of the first three, only
+those members are present that have not been disabled or
+excluded.
 .sp
 The \fIroas\fP member contains an array of objects with four
 elements each: The autonomous system number of the network
@@ -561,6 +585,13 @@ key is given in \fIasn\fP, the key identifier as a string of
 hexadecimal digits in \fISKI\fP, the actual public key as a
 Base 64 encoded string in \fIrouterPublicKey\fP, and extended
 information about the source of the key is contained in
+\fIsource\fP\&.
+.sp
+The \fIaspa\fP member contains an array of objects with four
+members each: The \fIcustomer\fP member contains the customer
+ASN, \fIafi\fP the address family as either \(dqipv4\(dq or \(dqipv6\(dq,
+\fIproviders\fP contains the provider ASN set as an array, and
+information about the source of the data can be found in
 \fIsource\fP\&.
 .sp
 This source information the same for route origins and
@@ -663,7 +694,7 @@ the prefix is RPKI valid or invalid.
 The option can be given multiple times, in which case VRPs for all
 prefixes are provided. It can also be combined with one or more
 ASN selections. Then all matching VRPs are included. That is,
-selectors combine as "or" not "and".
+selectors combine as \(dqor\(dq not \(dqand\(dq.
 .UNINDENT
 .INDENT 7.0
 .TP
@@ -675,6 +706,12 @@ prefixes equal or less specific are included.
 Note that VRPs with more specific prefixes have no influence on
 whether a route is RPKI valid or invalid and therefore these VRPs
 are of an informational nature only.
+.UNINDENT
+.INDENT 7.0
+.TP
+.B \-\-no\-route\-origins, \-\-no\-router\-keys, \-\-no\-aspas
+These three options can be used to exclude the various payload
+types from being included in the output.
 .UNINDENT
 .UNINDENT
 .INDENT 0.0
@@ -1477,6 +1514,16 @@ The members \fIannounced\fP and \fIwithdrawn\fP contain arrays with route
 origins that have been announced and withdrawn, respectively, since the
 provided session and serial. If \fIreset\fP is \fItrue\fP, the \fIwithdrawn\fP
 member is not present.
+.TP
+.B /json\-delta/notify, /json\-delta/notify?session=session&serial=serial
+Returns a JSON object with two members \fIsession\fP and \fIserial\fP which
+contain the session ID and serial number of the current data set.
+.sp
+If the \fIsession\fP and \fIserial\fP query parameters are provided, and the
+session ID and serial number of the current data set are identical
+to the provided values, the request will not return until a new data
+set is available. This can be used as a means to get notified when
+the data set has been updated.
 .UNINDENT
 .sp
 In addition, the current set of VRPs is available for each output format at a
@@ -1491,6 +1538,12 @@ fields can be repeated multiple times.
 In addition, the query parameter \fBinclude=more\-specifics\fP will cause the
 inclusion of VRPs for more specific prefixes of prefixes given via
 \fBselect\-prefix\fP\&.
+.sp
+Finally, the query parameter \fBexclude\fP can be used to exclude certain
+payload types from the response. The values \fBrouteOrigins\fP, \fBrouterKeys\fP,
+and \fBaspas\fP disable inclusion of route origins, router keys, and ASPAs,
+respectively. The values can either be given in separate \fBexclude\fP
+parameters or included in one separated by commas.
 .sp
 These parameters work in the same way as the options of the same name to the
 \fI\%vrps\fP command.
@@ -1637,6 +1690,10 @@ strings.
 When receiving SIGUSR1, Routinator will attempt to reload the TALs and, if
 that succeeds, restart validation. If loading the TALs fails, Routinator
 will exit.
+.TP
+.B SIGUSR2: Re\-open log file
+When receiving SIGUSR2 and logging to a file is enabled, Routinator will
+re\-open the log file. If this fails, Routinator will exit.
 .UNINDENT
 .SH EXIT STATUS
 .sp

--- a/src/config.rs
+++ b/src/config.rs
@@ -595,6 +595,7 @@ impl Config {
         }
 
         // enable_aspa
+        #[cfg(feature = "aspa")]
         if args.enable_aspa {
             self.enable_aspa = true
         }
@@ -944,7 +945,13 @@ impl Config {
                     .unwrap_or(DEFAULT_MAX_CA_DEPTH)
             },
             enable_bgpsec: file.take_bool("enable-bgpsec")?.unwrap_or(false),
+
+            #[cfg(feature = "aspa")]
             enable_aspa: file.take_bool("enable-aspa")?.unwrap_or(false),
+
+            #[cfg(not(feature = "aspa"))]
+            enable_aspa: false,
+
             dirty_repository: file.take_bool("dirty")?.unwrap_or(false),
             validation_threads: {
                 file.take_small_usize("validation-threads")?
@@ -1370,6 +1377,7 @@ impl Config {
             (self.max_ca_depth as i64).into()
         );
         res.insert("enable-bgpsec".into(), self.enable_bgpsec.into());
+        #[cfg(feature = "aspa")]
         res.insert("enable-aspa".into(), self.enable_aspa.into());
         res.insert("dirty".into(), self.dirty_repository.into());
         res.insert(
@@ -1838,6 +1846,7 @@ struct GlobalArgs {
     enable_bgpsec: bool,
 
     /// Include ASPA in the data set
+    #[cfg(feature = "aspa")]
     #[arg(long)]
     enable_aspa: bool,
 

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -46,6 +46,7 @@ impl Response {
     }
 
     /// Returns a Moved Permanently response pointing to the given location.
+    #[allow(dead_code)]
     pub fn moved_permanently(location: &str) -> Self {
         ResponseBuilder::moved_permanently()
             .content_type(ContentType::TEXT)
@@ -174,6 +175,7 @@ impl ResponseBuilder {
     }
 
     /// Adds the Location header.
+    #[allow(dead_code)]
     pub fn location(self, location: &str) -> Self {
         ResponseBuilder {
             builder: self.builder.header(


### PR DESCRIPTION
This PR moves the config and command line options to enable ASPA behind a feature flag `aspa` which is not part of the default features. All the actual ASPA code is still there, it is just now impossible to enable ASPA without the flag.

This change is necessary because the ASPA object format and RTR PDUs are currently changing and we want to avoid people accidentally using a draft version that is incompatible with the final standard. The feature will be removed as soon as the standardization process has advanced sufficiently to avoid this risk.

The PR removes the `enable-aspa` config and command line options from the manual page.