### PR TITLE
Ubuntu Noble package support

### DIFF
--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -305,8 +305,9 @@ to get started.
    ``routinator-init`` and ``--accept-arin-rpa``
 .. versionadded:: 0.13.0
    Packages for Debian Bookworm 12 and RHEL 9
-.. versionadded:: tbd
-   Ubuntu packages for Noble 24.04 (LTS)
+.. versionadded:: 0.14.1
+   Ubuntu packages for Noble 24.04 (LTS), remove packages for Debian Stretch 9,
+   Ubuntu Xenial 16.04 (LTS), and Ubuntu Bionic 18.04 (LTS)
 
 Updating
 --------

--- a/doc/manual/source/installation.rst
+++ b/doc/manual/source/installation.rst
@@ -123,6 +123,7 @@ to get started.
        To install a Routinator package, you need the 64-bit version of one of
        these Ubuntu versions:
 
+         - Ubuntu Noble 24.04 (LTS)
          - Ubuntu Jammy 22.04 (LTS)
          - Ubuntu Focal 20.04 (LTS)
 
@@ -304,6 +305,8 @@ to get started.
    ``routinator-init`` and ``--accept-arin-rpa``
 .. versionadded:: 0.13.0
    Packages for Debian Bookworm 12 and RHEL 9
+.. versionadded:: tbd
+   Ubuntu packages for Noble 24.04 (LTS)
 
 Updating
 --------

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -80,7 +80,7 @@ test-mode:
   - 'fresh-install'
   - 'upgrade-from-published'
 
-# Disable upgrade testing on Rocky Linux 9 and Debian Bookworm as we haven't published any packages for
+# Disable upgrade testing on Ubuntu Noble as we haven't published any packages for
 # those O/S versions yet.
 test-exclude:
   - pkg: 'routinator'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -84,8 +84,5 @@ test-mode:
 # those O/S versions yet.
 test-exclude:
   - pkg: 'routinator'
-    image: 'rockylinux:9'
-    mode: 'upgrade-from-published'
-  - pkg: 'routinator'
-    image: 'debian:bookworm'
+    image: 'ubuntu:noble'
     mode: 'upgrade-from-published'

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -4,11 +4,9 @@
 pkg:
   - 'routinator'
 image:
-  - "ubuntu:xenial"   # ubuntu/16.04
-  - "ubuntu:bionic"   # ubuntu/18.04
   - "ubuntu:focal"    # ubuntu/20.04
   - "ubuntu:jammy"    # ubuntu/22.04
-  - "debian:stretch"  # debian/9
+  - "ubuntu:noble"    # ubuntu/24.04
   - "debian:buster"   # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12


### PR DESCRIPTION
As the end of 2024 is approaching, it might be nice to support Ubuntu 24.04 for the Routinator packages. This PR adds that.

(Ubuntu 22.04 packages probably work on Ubuntu 24.04 as well, but they deserve some dedicated packages too)