### PR TITLE
Don’t try to delete a broken RRDP archive twice during cleanup.

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -533,7 +533,7 @@ impl<'a> Run<'a> {
                     Ok(some) => some,
                     Err(err) if err.should_retry() => {
                         // The RrdpArchive code has deleted the file already
-                        // in this case, so we musn’t do it again, so we
+                        // in this case, so we mustn’t do it again, so we
                         // pretend we want to keep it.
                         true
                     }

--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -531,7 +531,12 @@ impl<'a> Run<'a> {
                     entry_path.clone(), retain
                 ) {
                     Ok(some) => some,
-                    Err(err) if err.should_retry() => false,
+                    Err(err) if err.should_retry() => {
+                        // The RrdpArchive code has deleted the file already
+                        // in this case, so we musn’t do it again, so we
+                        // pretend we want to keep it.
+                        true
+                    }
                     Err(_) => return Err(Fatal),
                 };
                 if !keep {


### PR DESCRIPTION
This PR fixes an issue where the RRDP collector tried to delete a corrupt archive twice during cleanup resulting in a fatal error.