### PR TITLE
Directly log rsync error output.

### DIFF
--- a/doc/manual/source/requirements.txt
+++ b/doc/manual/source/requirements.txt
@@ -1,7 +1,7 @@
-sphinx==4.3.2
+sphinx==7.2
 sphinx-version-warning==1.1.2
-sphinx-tabs==3.2.0
-sphinx-copybutton==0.4.0
+sphinx-tabs==3.4.4
+sphinx-copybutton==0.5.2
 sphinx-notfound-page
-sphinx_rtd_theme
+sphinx_rtd_theme==2.0
 toml


### PR DESCRIPTION
This PR changes the rsync collector to directly log all stderr output from the rsync command rather than collecting it and then blasting it out all at once which can cause issues with the syslog daemon on some systems.