### PR TITLE
Use Stream Buffers to Read/Write validation input/outputs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ New
 Bug fixes
 
 Other changes
+* Improved performance of file system operations on validate subcommand.
+  ([#1043])
 
 * Add package.homepage to Cargo.toml ([#1024])
 * Added building packages for RHEL 10. ([#1034])

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -805,8 +805,8 @@ impl Validate {
                 Ok(validity::RequestList::single(prefix, asn))
             }
             ValidateWhat::File(ref path) => {
-                let mut file = match fs::File::open(path) {
-                    Ok(file) => file,
+                let mut stream = match fs::File::open(path) {
+                    Ok(file) => io::BufReader::new(file),
                     Err(err) => {
                         error!(
                             "Failed to open input file '{}': {}'",
@@ -817,7 +817,7 @@ impl Validate {
                 };
                 if self.json {
                     validity::RequestList::from_json_reader(
-                        &mut file
+                        &mut stream
                     ).map_err(|err| {
                         error!(
                             "Failed to read input file '{}': {}'",
@@ -828,7 +828,7 @@ impl Validate {
                 }
                 else {
                     validity::RequestList::from_plain_reader(
-                        io::BufReader::new(file)
+                        &mut stream
                     ).map_err(|err| {
                         error!(
                             "Failed to read input file '{}': {}'",


### PR DESCRIPTION
This pull request improves validation input/output file operations' performance, by using buffers.
JSON readers/writers are tend to do small file system operations very frequently, so buffering is essential.

Simple benchmark shows 5% win in total (including startup ROA validations):

<img width="1597" height="940" alt="image" src="https://github.com/user-attachments/assets/fdad72bd-dd1b-43e6-801b-e9a56d04a6b1" />
