### PR TITLE
Remove aspa cargo feature from docs, ref #990

### DIFF
--- a/doc/manual/source/advanced-features.rst
+++ b/doc/manual/source/advanced-features.rst
@@ -21,13 +21,6 @@ object through which the holder of an Autonomous System (AS) can authorise
 one or more other ASes as its upstream providers. When validated, an ASPA's
 content can be used for detection and mitigation of route leaks.
 
-.. note:: 
-   
-   ASPA support is temporarily behind a feature flag while the draft is under
-   discussion in the IETF. This way operators can gain operational experience
-   without unintended side effects. See 
-   :ref:`building:Enabling or Disabling Features` for more information.
-
 You can let Routinator process ASPA objects and include them in the published
 dataset, as well as the metrics, using the :option:`--enable-aspa` option
 or by setting ``enable-aspa`` to True in the :doc:`configuration

--- a/doc/manual/source/building.rst
+++ b/doc/manual/source/building.rst
@@ -154,14 +154,6 @@ Routinator currently has the following features:
 ``rta`` —  *Disabled* by default
     Let Routinator validate :ref:`advanced-features:Resource Tagged
     Attestations`.
-``aspa`` —  *Disabled* by default
-    Let Routinator validate :ref:`advanced-features:ASPA` objects. 
-
-.. note:: 
-   
-   ASPA support is temporarily behind a feature flag while the draft is under
-   discussion in the IETF. This way operators can gain operational experience
-   without unintended side effects.
 
 To disable the features that are enabled by default, use the
 ``--no-default-features`` option. You can then choose which features you want


### PR DESCRIPTION
ASPA is always compiled in from 0.14.1 through #990, but the docs were not updated.