### PR TITLE
Add logging for from directory

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -151,7 +151,10 @@ impl Collector {
     #[allow(clippy::mutable_key_type)]
     pub fn dump(&self, dir: &Path) -> Result<(), Fatal> {
         let dir = dir.join("rrdp");
-        debug!("Dumping RRDP collector content to {}", dir.display());
+        debug!("Dumping RRDP collector content from {} to {}", 
+            self.working_dir.display(), 
+            dir.display()
+        );
         let mut registry = DumpRegistry::new(dir);
         let mut states = HashMap::new();
         for entry in fatal::read_dir(&self.working_dir)? {

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -130,7 +130,10 @@ impl Collector {
     /// Dumps the content of the rsync collector.
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
         let target = dir.join("rsync");
-        debug!("Dumping rsync collector content to {}", target.display());
+        debug!("Dumping rsync collector content from {} to {}", 
+            self.working_dir.base.display(), 
+            target.display()
+        );
 
         if let Err(err) = fs::remove_dir_all(&target) {
             if err.kind() != io::ErrorKind::NotFound {

--- a/src/store.rs
+++ b/src/store.rs
@@ -161,7 +161,10 @@ impl Store {
     pub fn dump(&self, dir: &Path) -> Result<(), Failed> {
         self.dump_ta_certs(dir)?;
         let dir = dir.join("store");
-        debug!("Dumping store content to {}", dir.display());
+        debug!("Dumping store content from {} to {}", 
+            self.path.display(), 
+            dir.display()
+        );
         fatal::remove_dir_all(&dir)?;
         let mut repos = DumpRegistry::new(dir);
         self.dump_tree(&self.rsync_repository_path(), &mut repos)?;


### PR DESCRIPTION
Because it can sometimes be unclear where `routinator dump` gets its data from, extend the current debug logging with information about where the data comes from: 

```
$ routinator -c routinator.conf dump -o /tmp/routinator2
[DEBUG] Dumping trust anchor certificates to /tmp/routinator2/ta
[DEBUG] Trust anchor certificate dump complete.
[DEBUG] Dumping store content from /home/koen/.rpki-cache/repository/stored to /tmp/routinator2/store
[DEBUG] Store dump complete.
[DEBUG] Dumping RRDP collector content from /home/koen/.rpki-cache/repository/rrdp to /tmp/routinator2/rrdp
[DEBUG] RRDP collector dump complete.
[DEBUG] Dumping rsync collector content from /home/koen/.rpki-cache/repository/rsync to /tmp/routinator2/rsync
[DEBUG] Rsync collector dump complete.
```