### PR TITLE
Replace `num_cpus` with `std::thread::available_parallelism`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,6 @@ dependencies = [
  "listenfd",
  "log",
  "nix",
- "num_cpus",
  "pin-project-lite",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ futures         = "0.3.4"
 hyper           = { version = "0.14", features = [ "server", "stream" ] }
 listenfd        = "1"
 log             = "0.4.8"
-num_cpus        = "1.12.0"
 pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::thread::available_parallelism;
 use std::time::Duration;
 use clap::{
     Command, Args, ArgAction, ArgMatches, FromArgMatches, Parser,
@@ -955,8 +956,11 @@ impl Config {
 
             dirty_repository: file.take_bool("dirty")?.unwrap_or(false),
             validation_threads: {
-                file.take_small_usize("validation-threads")?
-                    .unwrap_or_else(::num_cpus::get)
+                file.take_small_usize(
+                    "validation-threads"
+                )?.unwrap_or_else(|| {
+                    available_parallelism().map(|x| x.get()).unwrap_or(1)
+                })
             },
             refresh: {
                 Duration::from_secs(
@@ -1155,7 +1159,9 @@ impl Config {
             enable_bgpsec: false,
             enable_aspa: false,
             dirty_repository: DEFAULT_DIRTY_REPOSITORY,
-            validation_threads: ::num_cpus::get(),
+            validation_threads: {
+                    available_parallelism().map(|x| x.get()).unwrap_or(1)
+            },
             refresh: Duration::from_secs(DEFAULT_REFRESH),
             retry: Duration::from_secs(DEFAULT_RETRY),
             expire: Duration::from_secs(DEFAULT_EXPIRE),
@@ -2590,7 +2596,10 @@ mod test {
         assert!(config.extra_tals_dir.is_none());
         assert!(config.exceptions.is_empty());
         assert_eq!(config.strict, DEFAULT_STRICT);
-        assert_eq!(config.validation_threads, ::num_cpus::get());
+        assert_eq!(
+            config.validation_threads,
+            available_parallelism().map(|x| x.get()).unwrap_or(1),
+        );
         assert_eq!(config.refresh, Duration::from_secs(DEFAULT_REFRESH));
         assert_eq!(config.retry, Duration::from_secs(DEFAULT_RETRY));
         assert_eq!(config.expire, Duration::from_secs(DEFAULT_EXPIRE));
@@ -2673,7 +2682,10 @@ mod test {
         );
         assert!(config.exceptions.is_empty());
         assert!(!config.strict);
-        assert_eq!(config.validation_threads, ::num_cpus::get());
+        assert_eq!(
+            config.validation_threads,
+            available_parallelism().map(|x| x.get()).unwrap_or(1),
+        );
         assert_eq!(config.refresh, Duration::from_secs(DEFAULT_REFRESH));
         assert_eq!(config.retry, Duration::from_secs(DEFAULT_RETRY));
         assert_eq!(config.expire, Duration::from_secs(DEFAULT_EXPIRE));

--- a/src/config.rs
+++ b/src/config.rs
@@ -959,7 +959,7 @@ impl Config {
                 file.take_small_usize(
                     "validation-threads"
                 )?.unwrap_or_else(|| {
-                    available_parallelism().map(|x| x.get()).unwrap_or(1)
+                    Config::default_validation_threads()
                 })
             },
             refresh: {
@@ -1159,9 +1159,7 @@ impl Config {
             enable_bgpsec: false,
             enable_aspa: false,
             dirty_repository: DEFAULT_DIRTY_REPOSITORY,
-            validation_threads: {
-                    available_parallelism().map(|x| x.get()).unwrap_or(1)
-            },
+            validation_threads: Config::default_validation_threads(),
             refresh: Duration::from_secs(DEFAULT_REFRESH),
             retry: Duration::from_secs(DEFAULT_RETRY),
             expire: Duration::from_secs(DEFAULT_EXPIRE),
@@ -1186,6 +1184,11 @@ impl Config {
             group: None,
             tal_labels: HashMap::new(),
         }
+    }
+
+    /// Returns the default value for validation threads.
+    fn default_validation_threads() -> usize {
+        available_parallelism().map(|x| x.get()).unwrap_or(1)
     }
 
     /// Alters paths so that they are relative to a possible chroot.
@@ -2598,7 +2601,7 @@ mod test {
         assert_eq!(config.strict, DEFAULT_STRICT);
         assert_eq!(
             config.validation_threads,
-            available_parallelism().map(|x| x.get()).unwrap_or(1),
+            Config::default_validation_threads(),
         );
         assert_eq!(config.refresh, Duration::from_secs(DEFAULT_REFRESH));
         assert_eq!(config.retry, Duration::from_secs(DEFAULT_RETRY));
@@ -2684,7 +2687,7 @@ mod test {
         assert!(!config.strict);
         assert_eq!(
             config.validation_threads,
-            available_parallelism().map(|x| x.get()).unwrap_or(1),
+            Config::default_validation_threads()
         );
         assert_eq!(config.refresh, Duration::from_secs(DEFAULT_REFRESH));
         assert_eq!(config.retry, Duration::from_secs(DEFAULT_RETRY));


### PR DESCRIPTION
This PR removes the dependency on the num_cpus crate by using the standard library’s `std::thread::available_parallelism` instead.

Fixes #902.