### PR TITLE
Add --no-motd to and remove -l from rsync options.

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1089,8 +1089,10 @@ All values can be overridden via the command line options.
             The options ``-rtzO --delete`` are always passed to the command.
             The options listed in the option are added to it.
 
-            If the option is not provided, will add ``--contimeout=10`` if
-            that is supported by the rsync command and ``--no-motd`` always.
+            If the option is not provided, will add ``--contimeout=10``, if
+            it is supported by the rsync command, `--max-size` if the
+            ``max-object-size`` option has not been set to 0, and
+            ``--no-motd`` always.
 
       rsync-timeout
             An integer value specifying the number seconds an rsync command

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1083,14 +1083,14 @@ All values can be overridden via the command line options.
             default is simply *rsync*.
 
       rsync-args
-            A list of strings containing the arguments to be passed to the
-            rsync command. Each string is an argument of its own.
+            A list of strings containing additional arguments to be passed
+            to the rsync command. Each string is an argument of its own.
 
-            If this option is not provided, Routinator will try to find out
-            if your rsync understands the ``--contimeout`` option and, if so,
-            will set it to 10 thus letting connection attempts time out after
-            ten seconds. If your rsync is too old to support this option, no
-            arguments are used.
+            The options ``-rtzO --delete`` are always passed to the command.
+            The options listed in the option are added to it.
+
+            If the option is not provided, will add ``--contimeout=10`` if
+            that is supported by the rsync command and ``--no-motd`` always.
 
       rsync-timeout
             An integer value specifying the number seconds an rsync command

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1086,13 +1086,13 @@ All values can be overridden via the command line options.
             A list of strings containing additional arguments to be passed
             to the rsync command. Each string is an argument of its own.
 
-            The options ``-rtzO --delete`` are always passed to the command.
+            The options ``-rtO --delete`` are always passed to the command.
             The options listed in the option are added to it.
 
-            If the option is not provided, will add ``--contimeout=10``, if
-            it is supported by the rsync command, `--max-size` if the
-            ``max-object-size`` option has not been set to 0, and
-            ``--no-motd`` always.
+            If the option is not provided, Routinator will add ``-z`` and
+            ``--no-motd``, as well as ``--contimeout=10`` if it is supported
+            by the rsync command, and ``--max-size`` if the
+            ``max-object-size`` option has not been set to 0.
 
       rsync-timeout
             An integer value specifying the number seconds an rsync command

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -469,6 +469,8 @@ impl RsyncCommand {
             Some(ref args) => args.clone(),
             None => {
                 let mut args = Vec::new();
+                args.push("--no-motd".into());
+                args.push("-z".into());
                 let has_contimeout =
                    output.stdout.windows(12)
                    .any(|window| window == b"--contimeout");
@@ -478,7 +480,6 @@ impl RsyncCommand {
                 if let Some(max_size) = config.max_object_size {
                     args.push(format!("--max-size={}", max_size));
                 }
-                args.push("--no-motd".into());
                 args
             }
         };
@@ -619,7 +620,7 @@ impl RsyncCommand {
         for item in &self.args {
             cmd.arg(item);
         }
-        cmd.arg("-rtzO")
+        cmd.arg("-rtO")
            .arg("--delete")
            .arg(source.to_string())
            .arg(destination);

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -478,6 +478,7 @@ impl RsyncCommand {
                 if let Some(max_size) = config.max_object_size {
                     args.push(format!("--max-size={}", max_size));
                 }
+                args.push("--no-motd".into());
                 args
             }
         };
@@ -618,7 +619,7 @@ impl RsyncCommand {
         for item in &self.args {
             cmd.arg(item);
         }
-        cmd.arg("-rltz")
+        cmd.arg("-rtzO")
            .arg("--delete")
            .arg(source.to_string())
            .arg(destination);


### PR DESCRIPTION
This PR adds the `--no-motd` option to the default extra rsync options and removes `-l` from the base rsync options.

This means we now have `-rtO --delete` as the base options and `-z`, `--contimeout=10`, `--max-size`, and `--no-motd` as the default extra options that can be overwritten.

I think keeping `--delete` is fine – an attacker can always replace a file rather than deleting it and still break the publication point in question. We cannot limit the file patterns accepted as that would prevent adding new file types until all relying party installations are updated – RFC 9286 specifically says that missing fails lead to a failed fetch.