### PR TITLE
Replace inconsistent mix of '.' and ';' output line terminators with only ';' terminators.

### DIFF
--- a/doc/manual/source/output-formats.rst
+++ b/doc/manual/source/output-formats.rst
@@ -407,38 +407,38 @@ generated in a wide range of output formats for various use cases.
                         ROAs:    4896 verified;
                         VRPs:    6248 verified,    5956 final;
                 router certs:       0 verified;
-                 router keys:       0 verified,       0 final.
-                       ASPAs:       0 verified,       0 final.
+                 router keys:       0 verified,       0 final;
+                       ASPAs:       0 verified,       0 final;
             apnic: 
                         ROAs:   25231 verified;
                         VRPs:  109978 verified,  109717 final;
                 router certs:       0 verified;
-                 router keys:       0 verified,       0 final.
-                       ASPAs:       2 verified,       2 final.
+                 router keys:       0 verified,       0 final;
+                       ASPAs:       2 verified,       2 final;
             arin: 
                         ROAs:   63188 verified;
                         VRPs:   78064 verified,   76941 final;
                 router certs:       1 verified;
-                 router keys:       1 verified,       1 final.
-                       ASPAs:       7 verified,       7 final.
+                 router keys:       1 verified,       1 final;
+                       ASPAs:       7 verified,       7 final;
             lacnic: 
                         ROAs:   18036 verified;
                         VRPs:   32565 verified,   30929 final;
                 router certs:       0 verified;
-                 router keys:       0 verified,       0 final.
-                       ASPAs:       0 verified,       0 final.
+                 router keys:       0 verified,       0 final;
+                       ASPAs:       0 verified,       0 final;
             ripe: 
                         ROAs:   39081 verified;
                         VRPs:  211048 verified,  211043 final;
                 router certs:       2 verified;
-                 router keys:       2 verified,       2 final.
-                       ASPAs:      57 verified,      57 final.
+                 router keys:       2 verified,       2 final;
+                       ASPAs:      57 verified,      57 final;
             total: 
                         ROAs:  150432 verified;
                         VRPs:  437903 verified,  434586 final;
                 router certs:       3 verified;
-                 router keys:       3 verified,       3 final.
-                       ASPAs:      66 verified,      66 final.
+                 router keys:       3 verified,       3 final;
+                       ASPAs:      66 verified,      66 final;
 
           .. versionchanged:: 0.11.0
              Reformat, sort alphabetically and add 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1399,12 +1399,12 @@ impl Summary {
                 tal.publication.valid_router_certs,
             ))?;
             line(format_args!(
-                "     router keys: {:7} verified, {:7} final.",
+                "     router keys: {:7} verified, {:7} final;",
                 tal.payload.router_keys.valid,
                 tal.payload.router_keys.contributed
             ))?;
             line(format_args!(
-                "           ASPAs: {:7} verified, {:7} final.",
+                "           ASPAs: {:7} verified, {:7} final;",
                 tal.publication.valid_aspas,
                 tal.payload.aspas.contributed
             ))?;
@@ -1424,12 +1424,12 @@ impl Summary {
             metrics.publication.valid_router_certs,
         ))?;
         line(format_args!(
-            "     router keys: {:7} verified, {:7} final.",
+            "     router keys: {:7} verified, {:7} final;",
             metrics.payload.router_keys.valid,
             metrics.payload.router_keys.contributed
         ))?;
         line(format_args!(
-            "           ASPAs: {:7} verified, {:7} final.",
+            "           ASPAs: {:7} verified, {:7} final;",
             metrics.publication.valid_aspas,
             metrics.payload.aspas.contributed
         ))?;


### PR DESCRIPTION
Note: If these formats are consumed by automation clients this might be a breaking change.