### PR TITLE
Change Routinator refresh behaviour

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -856,6 +856,21 @@ These can be requested by providing different commands on the command line.
               The amount of seconds the server should wait after having
               finished updating and validating the local repository before
               starting to update again. The next update will be earlier if
+              objects in the repository expire earlier and min-refresh is set. 
+              The default value is 600 seconds.
+
+       .. option:: --min-refresh=seconds
+
+              The amount of seconds the server should at least wait after 
+              having finished updating and validating the local repository 
+              before starting to update again. If not set this will default to
+              refresh.
+
+       .. option:: --refresh=seconds
+
+              The amount of seconds the server should wait after having
+              finished updating and validating the local repository before
+              starting to update again. The next update will be earlier if
               objects in the repository expire earlier. The default value is
               600 seconds.
 

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -1331,8 +1331,13 @@ All values can be overridden via the command line options.
       refresh
             An integer value specifying the number of seconds Routinator
             should wait between consecutive validation runs in server mode.
-            The next validation run will happen earlier, if objects expire
-            earlier. The default is 600 seconds.
+            The next validation run will happen earlier if objects expire
+            earlier and min-refresh is set. The default is 600 seconds.
+
+      min-refresh
+            An integer value specifying the number of seconds Routinator
+            should at least wait between consecutive validation runs in server 
+            mode. If not set this will default to refresh. 
 
       retry
             An integer value specifying the number of seconds an RTR client

--- a/doc/routinator.1
+++ b/doc/routinator.1
@@ -1442,7 +1442,12 @@ must contain one or more certificates in PEM format.
 An integer value specifying the number of seconds Routinator
 should wait between consecutive validation runs in server mode.
 The next validation run will happen earlier, if objects expire
-earlier. The default is 600 seconds.
+earlier and min-refresh is set. The default is 600 seconds.
+.TP
+.B min-refresh
+An integer value specifying the number of seconds Routinator
+should at least wait between consecutive validation runs in server 
+mode. If not set this will default to refresh. 
 .TP
 .B retry
 An integer value specifying the number of seconds an RTR client

--- a/src/config.rs
+++ b/src/config.rs
@@ -283,6 +283,9 @@ pub struct Config {
     /// The refresh interval for repository validation.
     pub refresh: Duration,
 
+    /// The minimum refresh interval for repository validation.
+    pub min_refresh: Option<Duration>,
+
     /// The RTR retry inverval to be announced to a client.
     pub retry: Duration,
 
@@ -725,6 +728,11 @@ impl Config {
             self.refresh = Duration::from_secs(value)
         }
 
+        // min-refresh
+        if let Some(value) = args.min_refresh {
+            self.min_refresh = Some(Duration::from_secs(value))
+        }
+
         // retry
         if let Some(value) = args.retry {
             self.retry = Duration::from_secs(value)
@@ -987,6 +995,14 @@ impl Config {
                     file.take_u64("refresh")?.unwrap_or(DEFAULT_REFRESH)
                 )
             },
+            min_refresh: {
+                let val = file.take_u64("min-refresh")?;
+                if let Some(val) = val {
+                    Some(Duration::from_secs(val))
+                } else {
+                    None
+                }
+            },
             retry: {
                 Duration::from_secs(
                     file.take_u64("retry")?.unwrap_or(DEFAULT_RETRY)
@@ -1186,6 +1202,7 @@ impl Config {
             dirty_repository: DEFAULT_DIRTY_REPOSITORY,
             validation_threads: Config::default_validation_threads(),
             refresh: Duration::from_secs(DEFAULT_REFRESH),
+            min_refresh: None,
             retry: Duration::from_secs(DEFAULT_RETRY),
             expire: Duration::from_secs(DEFAULT_EXPIRE),
             history_size: DEFAULT_HISTORY_SIZE,
@@ -1905,9 +1922,13 @@ struct GlobalArgs {
 /// The server-related command line arguments.
 #[derive(Clone, Debug, Parser)]
 struct ServerArgs {
-    /// Refresh interval in seconds [default 3600]
+    /// Refresh interval in seconds [default 600]
     #[arg(long, value_name = "SECONDS")]
     refresh: Option<u64>,
+
+    /// Refresh interval in seconds [default 600]
+    #[arg(long, value_name = "SECONDS")]
+    min_refresh: Option<u64>,
 
     /// RTR retry interval in seconds [default 600]
     #[arg(long, value_name = "SECONDS")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1429,6 +1429,9 @@ impl Config {
         insert(&mut res, "dirty", self.dirty_repository);
         insert_int(&mut res, "validation-threads", self.validation_threads);
         insert_int(&mut res, "refresh", self.refresh.as_secs());
+        if let Some(min_refresh) = self.min_refresh.as_ref() {
+            insert_int(&mut res, "min-refresh", min_refresh.as_secs());
+        }
         insert_int(&mut res, "retry", self.retry.as_secs());
         insert_int(&mut res, "expire", self.expire.as_secs());
         insert_int(&mut res, "history-size", self.history_size);
@@ -2661,6 +2664,7 @@ mod test {
             Config::default_validation_threads(),
         );
         assert_eq!(config.refresh, Duration::from_secs(DEFAULT_REFRESH));
+        assert_eq!(config.min_refresh, None);
         assert_eq!(config.retry, Duration::from_secs(DEFAULT_RETRY));
         assert_eq!(config.expire, Duration::from_secs(DEFAULT_EXPIRE));
         assert_eq!(config.history_size, DEFAULT_HISTORY_SIZE);

--- a/src/config.rs
+++ b/src/config.rs
@@ -996,12 +996,7 @@ impl Config {
                 )
             },
             min_refresh: {
-                let val = file.take_u64("min-refresh")?;
-                if let Some(val) = val {
-                    Some(Duration::from_secs(val))
-                } else {
-                    None
-                }
+                file.take_u64("min-refresh")?.map(Duration::from_secs)
             },
             retry: {
                 Duration::from_secs(


### PR DESCRIPTION
This PR adds support for a min-refresh option in the configuration, and changes the default behaviour relating to #1025

Currently Routinator will look at the earliest expiry time of any non-expired object in the RPKI, and set the refresh time to that time. The validation of all objects in the RPKI takes some time. In this time, an object that was already verified as valid might have expired before the run completes. This would cause Routinator to immediately run again after completion.

This PR changes that behaviour by introducing a minimum duration to wait, and if not set to wait the `refresh` time (by default 10 minutes).