### PR TITLE
Dockerfile: listen on both IPv4 and IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,4 +175,4 @@ EXPOSE 9556/tcp
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).
 ENTRYPOINT ["/sbin/tini", "--", "routinator"]
-CMD ["server", "--rtr", "0.0.0.0:3323", "--http", "0.0.0.0:8323", "--http", "0.0.0.0:9556"]
+CMD ["server", "--rtr", "[::]:3323", "--http", "[::]:8323", "--http", "[::]:9556"]


### PR DESCRIPTION
Follow up for https://github.com/NLnetLabs/routinator/issues/805.

Docker indeed doesn't support IPv6 properly, but a lot of other container runtimes do. This change makes routinator running in a container listen on both IPv4 (if available) and IPv6 (if available) by default.

Should I remove the documentation that was added in 603e44dc72a2b5542684969acdac1a51f0b13478 with this change?