### PR TITLE
Make dumping an empty cache succeed.

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -208,6 +208,7 @@ impl Collector {
         repos: DumpRegistry,
         states: HashMap<uri::Https, RepositoryState>,
     ) -> Result<(), Fatal> {
+        fatal::create_dir_all(repos.base_dir())?;
         let path = repos.base_dir().join("repositories.json");
         if let Err(err) = fs::write(
             &path, 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1119,7 +1119,7 @@ impl Config {
     ///
     /// Uses default values for everything except for the cache directory
     /// which needs to be provided.
-    fn default_with_paths(cache_dir: PathBuf) -> Self {
+    pub fn default_with_paths(cache_dir: PathBuf) -> Self {
         Config {
             cache_dir,
             no_rir_tals: false,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2049,3 +2049,24 @@ pub trait ProcessPubPoint: Sized + Send + Sync {
     }
 }
 
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dump_empty_cache() {
+        let _ = crate::process::Process::init(); // May be inited already.
+        let src = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let target = target.path().join("dump");
+        let mut config = Config::default_with_paths(src.path().into());
+        config.rsync_command = "echo".into();
+        config.rsync_args = Some(vec!["some".into()]);
+        let engine = Engine::new(&config, true).unwrap();
+        engine.dump(&target).unwrap();
+    }
+}
+

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -318,12 +318,12 @@ pub fn write_file(path: &Path, contents: &[u8]) -> Result<(), Failed> {
 
 //------------ copy_dir_all --------------------------------------------------
 
-/// Copies the content of a directory.
+/// Copies the content of a directory if it exists.
 ///
 /// Creates the target directory with `create_dir_all`.  Errors out if
 /// anything goes wrong.
 ///
-/// If the source director does not exist, does nothing.
+/// If the source directory does not exist, does nothing.
 pub fn copy_existing_dir_all(
     source: &Path, target: &Path
 ) -> Result<(), Failed> {

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -322,9 +322,17 @@ pub fn write_file(path: &Path, contents: &[u8]) -> Result<(), Failed> {
 ///
 /// Creates the target directory with `create_dir_all`.  Errors out if
 /// anything goes wrong.
-pub fn copy_dir_all(source: &Path, target: &Path) -> Result<(), Failed> {
+///
+/// If the source director does not exist, does nothing.
+pub fn copy_existing_dir_all(
+    source: &Path, target: &Path
+) -> Result<(), Failed> {
+    let source_dir = match read_existing_dir(source)? {
+        Some(entry) => entry,
+        None => return Ok(()),
+    };
     create_dir_all(target)?;
-    for entry in read_dir(source)? {
+    for entry in source_dir {
         let entry = entry?;
         if entry.is_file() {
             if let Err(err) = fs::copy(
@@ -338,7 +346,7 @@ pub fn copy_dir_all(source: &Path, target: &Path) -> Result<(), Failed> {
             }
         }
         else if entry.is_dir() {
-            copy_dir_all(
+            copy_existing_dir_all(
                 entry.path(),
                 &target.join(entry.file_name())
             )?;


### PR DESCRIPTION
This PR fixes a number of error that can happen during dump when the cache is missing certain directories.

This is a clone of #916 applied to current main. It differs slightly in that it cleans up the changes to the `utils::fatal` module.