### PR TITLE
Accept EC PRIVATE KEY items in PEM files. (0.13 backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.16.12"
 rpki            = { version = "0.17.2", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
-rustls-pemfile  = "1"
+rustls-pemfile  = "1.0.2"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"
 tempfile        = "3.1.0"

--- a/src/utils/tls.rs
+++ b/src/utils/tls.rs
@@ -96,7 +96,7 @@ fn read_key(key_path: &Path) -> Result<PrivateKey, ExitError> {
         })?;
 
         let bits = match item {
-            RSAKey(bits) | PKCS8Key(bits) => bits,
+            RSAKey(bits) | PKCS8Key(bits) | ECKey(bits) => bits,
             _ => continue
         };
         if key.is_some() {


### PR DESCRIPTION
This PR adds support for private keys marked as “EC PRIVATE KEY“ in the PEM files for TLS server configuration.

This is a backport of #909 to the 0.13 series.