### PR TITLE
Relaxed prefix in validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,8 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7102b9a305889ef344e7b010dd256a53055ea1d436a7414277db053000f250ad"
+version = "0.18.4"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git#01024d58589e55f3658885b6700d537d1ca71f38"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pin-project-lite = "0.2.4"
 rand            = "0.8.1"
 reqwest         = { version = "0.12.4", default-features = false, features = ["blocking", "rustls-tls" ] }
 ring            = "0.17"
-rpki            = { version = "0.18.3", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { version = "0.18.3", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ], git = "https://github.com/NLnetLabs/rpki-rs.git" }
 rustls-pemfile  = "2.1.2"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/src/http/validity.rs
+++ b/src/http/validity.rs
@@ -103,7 +103,7 @@ fn validity(
         Ok(asn) => asn,
         Err(_) => return Response::bad_request()
     };
-    let prefix = match Prefix::from_str(prefix) {
+    let prefix = match Prefix::from_str_relaxed(prefix) {
         Ok(prefix) => prefix,
         Err(_) => return Response::bad_request()
     };


### PR DESCRIPTION
This PR changes parsing of the prefix portion of the query string or URI path in the validation HTTP request to allow (and ignore) non-zero bits in the host portion.