### PR TITLE
Fix warnings from new mismatched_lifetime_syntaxes lint.

### DIFF
--- a/src/collector/base.rs
+++ b/src/collector/base.rs
@@ -93,7 +93,7 @@ impl Collector {
     }
 
     /// Starts a new validation run using this collector.
-    pub fn start(&self) -> Run {
+    pub fn start(&self) -> Run<'_> {
         Run::new(self)
     }
 

--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -144,7 +144,7 @@ impl Collector {
         Ok(())
     }
 
-    pub fn start(&self) -> Run {
+    pub fn start(&self) -> Run<'_> {
         Run::new(self)
     }
 

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -123,7 +123,7 @@ impl Collector {
     }
 
     /// Start a validation run on the collector.
-    pub fn start(&self) -> Run {
+    pub fn start(&self) -> Run<'_> {
         Run::new(self)
     }
 
@@ -775,7 +775,7 @@ impl Module {
     /// function may have to convert upper ASCII case letters into lower case
     /// to create a canonical value. If this has to happen, an [`OwnedModule`]
     /// is returned via the cow.
-    pub fn from_uri(uri: &uri::Rsync) -> Cow<Module> {
+    pub fn from_uri(uri: &uri::Rsync) -> Cow<'_, Module> {
         match uri.canonical_module() {
             Cow::Borrowed(s) => {
                 Cow::Borrowed(unsafe { Module::from_str(s) })

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -296,7 +296,7 @@ impl Engine {
     /// The method returns a [`Run`] that drives the validation run.
     pub fn start<P: ProcessRun>(
         &self, processor: P
-    ) -> Result<Run<P>, Failed> {
+    ) -> Result<Run<'_, P>, Failed> {
         info!("Using the following TALs:");
         for tal in &self.tals {
             info!("  * {}", tal.info().name());

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -814,7 +814,7 @@ impl Target {
         metric.header(self)
     }
     
-    pub fn multi(&mut self, metric: Metric) -> LabelValue {
+    pub fn multi(&mut self, metric: Metric) -> LabelValue<'_> {
         metric.multi(self)
     }
 }
@@ -869,7 +869,7 @@ impl Metric {
         ).expect("writing to string");
     }
 
-    fn multi(self, target: &mut Target) -> LabelValue {
+    fn multi(self, target: &mut Target) -> LabelValue<'_> {
         LabelValue::new(self, target)
     }
 }

--- a/src/payload/delta.rs
+++ b/src/payload/delta.rs
@@ -162,7 +162,7 @@ impl PayloadDelta {
     /// Returns an iterator over the actions.
     pub fn actions(
         &self
-    ) -> impl Iterator<Item = (PayloadRef, Action)> + '_ {
+    ) -> impl Iterator<Item = (PayloadRef<'_>, Action)> + '_ {
         self.origin_actions().map(|(p, a)| (p.into(), a)).chain(
             self.router_key_actions().map(|(p, a)| (p.into(), a))
         ).chain(
@@ -664,7 +664,7 @@ impl DeltaArcIter {
 }
 
 impl PayloadDiff for DeltaArcIter {
-    fn next(&mut self) -> Option<(PayloadRef, Action)> {
+    fn next(&mut self) -> Option<(PayloadRef<'_>, Action)> {
         if matches!(self.current_type, PayloadType::Origin) {
             if let Some(res) = self.delta.origins.get(self.next) {
                 self.next += 1;

--- a/src/payload/info.rs
+++ b/src/payload/info.rs
@@ -43,7 +43,7 @@ impl PayloadInfo {
     }
 
     /// Returns an iterator over the chain of information.
-    pub fn iter(&self) -> PayloadInfoIter {
+    pub fn iter(&self) -> PayloadInfoIter<'_> {
         PayloadInfoIter { info: Some(self) }
     }
 

--- a/src/payload/snapshot.rs
+++ b/src/payload/snapshot.rs
@@ -83,7 +83,7 @@ impl PayloadSnapshot {
     /// Returns an iterator over all payload.
     pub fn payload(
         &self
-    ) -> impl Iterator<Item = PayloadRef> {
+    ) -> impl Iterator<Item = PayloadRef<'_>> {
         self.origins.iter_payload().chain(
             self.router_keys.iter_payload()
         ).chain(
@@ -108,7 +108,7 @@ impl PayloadSnapshot {
     /// Returns an iterator over route origins as payload.
     pub fn origin_payload(
         &self
-    ) -> impl Iterator<Item = PayloadRef> {
+    ) -> impl Iterator<Item = PayloadRef<'_>> {
         self.origins.iter_payload()
     }
 
@@ -122,7 +122,7 @@ impl PayloadSnapshot {
     /// Returns an iterator over router keys as payload.
     pub fn router_key_payload(
         &self
-    ) -> impl Iterator<Item = PayloadRef> {
+    ) -> impl Iterator<Item = PayloadRef<'_>> {
         self.router_keys.iter_payload()
     }
 
@@ -136,7 +136,7 @@ impl PayloadSnapshot {
     /// Returns an iterator over ASPAs as payload.
     pub fn aspa_payload(
         &self
-    ) -> impl Iterator<Item = PayloadRef> {
+    ) -> impl Iterator<Item = PayloadRef<'_>> {
         self.aspas.iter_payload()
     }
 
@@ -211,13 +211,17 @@ impl<P> PayloadCollection<P> {
     }
 
     /// Returns an iterator over the payload.
-    pub fn iter_ref(&self) -> impl Iterator<Item = (PayloadRef, &PayloadInfo)>
-    where for<'a> &'a P: Into<PayloadRef<'a>> {
+    pub fn iter_ref(
+        &self
+    ) -> impl Iterator<Item = (PayloadRef<'_>, &PayloadInfo)>
+    where
+        for<'a> &'a P: Into<PayloadRef<'a>>
+    {
         self.vec.iter().map(|item| ((&item.0).into(), &item.1))
     }
 
     /// Returns an iterator over just the payload.
-    pub fn iter_payload(&self) -> impl Iterator<Item = PayloadRef>
+    pub fn iter_payload(&self) -> impl Iterator<Item = PayloadRef<'_>>
     where for<'a> &'a P: Into<PayloadRef<'a>> {
         self.vec.iter().map(|item| (&item.0).into())
     }
@@ -294,7 +298,9 @@ impl SnapshotArcIter {
     }
 
     /// Returns the next item and its information.
-    pub fn next_with_info(&mut self) -> Option<(PayloadRef, &PayloadInfo)> {
+    pub fn next_with_info(
+        &mut self
+    ) -> Option<(PayloadRef<'_>, &PayloadInfo)> {
         if matches!(self.current_type, PayloadType::Origin) {
             if let Some(res) = self.snapshot.origins.get(self.next) {
                 self.next += 1;
@@ -319,7 +325,7 @@ impl SnapshotArcIter {
 }
 
 impl PayloadSet for SnapshotArcIter {
-    fn next(&mut self) -> Option<PayloadRef> {
+    fn next(&mut self) -> Option<PayloadRef<'_>> {
         self.next_with_info().map(|(res, _)| res)
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -153,7 +153,7 @@ impl Store {
     }
 
     /// Start a validation run with the store.
-    pub fn start(&self) -> Run {
+    pub fn start(&self) -> Run<'_> {
         Run::new(self)
     }
 

--- a/src/utils/archive.rs
+++ b/src/utils/archive.rs
@@ -204,7 +204,7 @@ impl<Meta> Archive<Meta> {
     /// Returns an iterator over all the objects in the archive.
     ///
     /// The iterator will _not_ traverse objects in any kind of order.
-    pub fn objects(&self) -> Result<ObjectsIter<Meta>, ArchiveError> {
+    pub fn objects(&self) -> Result<ObjectsIter<'_, Meta>, ArchiveError> {
         ObjectsIter::new(self)
     }
 }
@@ -221,7 +221,7 @@ impl<Meta: ObjectMeta> Archive<Meta> {
     pub fn fetch(
         &self,
         name: &[u8],
-    ) -> Result<Cow<[u8]>, FetchError> {
+    ) -> Result<Cow<'_, [u8]>, FetchError> {
         let hash = self.meta.hash_name(name);
         let found = match self.find(hash, name)? {
             Some(found) => found,
@@ -265,7 +265,7 @@ impl<Meta: ObjectMeta> Archive<Meta> {
         &self,
         name: &[u8],
         check: impl FnOnce(&Meta) -> Result<(), Meta::ConsistencyError>,
-    ) -> Result<Cow<[u8]>, AccessError<Meta::ConsistencyError>> {
+    ) -> Result<Cow<'_, [u8]>, AccessError<Meta::ConsistencyError>> {
         let hash = self.meta.hash_name(name);
         let found = match self.find(hash, name)? {
             Some(found) => found,
@@ -1022,7 +1022,7 @@ impl ObjectHeader {
     /// Reads the header and name from the given archive position.
     fn read_with_name(
         storage: &Storage, start: u64
-    ) -> Result<(Self, Cow<[u8]>), ArchiveError> {
+    ) -> Result<(Self, Cow<'_, [u8]>), ArchiveError> {
         storage.read(start, |read| {
             let header = Self::read_from(read)?;
             let name = read.read_slice(header.name_len)?;
@@ -1778,7 +1778,7 @@ mod mmapimpl {
         /// This will always be borrowed.
         pub fn read(
             &self, start: u64, len: usize,
-        ) -> Result<(Cow<[u8]>, u64), io::Error> {
+        ) -> Result<(Cow<'_, [u8]>, u64), io::Error> {
             let start = match usize::try_from(start) {
                 Ok(start) => start,
                 Err(_) => {

--- a/src/utils/fatal.rs
+++ b/src/utils/fatal.rs
@@ -116,7 +116,7 @@ impl Iterator for ReadDir<'_> {
 //------------ read_dir ------------------------------------------------------
 
 /// Returns an iterator over a directory, logging fatal errors on any error.
-pub fn read_dir(path: &Path) -> Result<ReadDir, Failed> {
+pub fn read_dir(path: &Path) -> Result<ReadDir<'_>, Failed> {
     match fs::read_dir(path) {
         Ok(iter) => Ok(ReadDir { path, iter }),
         Err(err) => {
@@ -135,7 +135,7 @@ pub fn read_dir(path: &Path) -> Result<ReadDir, Failed> {
 /// Returns an iterator over an existing directory.
 ///
 /// Returns `None` if the repository doesn’t exist.
-pub fn read_existing_dir(path: &Path) -> Result<Option<ReadDir>, Failed> {
+pub fn read_existing_dir(path: &Path) -> Result<Option<ReadDir<'_>>, Failed> {
     match fs::read_dir(path) {
         Ok(iter) => Ok(Some(ReadDir { path, iter })),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),

--- a/src/utils/sync.rs
+++ b/src/utils/sync.rs
@@ -29,7 +29,7 @@ impl<T: ?Sized> RwLock<T> {
     /// The method panics if the lock is poisoned, i.e., if a writer panicked
     /// while holding the write lock. It may also panic if the current thread
     /// already holds the lock.
-    pub fn read(&self) -> RwLockReadGuard<T> {
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
         self.0.read().expect("acquiring a poisoned rwlock")
     }
 
@@ -43,7 +43,7 @@ impl<T: ?Sized> RwLock<T> {
     /// The method panics if the lock is poisoned, i.e., if a writer panicked
     /// while holding the write lock. It may also panic if the current thread
     /// already holds the lock.
-    pub fn write(&self) -> RwLockWriteGuard<T> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
         self.0.write().expect("acquiring a poisoned rwlock")
     }
 }
@@ -82,7 +82,7 @@ impl<T: ?Sized> Mutex<T> {
     /// The method panics if the lock is poisoned, i.e., if a panic occured
     /// while holding the lock. It may also panic if the current thread
     /// already holds the lock.
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
         self.0.lock().expect("acquiring a poisoned mutex")
     }
 }

--- a/src/utils/uri.rs
+++ b/src/utils/uri.rs
@@ -13,7 +13,7 @@ use rpki::crypto::{Digest, DigestAlgorithm};
 /// An extension trait for URI kind of types.
 pub trait UriExt {
     fn get_authority(&self) -> &str;
-    fn unique_components(&self) -> (Cow<str>, Digest);
+    fn unique_components(&self) -> (Cow<'_, str>, Digest);
 
     /// Returns whether the URI has a dubious authority.
     ///
@@ -80,7 +80,7 @@ impl UriExt for uri::Https {
         self.authority()
     }
 
-    fn unique_components(&self) -> (Cow<str>, Digest) {
+    fn unique_components(&self) -> (Cow<'_, str>, Digest) {
         let authority = self.canonical_authority();
         let mut digest = DigestAlgorithm::sha256().start();
         digest.update(b"https://");
@@ -96,7 +96,7 @@ impl UriExt for uri::Rsync {
         self.authority()
     }
 
-    fn unique_components(&self) -> (Cow<str>, Digest) {
+    fn unique_components(&self) -> (Cow<'_, str>, Digest) {
         let authority = self.canonical_authority();
         let mut digest = DigestAlgorithm::sha256().start();
         digest.update(b"rsync://");


### PR DESCRIPTION
This PR fixes the warnings from the `mismatched_lifetime_syntaxes` lint that will appear in Rust 1.89.