### PR TITLE
Enforce same origin for all resources of an RRDP server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.18.2-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=rrdp-same-origin#14df312c5475e33fa45d94475cf4bd460122fa3d"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git#d16df4f644f093423b3fc95410d8d326746e0197"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.18.2-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#6e3e89b5aa5ff9a4924150efabed004d20dd2a9f"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=rrdp-same-origin#14df312c5475e33fa45d94475cf4bd460122fa3d"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.17"
 #rpki            = { version = "0.18", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "rrdp-same-origin", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "1"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand            = "0.8.1"
 reqwest         = { version = "0.11.0", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.17"
 #rpki            = { version = "0.18", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "rrdp-same-origin", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "1"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/src/collector/rrdp/update.rs
+++ b/src/collector/rrdp/update.rs
@@ -98,6 +98,12 @@ impl Notification {
             warn!("RRDP {}: {}", uri, err);
             Failed
         })?;
+        if !content.has_matching_origins(&uri) {
+            warn!("RRDP {}: snapshot or delta files with different origin",
+                uri
+            );
+            return Err(Failed)
+        }
         content.sort_deltas();
         Ok(Notification { uri, content, etag, last_modified })
     }


### PR DESCRIPTION
This PR enforces that all resources fetched for an RRDP server have the same origin as the URI provided in the CA certificate. It checks this for all URIs provided in the server’s notification file and restricts redirects to URIs with the same origin.