### PR TITLE
Exclude the manual from the cargo package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["rpki", "routing-security", "bgp"]
 categories = ["command-line-utilities"]
 license = "BSD-3-Clause"
 readme = "README.md"
-exclude = [ ".github" ]
+exclude = [ ".github", "doc/manual" ]
 
 [dependencies]
 arbitrary       = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
This PR excludes the `doc/manual` directory from the files included with the package uploaded to crates.io when publishing.