### PR TITLE
Produce JSON body for API error responses.

### DIFF
--- a/src/http/dispatch.rs
+++ b/src/http/dispatch.rs
@@ -46,7 +46,7 @@ impl State {
     pub async fn handle_request(&self, req: Request) -> Response {
         self.metrics.inc_requests();
         if !req.is_get_or_head() {
-            return Response::method_not_allowed()
+            return Response::method_not_allowed(req.is_api())
         }
 
         if let Some(response) = self.payload.handle_get_or_head(
@@ -87,7 +87,7 @@ impl State {
             return response
         }
         
-        Response::not_found()
+        Response::not_found(req.is_api())
     }
 }
 

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -44,7 +44,7 @@ async fn handle_metrics(
         (
             match history.metrics() {
                 Some(metrics) => metrics,
-                None => return Response::initial_validation(),
+                None => return Response::initial_validation(false),
             },
             history.serial(),
             history.last_update_start(),

--- a/src/http/payload.rs
+++ b/src/http/payload.rs
@@ -35,8 +35,8 @@ impl State {
         };
 
         let mut output = self.output.clone();
-        if output.update_from_query(req.uri().query()).is_err() {
-            return Some(Response::bad_request())
+        if let Err(err) = output.update_from_query(req.uri().query()) {
+            return Some(Response::bad_request(req.is_api(), err))
         };
 
         let (session, serial, created, snapshot, metrics) = {
@@ -53,7 +53,7 @@ impl State {
             (Some(snapshot), Some(metrics), Some(created)) => {
                 (snapshot, metrics, created)
             }
-            _ => return Some(Response::initial_validation()),
+            _ => return Some(Response::initial_validation(req.is_api())),
         };
 
         let etag = format!("\"{session:x}-{serial}\"");

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -31,6 +31,13 @@ impl Request {
     pub fn headers(&self) -> &HeaderMap {
         self.hyper.headers()
     }
+
+    /// Returns whether the request is an API request.
+    ///
+    /// API requests have their path start with `/api/`.
+    pub fn is_api(&self) -> bool {
+        self.hyper.uri().path().starts_with("/api/")
+    }
 }
 
 

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -46,7 +46,7 @@ async fn handle_status(
         (
             match history.metrics() {
                 Some(metrics) => metrics,
-                None => return Response::initial_validation(),
+                None => return Response::initial_validation(false),
             },
             history.serial(),
             history.last_update_start(),
@@ -333,7 +333,7 @@ async fn handle_api_status(
         (
             match history.metrics() {
                 Some(metrics) => metrics,
-                None => return Response::initial_validation()
+                None => return Response::initial_validation(true)
             },
             history.serial(),
             history.last_update_start(),

--- a/src/http/ui.rs
+++ b/src/http/ui.rs
@@ -45,14 +45,14 @@ pub fn handle_get_or_head(req: &Request) -> Option<Response> {
                 else {
                     // if CATCH_ALL_URL is not defined in ui_resources
                     // we'll return a 404
-                    Some(Response::not_found())
+                    Some(Response::not_found(false))
                 }
             }
         }
     } else {
         // This is the last handler in the chain, so if the requested URL did
         // not start with BASE_URL, we're returning 404.
-        Some(Response::not_found())
+        Some(Response::not_found(false))
     }
 }
 

--- a/src/http/validity.rs
+++ b/src/http/validity.rs
@@ -33,18 +33,17 @@ pub fn handle_get_or_head(
 fn handle_validity_path(
     head: bool, origins: &SharedHistory, path: &str
 ) -> Response {
-    let current = match validity_check(origins) {
-        Ok(current) => current,
-        Err(resp) => return resp
+    let Some(current) = origins.read().current() else {
+        return Response::initial_validation(true)
     };
     let mut path = path.splitn(2, '/');
     let asn = match path.next() {
         Some(asn) => asn,
-        None => return Response::bad_request()
+        None => return Response::bad_request(true, "missing ASN in path")
     };
     let prefix = match path.next() {
         Some(prefix) => prefix,
-        None => return Response::bad_request()
+        None => return Response::bad_request(true, "missing prefix in path")
     };
     validity(head, asn, prefix, current)
 }
@@ -54,13 +53,12 @@ fn handle_validity_query(
     origins: &SharedHistory,
     query: Option<&str>
 ) -> Response {
-    let current = match validity_check(origins) {
-        Ok(current) => current,
-        Err(resp) => return resp
+    let Some(current) = origins.read().current() else {
+        return Response::initial_validation(true)
     };
     let query = match query {
         Some(query) => query.as_bytes(),
-        None => return Response::bad_request()
+        None => return Response::bad_request(true, "missing query arguments")
     };
 
     let mut asn = None;
@@ -73,28 +71,28 @@ fn handle_validity_query(
             prefix = Some(value)
         }
         else {
-            return Response::bad_request()
+            return Response::bad_request(
+                true, format_args!("unexpected argument '{key}' in query")
+            )
         }
     }
     let asn = match asn {
         Some(asn) => asn,
-        None => return Response::bad_request()
+        None => {
+            return Response::bad_request(
+                true, "missing 'asn' argument in query"
+            )
+        }
     };
     let prefix = match prefix {
         Some(prefix) => prefix,
-        None => return Response::bad_request()
+        None => {
+            return Response::bad_request(
+                true, "missing 'prefix' argument in query"
+            )
+        }
     };
     validity(head, &asn, &prefix, current)
-}
-
-#[allow(clippy::result_large_err)]
-fn validity_check(
-    history: &SharedHistory
-) -> Result<Arc<PayloadSnapshot>, Response> {
-    match history.read().current() {
-        Some(history) => Ok(history),
-        None => Err(Response::initial_validation())
-    }
 }
 
 fn validity(
@@ -102,11 +100,11 @@ fn validity(
 ) -> Response {
     let asn = match Asn::from_str(asn) {
         Ok(asn) => asn,
-        Err(_) => return Response::bad_request()
+        Err(_) => return Response::bad_request(true, "invalid ASN")
     };
     let prefix = match Prefix::from_str_relaxed(prefix) {
         Ok(prefix) => prefix,
-        Err(_) => return Response::bad_request()
+        Err(_) => return Response::bad_request(true, "invalid prefix")
     };
     let res = ResponseBuilder::ok().content_type(ContentType::JSON);
     if head {


### PR DESCRIPTION
This PR adds the ability to produce a JSON body for HTTP error responses and uses this for all API-related errors.

This PR replaces #985. Fixes #925.