### PR TITLE
Ensure that RRDP delta hashes don’t changes between updates.

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -905,6 +905,10 @@ impl<'a> RepositoryUpdate<'a> {
         mut archive: RrdpArchive,
         state: RepositoryState,
     ) -> Result<Option<SnapshotReason>, RunFailed> {
+        if let Err(reason) = notify.check_deltas(&state) {
+            return Ok(Some(reason))
+        }
+
         let deltas = match self.calc_deltas(notify.content(), &state) {
             Ok(deltas) => deltas,
             Err(reason) => return Ok(Some(reason)),
@@ -1013,6 +1017,5 @@ impl<'a> RepositoryUpdate<'a> {
 
         Ok(deltas)
     }
-
 }
 


### PR DESCRIPTION
This PR ensures that the hash of an RRDP delta with a given serial doesn’t change between updates. It stores the list of delta serials and hashes with the RRDP repository state in its archive and checks that hashes for serial numbers present both in the repository state and a new notification are equal. Otherwise falls back to a snapshot update.

This PR implements the [draft-ietf-sidrops-rrdp-desynchronization-00](https://datatracker.ietf.org/doc/draft-ietf-sidrops-rrdp-desynchronization/). The draft suggests to limit the number of deltas stored. We are not yet doing that. Instead this should be part of limiting the number of deltas taken out of the notification file when parsing in a follow up PR in rpki-rs.

This PR changes the format of the repository state and thus increases its version to 1. Strictly speaking, we never released version 0, but it’s been in _main_ from quite some time, so an increase feels prudent.