### PR TITLE
Print a more meaningful message when decoding an object fails.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -789,9 +789,12 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             manifest_bytes.clone(), self.run.validation.strict
         ) {
             Ok(manifest) => manifest,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_manifests += 1;
-                warn!("{}: {}.", self.cert.rpki_manifest(), err);
+                warn!(
+                    "{}: failed to decode manifest.",
+                    self.cert.rpki_manifest()
+                );
                 return Ok(None)
             }
         };
@@ -916,9 +919,9 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         // Decode and validate the CRL.
         let mut crl = match Crl::decode(crl_bytes.clone()) {
             Ok(crl) => crl,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_crls += 1;
-                warn!("{}: {}.", crl_uri, err);
+                warn!("{}: failed to decode CRL.", crl_uri);
                 return Ok(None)
             }
         };
@@ -1048,8 +1051,11 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             stored_manifest.manifest().clone(), self.run.validation.strict
         ) {
             Ok(manifest) => manifest,
-            Err(err) => {
-                warn!("{}: {}.", self.cert.rpki_manifest(), err);
+            Err(_) => {
+                warn!(
+                    "{}: failed to decode manifest.",
+                    self.cert.rpki_manifest(),
+                );
                 self.metrics.invalid_manifests += 1;
                 return Err(Failed);
             }
@@ -1096,8 +1102,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         // Decode and validate the CRL.
         let mut crl = match Crl::decode(stored_manifest.crl().clone()) {
             Ok(crl) => crl,
-            Err(err) => {
-                warn!("{}: {}.", crl_uri, err);
+            Err(_) => {
+                warn!("{}: failed to decode CRL.", crl_uri);
                 self.metrics.invalid_manifests += 1;
                 self.metrics.invalid_crls += 1;
                 return Err(Failed)
@@ -1242,8 +1248,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
     ) -> Result<(), Failed> {
         let cert = match Cert::decode(content) {
             Ok(cert) => cert,
-            Err(err) => {
-                warn!("{}: {}.", uri, err);
+            Err(_) => {
+                warn!("{}: failed to decode certificate.", uri);
                 manifest.metrics.invalid_certs += 1;
                 return Ok(())
             }
@@ -1357,8 +1363,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             content, self.run.validation.strict
         ) {
             Ok(roa) => roa,
-            Err(err) => {
-                warn!("{}: {}.", uri, err);
+            Err(_) => {
+                warn!("{}: failed to decode ROA.", uri);
                 manifest.metrics.invalid_roas += 1;
                 return Ok(())
             }
@@ -1391,8 +1397,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 content, self.run.validation.strict
             ) {
                 Ok(aspa) => aspa,
-                Err(err) => {
-                    warn!("{}: {}.", uri, err);
+                Err(_) => {
+                    warn!("{}: failed to decode ASPA.", uri);
                     manifest.metrics.invalid_aspas += 1;
                     return Ok(())
                 }
@@ -1424,8 +1430,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             content, self.run.validation.strict
         ) {
             Ok(obj) => obj,
-            Err(err) => {
-                warn!("{}: {}.", uri, err);
+            Err(_) => {
+                warn!("{}: failed to decode GBR.", uri);
                 manifest.metrics.invalid_gbrs += 1;
                 return Ok(())
             }


### PR DESCRIPTION
This PR changes the error message printed when decoding any of the RPKI objects fails from whatever wondrous thing the decoder says to a generic message stating that decoding an object of a certain expected type failed.