### PR TITLE
Enable Noble upgrade testing

### DIFF
--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -79,6 +79,4 @@ test-mode:
 # Disable upgrade testing on Ubuntu Noble as we haven't published any packages for
 # those O/S versions yet.
 test-exclude:
-  - pkg: 'routinator'
-    image: 'ubuntu:noble'
-    mode: 'upgrade-from-published'
+


### PR DESCRIPTION
Now that there is a release for Noble, we can do the test to see if upgrades work too.