### PR TITLE
Remove rrdp-keep-responses feature.

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -327,15 +327,6 @@ The available options are:
       option can be given multiple times in which case proxies are tried in
       the given order.
 
-.. option:: --rrdp-keep-responses=path
-
-      If this option is enabled, the bodies of all HTTPS responses received
-      from RRDP servers will be stored under *path*. The sub-path will be
-      constructed using the components of the requested URI. For the
-      responses to the notification files, the timestamp is appended to the
-      path to make it possible to distinguish the series of requests made
-      over time.
-
 .. option:: --max-object-size=BYTES
 
       Limits the size of individual objects received via either rsync or RRDP
@@ -1209,14 +1200,6 @@ All values can be overridden via the command line options.
             A list of string each providing the URI for a proxy for outgoing
             RRDP connections. The proxies are tried in order for each
             request. HTTP and SOCKS5 proxies are supported.
-
-      rrdp-keep-responses
-            A string containing a path to a directory into which the bodies
-            of all HTTPS responses received from RRDP servers will be stored.
-            The sub-path will be constructed using the components of the
-            requested URI. For the responses to the notification files, the
-            timestamp is appended to the path to make it possible to
-            distinguish the series of requests made over time.
 
       max-object-size
             An integer value that provides a limit for the size of individual

--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -366,7 +366,7 @@ impl<'a> Run<'a> {
     /// This just downloads the file. It is not cached since that is done
     /// by the store anyway.
     pub fn load_ta(&self, uri: &uri::Https) -> Option<Bytes> {
-        let mut response = match self.collector.http.response(uri, false) {
+        let mut response = match self.collector.http.response(uri) {
             Ok(response) => response,
             Err(_) => return None,
         };

--- a/src/collector/rrdp/update.rs
+++ b/src/collector/rrdp/update.rs
@@ -59,7 +59,6 @@ impl Notification {
             uri,
             state.and_then(|state| state.etag.as_ref()),
             state.and_then(|state| state.last_modified()),
-            true
         ) {
             Ok(response) => {
                 *status = response.status().into();
@@ -192,7 +191,7 @@ impl<'a> SnapshotUpdate<'a> {
 
     pub fn try_update(mut self) -> Result<(), SnapshotError> {
         let response = match self.collector.http().response(
-            self.notify.content.snapshot().uri(), false
+            self.notify.content.snapshot().uri()
         ) {
             Ok(response) => {
                 self.metrics.payload_status = Some(response.status().into());
@@ -326,7 +325,7 @@ impl<'a> DeltaUpdate<'a> {
 
     pub fn try_update(mut self) -> Result<(), DeltaError> {
         let response = match self.collector.http().response(
-            self.info.uri(), false
+            self.info.uri()
         ) {
             Ok(response) => {
                 self.metrics.payload_status = Some(response.status().into());

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,9 +254,6 @@ pub struct Config {
     /// RRDP HTTP User Agent.
     pub rrdp_user_agent: String,
 
-    /// Should we keep RRDP responses and if so where?
-    pub rrdp_keep_responses: Option<PathBuf>,
-
     /// Optional size limit for objects.
     pub max_object_size: Option<u64>,
 
@@ -592,11 +589,6 @@ impl Config {
         // rrdp_proxies
         if let Some(list) = args.rrdp_proxy {
             self.rrdp_proxies = list
-        }
-
-        // rrdp_keep_responses
-        if let Some(path) = args.rrdp_keep_responses {
-            self.rrdp_keep_responses = Some(path)
         }
 
         // max_object_size
@@ -966,7 +958,6 @@ impl Config {
                 file.take_string_array("rrdp-proxies")?.unwrap_or_default()
             },
             rrdp_user_agent: DEFAULT_RRDP_USER_AGENT.to_string(),
-            rrdp_keep_responses: file.take_path("rrdp-keep-responses")?,
             max_object_size: {
                 match file.take_u64("max-object-size")? {
                     Some(0) => None,
@@ -1189,7 +1180,6 @@ impl Config {
             rrdp_root_certs: Vec::new(),
             rrdp_proxies: Vec::new(),
             rrdp_user_agent: DEFAULT_RRDP_USER_AGENT.to_string(),
-            rrdp_keep_responses: None,
             max_object_size: Some(DEFAULT_MAX_OBJECT_SIZE),
             max_ca_depth: DEFAULT_MAX_CA_DEPTH,
             enable_bgpsec: false,
@@ -1409,11 +1399,6 @@ impl Config {
                 }).collect()
             )
         );
-        if let Some(path) = self.rrdp_keep_responses.as_ref() {
-            insert(
-                &mut res,"rrdp-keep-responses", format!("{}", path.display())
-            );
-        }
         insert_int(
             &mut res, "max-object-size",
             self.max_object_size.unwrap_or(0),
@@ -1862,10 +1847,6 @@ struct GlobalArgs {
     /// Proxy server for RRDP (HTTP or SOCKS5)
     #[arg(long, value_name = "URI")]
     rrdp_proxy: Option<Vec<String>>,
-
-    /// Keep RRDP responses in the given directory
-    #[arg(long, value_name = "PATH")]
-    rrdp_keep_responses: Option<PathBuf>,
 
     /// Maximum size of downloaded objects (0 for no limit)
     #[arg(long, value_name = "BYTES")]


### PR DESCRIPTION
This PR removes the feature to store RRDP responses via the `rrdp-keep-responses` config option.

The feature is very rarely used but is somewhat tricky to get right and convenient. Instead, an HTTP proxy such as [mitmproxy](https://www.mitmproxy.org/) can be used to capture RRDP exchanges.

This is most definitely a breaking change. Fixes #935.