### PR TITLE
Print a more meaningful message when decoding an object fails.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -818,7 +818,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             manifest_bytes.clone(), self.run.validation.strict
         ) {
             Ok(manifest) => manifest,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_manifests += 1;
                 warn!(
                     "{}: failed to decode manifest.",
@@ -948,7 +948,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         // Decode and validate the CRL.
         let mut crl = match Crl::decode(crl_bytes.clone()) {
             Ok(crl) => crl,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_crls += 1;
                 warn!("{}: failed to decode CRL.", crl_uri);
                 return Ok(None)
@@ -1080,7 +1080,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             stored_manifest.manifest().clone(), self.run.validation.strict
         ) {
             Ok(manifest) => manifest,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_manifests += 1;
                 warn!(
                     "{}: failed to decode manifest.",
@@ -1131,7 +1131,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         // Decode and validate the CRL.
         let mut crl = match Crl::decode(stored_manifest.crl().clone()) {
             Ok(crl) => crl,
-            Err(err) => {
+            Err(_) => {
                 self.metrics.invalid_manifests += 1;
                 self.metrics.invalid_crls += 1;
                 warn!("{}: failed to decode CRL.", crl_uri);
@@ -1277,7 +1277,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
     ) -> Result<(), Failed> {
         let cert = match Cert::decode(content) {
             Ok(cert) => cert,
-            Err(err) => {
+            Err(_) => {
                 manifest.metrics.invalid_certs += 1;
                 warn!("{}: failed to decode certificate.", uri);
                 return Ok(())
@@ -1392,7 +1392,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             content, self.run.validation.strict
         ) {
             Ok(roa) => roa,
-            Err(err) => {
+            Err(_) => {
                 manifest.metrics.invalid_roas += 1;
                 warn!("{}: failed to decode ROA.", uri);
                 return Ok(())
@@ -1459,7 +1459,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             content, self.run.validation.strict
         ) {
             Ok(obj) => obj,
-            Err(err) => {
+            Err(_) => {
                 manifest.metrics.invalid_gbrs += 1;
                 warn!("{}: failed to decode GBR.", uri);
                 return Ok(())

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -820,7 +820,10 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(manifest) => manifest,
             Err(err) => {
                 self.metrics.invalid_manifests += 1;
-                warn!("{}: {}.", self.cert.rpki_manifest(), err);
+                warn!(
+                    "{}: failed to decode manifest.",
+                    self.cert.rpki_manifest()
+                );
                 return Ok(None)
             }
         };
@@ -947,7 +950,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(crl) => crl,
             Err(err) => {
                 self.metrics.invalid_crls += 1;
-                warn!("{}: {}.", crl_uri, err);
+                warn!("{}: failed to decode CRL.", crl_uri);
                 return Ok(None)
             }
         };
@@ -1078,8 +1081,11 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         ) {
             Ok(manifest) => manifest,
             Err(err) => {
-                warn!("{}: {}.", self.cert.rpki_manifest(), err);
                 self.metrics.invalid_manifests += 1;
+                warn!(
+                    "{}: failed to decode manifest.",
+                    self.cert.rpki_manifest(),
+                );
                 return Err(Failed);
             }
         };
@@ -1126,9 +1132,9 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         let mut crl = match Crl::decode(stored_manifest.crl().clone()) {
             Ok(crl) => crl,
             Err(err) => {
-                warn!("{}: {}.", crl_uri, err);
                 self.metrics.invalid_manifests += 1;
                 self.metrics.invalid_crls += 1;
+                warn!("{}: failed to decode CRL.", crl_uri);
                 return Err(Failed)
             }
         };
@@ -1272,8 +1278,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         let cert = match Cert::decode(content) {
             Ok(cert) => cert,
             Err(err) => {
-                warn!("{}: {}.", uri, err);
                 manifest.metrics.invalid_certs += 1;
+                warn!("{}: failed to decode certificate.", uri);
                 return Ok(())
             }
         };
@@ -1387,8 +1393,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         ) {
             Ok(roa) => roa,
             Err(err) => {
-                warn!("{}: {}.", uri, err);
                 manifest.metrics.invalid_roas += 1;
+                warn!("{}: failed to decode ROA.", uri);
                 return Ok(())
             }
         };
@@ -1421,8 +1427,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             ) {
                 Ok(aspa) => aspa,
                 Err(err) => {
-                    warn!("{}: {}.", uri, err);
                     manifest.metrics.invalid_aspas += 1;
+                    warn!("{}: failed to decode ASPA.", uri);
                     return Ok(())
                 }
             };
@@ -1454,8 +1460,8 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         ) {
             Ok(obj) => obj,
             Err(err) => {
-                warn!("{}: {}.", uri, err);
                 manifest.metrics.invalid_gbrs += 1;
+                warn!("{}: failed to decode GBR.", uri);
                 return Ok(())
             }
         };


### PR DESCRIPTION
This PR changes the error message printed when decoding any of the RPKI objects fails from whatever wondrous thing the decoder says to a generic message stating that decoding an object of a certain expected type failed.

This PR is a port of #917.