### PR TITLE
Remove duplicate construction of rtr_client_reset_queries

### DIFF
--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -679,18 +679,6 @@ async fn rtr_metrics(target: &mut Target, metrics: &SharedRtrServerMetrics) {
         });
 
         let item = Metric::new(
-            "rtr_client_reset_queries",
-            "number of of reset queries by a client address",
-            MetricType::Counter,
-        );
-        target.header(item);
-        metrics.fold_clients(0, |count, client| {
-            *count += client.reset_queries();
-        }).for_each(|(addr, count)| {
-            target.multi(item).label("addr", addr).value(count)
-        });
-
-        let item = Metric::new(
             "rtr_client_read_bytes",
             "number of bytes read from a client address",
             MetricType::Counter,


### PR DESCRIPTION
This change eliminates duplicate `rtr_client_reset_queries` in per-client RTR metrics.  Not only does the code still compile, it's running on one of our production RPKI servers now.  The metrics have reappeared in Prometheus after the initial validation phase and still look good.  And best of all, I no longer see messages such as this from our Prometheus scraper:

```
Jan 06 20:37:00 prom-scraper prometheus[1609784]: ts=2025-01-06T20:37:00.386Z caller=scrape.go:1754 level=warn component="scrape manager" scrape_pool=node-exporter target=http://rpki4.net.switch.ch:9556/metrics msg="Error on ingesting samples with different value but same timestamp" num_dropped=8
```

Before installing the patched version, such messages appeared in the Prometheus log every 15 seconds (`scrape_interval`).

Fixed #991