### PR TITLE
Limit the maximum number of deltas in an RRDP notification.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,12 +113,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1040,7 +1034,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1132,11 +1126,11 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.18.2-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git#d16df4f644f093423b3fc95410d8d326746e0197"
+version = "0.18.3-dev"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=limited-parse-notification#43ac83ba1fad42344329e2dedeacf7123fdabc92"
 dependencies = [
  "arbitrary",
- "base64 0.21.7",
+ "base64",
  "bcder",
  "bytes",
  "chrono",
@@ -1147,7 +1141,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "untrusted",
  "uuid",
 ]
@@ -1191,7 +1184,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -1530,17 +1523,6 @@ dependencies = [
  "either",
  "futures-util",
  "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,8 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.18.3-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=limited-parse-notification#43ac83ba1fad42344329e2dedeacf7123fdabc92"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7102b9a305889ef344e7b010dd256a53055ea1d436a7414277db053000f250ad"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.12.4", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.17"
-#rpki            = { version = "0.18", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "limited-parse-notification", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { version = "0.18.3", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "2.1.2"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand            = "0.8.1"
 reqwest         = { version = "0.12.4", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.17"
 #rpki            = { version = "0.18", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
-rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "limited-parse-notification", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
 rustls-pemfile  = "2.1.2"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -279,6 +279,13 @@ The available options are:
       larger than the value provided by this option, the snapshot is used
       instead. If the option is missing, the default of 100 is used.
 
+.. option:: --rrdp-max-delta-list-len=len
+ 
+      If the number of deltas included in the notification file of an RRDP
+      repository is larger than the value provied, the delta list is
+      considered empty instead and the snapshot is used. If the option is
+      missing, the default of 500 is used.
+
 .. option:: --rrdp-timeout=seconds
 
       Sets the timeout in seconds for any RRDP-related network operation,
@@ -1118,6 +1125,12 @@ All values can be overridden via the command line options.
             An integer value that specifies the maximum number of deltas
             necessary to update an RRDP repository before using the snapshot
             instead. If the value is missing, the default of 100 is used.
+
+      rrdp-max-delta-list-len
+            An integer value that specified the maximum bumber of deltas
+            listed the notification file of an RRDP repository before the
+            list is considered empty instead and the snapshot is user.
+            If the value is missing, the default of 500 is used.
 
       rrdp-timeout
             An integer value that provides a timeout in seconds for all

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -283,7 +283,7 @@ The available options are:
  
       If the number of deltas included in the notification file of an RRDP
       repository is larger than the value provided, the delta list is
-      considered empty instead and the snapshot is used. If the option is
+      considered empty and the snapshot is used instead. If the option is
       missing, the default of 500 is used.
 
 .. option:: --rrdp-timeout=seconds
@@ -1129,7 +1129,7 @@ All values can be overridden via the command line options.
       rrdp-max-delta-list-len
             An integer value that specifies the maximum number of deltas
             listed the notification file of an RRDP repository before the
-            list is considered empty instead and the snapshot is user.
+            list is considered empty and the snapshot is used instead.
             If the value is missing, the default of 500 is used.
 
       rrdp-timeout


### PR DESCRIPTION
This PR limits the number of entries in the notification file of an RRDP repository that Routinator is willing to consider. This can be set through the new `rrdp-max-delta-list-len` configuration value which defaults to a hopefully safe 500.

If this number is exceeded, the delta list will be considered to be empty and ignore, resulting in snapshots to be used.