### PR TITLE
Update the current snapshot even if there is no delta.

### DIFF
--- a/src/payload/history.rs
+++ b/src/payload/history.rs
@@ -74,26 +74,28 @@ impl SharedHistory {
 
         let mut history = self.write();
         history.metrics = Some(metrics.into());
-        if let Some(delta) = delta {
+        let res = if let Some(delta) = delta {
             // Data has changed.
             info!(
                 "Delta with {} announced and {} withdrawn items.",
                 delta.announce_len(),
                 delta.withdraw_len(),
             );
-            history.current = Some(snapshot.into());
             history.push_delta(delta);
             true
         }
         else if current.is_none() {
             // This is the first snapshot ever.
-            history.current = Some(snapshot.into());
             true
         }
         else {
             // Nothing has changed.
             false
-        }
+        };
+        // Update the snapshot. The refresh time and object information may
+        // have changed.
+        history.current = Some(snapshot.into());
+        res
     }
 
     /// Marks the beginning of an update cycle.


### PR DESCRIPTION
This PR fixes an issue with calculating the refresh time under certain conditions by updating the current internal payload snapshot even if the delta to the previous snapshot is empty.

Because this snapshot also contains the expiry time of certificate first to expire and this time is used as the refresh time if it is closer than the configure refresh time (so the date derived from the expired certificate is removed as soon as possible), not updating the snapshot can lead to a refresh time in the past (effectively: an immediate refresh) if there is a second, longer living object for an expiring object.