### PR TITLE
Upgrade nix to 0.29.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -979,12 +979,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -1030,9 +1031,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1056,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
@@ -1410,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -1436,9 +1437,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "schannel"
@@ -1896,9 +1897,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "untrusted"
@@ -2213,9 +2214,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ uuid            = "1.1"
 
 
 [target.'cfg(unix)'.dependencies]
-nix             = { version = "0.27.1", features = ["fs", "mman", "net", "process", "socket", "user"] }
+nix             = { version = "0.29.0", features = ["fs", "mman", "net", "process", "socket", "user"] }
 syslog          = "6"
 
 [features]

--- a/src/process.rs
+++ b/src/process.rs
@@ -631,21 +631,20 @@ use self::noop::ServiceImpl;
 mod unix {
     use std::env::set_current_dir;
     use std::ffi::CString;
-    use std::os::unix::io::RawFd;
+    use std::fs::{File, OpenOptions};
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
     use std::path::Path;
     use log::error;
     use nix::libc;
-    use nix::fcntl::{flock, open, FlockArg, OFlag};
-    use nix::unistd::{
-        chown, chroot, fork, getpid, setgid, setuid, write, Gid, Uid
-    };
-    use nix::sys::stat::Mode;
+    use nix::fcntl::{Flock, FlockArg};
+    use nix::unistd::{chown, chroot, fork, getpid, setgid, setuid, Gid, Uid};
     use crate::config::Config;
     use crate::error::Failed;
 
     #[derive(Debug, Default)]
     pub struct ServiceImpl {
-        pid_file: Option<RawFd>,
+        pid_file: Option<Flock<File>>,
         uid: Option<Uid>,
         gid: Option<Gid>,
     }
@@ -690,7 +689,7 @@ mod unix {
         }
 
         pub fn drop_privileges(
-            self, config: &mut Config
+            mut self, config: &mut Config
         ) -> Result<(), Failed> {
             config.adjust_chroot_paths()?;
             if let Some(path) = config.chroot.as_ref() {
@@ -719,12 +718,13 @@ mod unix {
         }
 
         fn create_pid_file(&mut self, path: &Path) -> Result<(), Failed> {
-            let fd = match open(
-                path,
-                OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_TRUNC,
-                Mode::from_bits_truncate(0o666)
-            ) {
-                Ok(fd) => fd,
+            let file = OpenOptions::new()
+                .read(false).write(true)
+                .create(true).truncate(true)
+                .mode(0o666)
+                .open(path);
+            let file = match file {
+                Ok(file) => file,
                 Err(err) => {
                     error!("Fatal: failed to create PID file {}: {}",
                         path.display(), err
@@ -732,34 +732,29 @@ mod unix {
                     return Err(Failed)
                 }
             };
-            if let Err(err) = flock(fd, FlockArg::LockExclusiveNonblock) {
-                error!("Fatal: cannot lock PID file {}: {}",
-                    path.display(), err
-                );
-                return Err(Failed)
-            }
-            self.pid_file = Some(fd);
+            let file = match Flock::lock(
+                file, FlockArg::LockExclusiveNonblock
+            ) {
+                Ok(file) => file,
+                Err((_, err)) => {
+                    error!("Fatal: cannot lock PID file {}: {}",
+                        path.display(), err
+                    );
+                    return Err(Failed)
+                }
+            };
+            self.pid_file = Some(file);
             Ok(())
         }
 
-        fn write_pid_file(&self) -> Result<(), Failed> {
-            if let Some(pid_file) = self.pid_file {
+        fn write_pid_file(&mut self) -> Result<(), Failed> {
+            if let Some(pid_file) = self.pid_file.as_mut() {
                 let pid = format!("{}", getpid());
-                match write(pid_file, pid.as_bytes()) {
-                    Ok(len) if len == pid.len() => {}
-                    Ok(_) => {
-                        error!(
-                            "Fatal: failed to write PID to PID file: \
-                             short write"
-                        );
-                        return Err(Failed)
-                    }
-                    Err(err) => {
-                        error!(
-                            "Fatal: failed to write PID to PID file: {}", err
-                        );
-                        return Err(Failed)
-                    }
+                if let Err(err) = pid_file.write_all(pid.as_bytes()) {
+                    error!(
+                        "Fatal: failed to write PID to PID file: {}", err
+                    );
+                    return Err(Failed)
                 }
             }
             Ok(())

--- a/src/utils/archive.rs
+++ b/src/utils/archive.rs
@@ -1493,6 +1493,7 @@ mod mmapimpl {
     use std::borrow::Cow;
     use std::ffi::c_void;
     use std::io::{Seek, SeekFrom};
+    use std::ptr::NonNull;
     use nix::sys::mman::{MapFlags, MsFlags, ProtFlags, mmap, msync, munmap};
 
 
@@ -1500,7 +1501,7 @@ mod mmapimpl {
     #[derive(Debug)]
     pub struct Mmap {
         /// The pointer to the start of the memory.
-        ptr: *mut c_void,
+        ptr: NonNull<c_void>,
 
         /// The size of the memory,
         len: usize,
@@ -1529,7 +1530,7 @@ mod mmapimpl {
                         ProtFlags::PROT_READ
                     },
                     MapFlags::MAP_SHARED,
-                    Some(file),
+                    file,
                     0
                 )?
             };
@@ -1553,12 +1554,20 @@ mod mmapimpl {
     impl Mmap {
         /// Returns the whole memory map.
         fn as_slice(&self) -> &[u8] {
-            unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+            unsafe {
+                slice::from_raw_parts(
+                    self.ptr.as_ptr() as *const u8, self.len
+                )
+            }
         }
 
         /// Returns the whole memory map mutably.
         fn as_slice_mut(&mut self) -> &mut [u8] {
-            unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
+            unsafe {
+                slice::from_raw_parts_mut(
+                    self.ptr.as_ptr() as *mut u8, self.len
+                )
+            }
         }
     }
 

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -366,7 +366,7 @@ impl fmt::Display for IoErrorDisplay {
         use nix::errno::Errno;
 
         if matches!(
-            self.0.raw_os_error().map(Errno::from_i32),
+            self.0.raw_os_error().map(Errno::from_raw),
             Some(Errno::ENOSPC)
         ) {
             f.write_str("No space or inodes left on device")


### PR DESCRIPTION
This PR upgrades nix to 0.29 and implements the changes resulting from the updated APIs.

Fixes #1003 