### PR TITLE
Make dumping an empty cache succeed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches: 
       - main
+      - series-*
   pull_request:
     branches: 
       - main
+      - series-*
 jobs:
   test:
     name: test

--- a/doc/manual/source/requirements.txt
+++ b/doc/manual/source/requirements.txt
@@ -3,4 +3,5 @@ sphinx-version-warning==1.1.2
 sphinx-tabs==3.2.0
 sphinx-copybutton==0.4.0
 sphinx-notfound-page
+sphinx_rtd_theme
 toml

--- a/src/collector/rrdp.rs
+++ b/src/collector/rrdp.rs
@@ -215,6 +215,7 @@ impl Collector {
         repos: DumpRegistry,
         states: HashMap<uri::Https, RepositoryState>,
     ) -> Result<(), Failed> {
+        fatal::create_dir_all(repos.base_dir())?;
         let path = repos.base_dir().join("repositories.json");
         if let Err(err) = fs::write(
             &path, 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1119,7 +1119,7 @@ impl Config {
     ///
     /// Uses default values for everything except for the cache directory
     /// which needs to be provided.
-    fn default_with_paths(cache_dir: PathBuf) -> Self {
+    pub fn default_with_paths(cache_dir: PathBuf) -> Self {
         Config {
             cache_dir,
             no_rir_tals: false,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2033,7 +2033,9 @@ mod test {
         let src = tempfile::tempdir().unwrap();
         let target = tempfile::tempdir().unwrap();
         let target = target.path().join("dump");
-        let config = Config::default_with_paths(src.path().into());
+        let mut config = Config::default_with_paths(src.path().into());
+        config.rsync_command = "echo".into();
+        config.rsync_args = Some(vec!["some".into()]);
         let engine = Engine::new(&config, true).unwrap();
         engine.dump(&target).unwrap();
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2020,3 +2020,22 @@ pub trait ProcessPubPoint: Sized + Send + Sync {
     }
 }
 
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dump_empty_cache() {
+        let _ = crate::process::Process::init(); // May be inited already.
+        let src = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let target = target.path().join("dump");
+        let config = Config::default_with_paths(src.path().into());
+        let engine = Engine::new(&config, true).unwrap();
+        engine.dump(&target).unwrap();
+    }
+}
+


### PR DESCRIPTION
This PR fixes a number of error that can happen during `dump` when the cache is missing certain directories.

Fixes  #914.