### PR TITLE
Fedora has switched to SPDX licenses since 40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,10 +93,6 @@ systemd-units = { unit-name = "routinator", unit-scripts = "pkg/common", enable 
 [package.metadata.deb.variants.minimal]
 
 [package.metadata.generate-rpm]
-# "BSD" alone is the 3-clause license. Inheriting "license" from above causes rpmlint to
-# complain with "invalid-license".
-# See: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing
-license = "BSD"
 assets = [
     { source = "target/release/routinator", dest = "/usr/bin/routinator", mode = "755" },
     { source = "target/rpm/routinator.service", dest = "/lib/systemd/system/routinator.service", mode = "644" },


### PR DESCRIPTION
All new packages should have lincese in SPDX format on Fedora. There is no need for separate license in legacy format, that would be considered wrong.

On Fedora package, the license field should include all binary dependencies built into binary packages. Not just the project itself. It is not strictly neccessary until you try to have your generated rpm in official repos. But you might be aware of that. That is the cost of bundling all dependencies in form of static libraries.

Details on:
- https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/#_license_field
- https://docs.fedoraproject.org/en-US/packaging-guidelines/Rust/#_license_tags