### PR TITLE
Remove "aspa" feature and make ASPA always available.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ syslog          = "6"
 [features]
 default = [ "socks", "ui"]
 arbitrary = [ "dep:arbitrary", "chrono/arbitrary", "rpki/arbitrary" ]
-aspa = []
 native-tls = [ "reqwest/native-tls" ]
 rta = []
 socks = [ "reqwest/socks" ]

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -351,6 +351,11 @@ The available options are:
       If this option is present, BGPsec router keys will be processed
       during validation and included in the produced data set.
 
+.. option:: --enable-aspa
+
+      If this option is present, ASPA assertions will be processed
+      during validation and included in the produced data set.
+
 .. option:: --dirty
 
       If this option is present, unused files and directories will not be
@@ -1189,6 +1194,11 @@ All values can be overridden via the command line options.
             A boolean value specifying whether BGPsec router keys should be
             included in the published dataset. If false or missing, no router
             keys will be included.
+
+      enable-aspa
+            A boolean value specifying whether ASPA assertions should be
+            included in the published dataset. If false or missing, no ASPA
+            assertions will be included.
 
       dirty
             A boolean value which, if true, specifies that unused files and

--- a/src/config.rs
+++ b/src/config.rs
@@ -617,7 +617,6 @@ impl Config {
         }
 
         // enable_aspa
-        #[cfg(feature = "aspa")]
         if args.enable_aspa {
             self.enable_aspa = true
         }
@@ -973,11 +972,7 @@ impl Config {
             },
             enable_bgpsec: file.take_bool("enable-bgpsec")?.unwrap_or(false),
 
-            #[cfg(feature = "aspa")]
             enable_aspa: file.take_bool("enable-aspa")?.unwrap_or(false),
-
-            #[cfg(not(feature = "aspa"))]
-            enable_aspa: false,
 
             dirty_repository: file.take_bool("dirty")?.unwrap_or(false),
             validation_threads: {
@@ -1413,7 +1408,6 @@ impl Config {
         );
         insert_int(&mut res, "max-ca-depth", self.max_ca_depth);
         insert(&mut res, "enable-bgpsec", self.enable_bgpsec);
-        #[cfg(feature = "aspa")]
         insert(&mut res, "enable-aspa", self.enable_aspa);
         insert(&mut res, "dirty", self.dirty_repository);
         insert_int(&mut res, "validation-threads", self.validation_threads);
@@ -1871,7 +1865,6 @@ struct GlobalArgs {
     enable_bgpsec: bool,
 
     /// Include ASPA in the data set
-    #[cfg(feature = "aspa")]
     #[arg(long)]
     enable_aspa: bool,
 

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -257,16 +257,14 @@ fn object_metrics<'a>(
             .label("state", "invalid")
             .value(metrics.invalid_roas);
 
-        #[cfg(feature = "aspa")] {
-            target.multi(metric).label(group.label(), name)
-                .label("type", "aspa")
-                .label("state", "valid")
-                .value(metrics.valid_aspas);
-            target.multi(metric).label(group.label(), name)
-                .label("type", "aspa")
-                .label("state", "invalid")
-                .value(metrics.invalid_aspas);
-        }
+        target.multi(metric).label(group.label(), name)
+            .label("type", "aspa")
+            .label("state", "valid")
+            .value(metrics.valid_aspas);
+        target.multi(metric).label(group.label(), name)
+            .label("type", "aspa")
+            .label("state", "invalid")
+            .value(metrics.invalid_aspas);
 
         target.multi(metric).label(group.label(), name)
             .label("type", "gbr")
@@ -419,20 +417,18 @@ fn payload_metrics<'a>(
                 .value(metrics.contributed);
         }
 
-        #[cfg(feature = "aspa")] {
-            target.multi(valid_metric)
-                .label(group.label(), name)
-                .label("type", "aspas")
-                .value(metrics.aspas.valid);
-            target.multi(duplicate_metric)
-                .label(group.label(), name)
-                .label("type", "aspas")
-                .value(metrics.aspas.duplicate);
-            target.multi(contributed_metric)
-                .label(group.label(), name)
-                .label("type", "aspas")
-                .value(metrics.aspas.contributed);
-        }
+        target.multi(valid_metric)
+            .label(group.label(), name)
+            .label("type", "aspas")
+            .value(metrics.aspas.valid);
+        target.multi(duplicate_metric)
+            .label(group.label(), name)
+            .label("type", "aspas")
+            .value(metrics.aspas.duplicate);
+        target.multi(contributed_metric)
+            .label(group.label(), name)
+            .label("type", "aspas")
+            .value(metrics.aspas.contributed);
     }
 }
 

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -598,10 +598,8 @@ fn json_publication_metrics(
     target.member_raw("validROAs", metrics.valid_roas);
     target.member_raw("invalidROAs", metrics.invalid_roas);
     target.member_raw("validGBRs", metrics.valid_gbrs);
-    #[cfg(feature = "aspa")] {
-        target.member_raw("invalidASPAs", metrics.invalid_aspas);
-        target.member_raw("validASPAs", metrics.valid_aspas);
-    }
+    target.member_raw("invalidASPAs", metrics.invalid_aspas);
+    target.member_raw("validASPAs", metrics.valid_aspas);
     target.member_raw("invalidGBRs", metrics.invalid_gbrs);
     target.member_raw("otherObjects", metrics.others);
 }
@@ -630,11 +628,9 @@ fn json_payload_metrics(
         target.member_object("routerKeys", |target| {
             json_vrps_metrics(target, &payload.router_keys, false)
         });
-        #[cfg(feature = "aspa")] {
-            target.member_object("aspas", |target| {
-                json_vrps_metrics(target, &payload.aspas, false)
-            });
-        }
+        target.member_object("aspas", |target| {
+            json_vrps_metrics(target, &payload.aspas, false)
+        });
     });
 }
 


### PR DESCRIPTION
This PR removes the `"aspa"` Cargo feature and thus makes ASPA always available and included in processing when enabled via the `enable-aspa` configuration option.

Fixes #988.