### PR TITLE
Prepare for release 0.14.0-rc2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "routinator"
-version = "0.14.0-dev"
+version = "0.14.0-rc2"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name = "routinator"
-version = "0.14.0-dev"
+version = "0.14.0-rc2"
 edition = "2021"
 rust-version = "1.70"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,13 +1,15 @@
 # Change Log
 
-## Unreleased next version
+## 0.14.0-rc2
+
+Released 2024-06-13.
 
 Bug fixes
 
 * Updated the bundled Routinator UI to version 0.4.1. This fixes internal
-  linking.
+  linking. ([#965])
 
-Other changes
+[#965]: https://github.com/NLnetLabs/routinator/pull/965
 
 
 ## 0.14.0-rc1

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "ROUTINATOR" "1" "Jun 10, 2024" "0.14.0-dev" "Routinator"
+.TH "ROUTINATOR" "1" "Jun 13, 2024" "0.14.0-rc2" "Routinator"
 .SH NAME
 routinator \- RPKI relying party software
 .SH SYNOPSIS


### PR DESCRIPTION
Bug fixes

* Updated the bundled Routinator UI to version 0.4.1. This fixes internal
  linking. ([#965])

[#965]: https://github.com/NLnetLabs/routinator/pull/965