### PR TITLE
Don’t have the RTR listener fail if a socket fails after accept.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
- "tokio-stream",
  "toml_edit",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ serde_json      = "1.0.57"
 tempfile        = "3.1.0"
 tokio           = { version = "1.24", features = [ "io-util", "macros", "process", "rt", "rt-multi-thread", "signal", "sync" ] }
 tokio-rustls    = "0.24.1"
-tokio-stream    = { version = "0.1", features = ["net"] }
 toml_edit       = "0.20"
 uuid            = "1.1"
 routinator-ui   = { version = "0.3.4", optional = true }


### PR DESCRIPTION
This PR changes the RTR listener to not fail the accept loop when setting up a stream after accepting it fails. Instead it will quietly drop the stream in this case and keep going.

As part of this, the PR also drops tokio-stream as a dependency and implements its own listener stream.

This PR fixes [CVE-2024-1622](https://www.nlnetlabs.nl/downloads/routinator/CVE-2024-1622.txt) reported by Yohei Nishimura, Atsushi Enomoto, Ruka Miyachi; Internet Multifeed Co., Japan.
