### PR TITLE
Include the RRDP serial and session in metrics on Not Modified

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -829,6 +829,10 @@ impl<'a> RepositoryUpdate<'a> {
     ) -> Result<(), RunFailed> {
         info!("RRDP {}: Not modified.", self.rpki_notify);
         if let Some((mut archive, mut state)) = current {
+            // Copy serial and session to the metrics so they will still be
+            // present.
+            self.metrics.serial = Some(state.serial);
+            self.metrics.session = Some(state.session);
             state.touch(self.collector.config().fallback_time);
             archive.update_state(&state)?;
         }


### PR DESCRIPTION
This PR adds the current RRDP serial number and session ID to the RRDP server metrics when a Not Modified response is received from the server. This makes Prometheus have a constant value for this metrics.

Fixes #941.