### PR TITLE
Disable more ASPA code without the aspa feature.

### DIFF
--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -256,14 +256,16 @@ fn object_metrics<'a>(
             .label("state", "invalid")
             .value(metrics.invalid_roas);
 
-        target.multi(metric).label(group.label(), name)
-            .label("type", "aspa")
-            .label("state", "valid")
-            .value(metrics.valid_aspas);
-        target.multi(metric).label(group.label(), name)
-            .label("type", "aspa")
-            .label("state", "invalid")
-            .value(metrics.invalid_aspas);
+        #[cfg(feature = "aspa")] {
+            target.multi(metric).label(group.label(), name)
+                .label("type", "aspa")
+                .label("state", "valid")
+                .value(metrics.valid_aspas);
+            target.multi(metric).label(group.label(), name)
+                .label("type", "aspa")
+                .label("state", "invalid")
+                .value(metrics.invalid_aspas);
+        }
 
         target.multi(metric).label(group.label(), name)
             .label("type", "gbr")
@@ -416,19 +418,20 @@ fn payload_metrics<'a>(
                 .value(metrics.contributed);
         }
 
-        target.multi(valid_metric)
-            .label(group.label(), name)
-            .label("type", "aspas")
-            .value(metrics.aspas.valid);
-        target.multi(duplicate_metric)
-            .label(group.label(), name)
-            .label("type", "aspas")
-            .value(metrics.aspas.duplicate);
-        target.multi(contributed_metric)
-            .label(group.label(), name)
-            .label("type", "aspas")
-            .value(metrics.aspas.contributed);
-
+        #[cfg(feature = "aspa")] {
+            target.multi(valid_metric)
+                .label(group.label(), name)
+                .label("type", "aspas")
+                .value(metrics.aspas.valid);
+            target.multi(duplicate_metric)
+                .label(group.label(), name)
+                .label("type", "aspas")
+                .value(metrics.aspas.duplicate);
+            target.multi(contributed_metric)
+                .label(group.label(), name)
+                .label("type", "aspas")
+                .value(metrics.aspas.contributed);
+        }
     }
 }
 

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -598,8 +598,10 @@ fn json_publication_metrics(
     target.member_raw("validROAs", metrics.valid_roas);
     target.member_raw("invalidROAs", metrics.invalid_roas);
     target.member_raw("validGBRs", metrics.valid_gbrs);
-    target.member_raw("invalidASPAs", metrics.invalid_aspas);
-    target.member_raw("validASPAs", metrics.valid_aspas);
+    #[cfg(feature = "aspa")] {
+        target.member_raw("invalidASPAs", metrics.invalid_aspas);
+        target.member_raw("validASPAs", metrics.valid_aspas);
+    }
     target.member_raw("invalidGBRs", metrics.invalid_gbrs);
     target.member_raw("otherObjects", metrics.others);
 }
@@ -628,9 +630,11 @@ fn json_payload_metrics(
         target.member_object("routerKeys", |target| {
             json_vrps_metrics(target, &payload.router_keys, false)
         });
-        target.member_object("aspas", |target| {
-            json_vrps_metrics(target, &payload.aspas, false)
-        })
+        #[cfg(feature = "aspa")] {
+            target.member_object("aspas", |target| {
+                json_vrps_metrics(target, &payload.aspas, false)
+            });
+        }
     });
 }
 


### PR DESCRIPTION
This PR completely disables processing of .asa files and removes output of ASPA related metrics if the `aspa` feature is not enabled.

Previously, the change in ASPA format and the presence of a number of old-format ASPA objects in the repositories lead to a sequence of confusing error messages. Now .asa files are simply ignored when encountered.