### PR TITLE
Add rrdp-read-timeout and revise timeout defaults.

### DIFF
--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -290,15 +290,21 @@ The available options are:
 
 .. option:: --rrdp-timeout=seconds
 
-      Sets the timeout in seconds for any RRDP-related network operation,
-      i.e., connects, reads, and writes. If this option is omitted, the
-      default timeout of 300 seconds is used. Set the option to 0 to disable
-      the timeout.
+      Sets the timeout in seconds for retrieving a resource from an RRDP
+      server. If this option is omitted, a default timeout of 600 seconds is
+      used. Set the option to 0 to disable the timeout.
+
+.. option:: --rrdp-read-timeout=seconds
+
+      Sets the timeout in seconds for RRDP-related network operation,
+      primarily waiting for the be able to read more data from the server.
+      If this option is omitted, a default timeout of 10 seconds is used.
+      Set the option to 0 to disable the timeout.
 
 .. option:: --rrdp-connect-timeout=seconds
 
       Sets the timeout in seconds for RRDP connect requests. If omitted, the
-      general timeout will be used.
+      read timeout will be used.
 
 .. option:: --rrdp-tcp-keepalive=seconds
 
@@ -1176,15 +1182,22 @@ All values can be overridden via the command line options.
             If the value is missing, the default of 500 is used.
 
       rrdp-timeout
-            An integer value that provides a timeout in seconds for all
-            individual RRDP-related network operations, i.e., connects,
-            reads, and writes. If the value is missing, a default timeout of
-            300 seconds will be used. Set the value to 0 to turn the timeout
-            off.
+            An integer value that provides a timeout in seconds for retrieving
+            a resource from an RRDP server. If the value is missing, a default
+            timeout of 600 seconds will be used. Set the value to 0 to turn
+            off the timout.
+
+      rrdp-read-timeout
+            An integer value that provides a timeout in seconds for 
+            RRDP-related network operations, primarily waiting for the be
+            able to read more data from the server. If the value is missing,
+            a default timeout of 10 seconds will be used. Set the value to 0
+            to turn off the timeout.
 
       rrdp-connect-timeout
             An integer value that, if present, sets a separate timeout in
-            seconds for RRDP connect requests only.
+            seconds for connecting to an RRDP. If this value is absent, the
+            RRDP read timeout is used.
 
       rrdp-tcp-keepalive
             An integer value that provides the duration in seconds for the

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -297,7 +297,7 @@ The available options are:
 .. option:: --rrdp-read-timeout=seconds
 
       Sets the timeout in seconds for RRDP-related network operation,
-      primarily waiting for the be able to read more data from the server.
+      primarily waiting to be able to read more data from the server.
       If this option is omitted, a default timeout of 10 seconds is used.
       Set the option to 0 to disable the timeout.
 
@@ -1185,11 +1185,11 @@ All values can be overridden via the command line options.
             An integer value that provides a timeout in seconds for retrieving
             a resource from an RRDP server. If the value is missing, a default
             timeout of 600 seconds will be used. Set the value to 0 to turn
-            off the timout.
+            off the timeout.
 
       rrdp-read-timeout
             An integer value that provides a timeout in seconds for 
-            RRDP-related network operations, primarily waiting for the be
+            RRDP-related network operations, primarily waiting to be
             able to read more data from the server. If the value is missing,
             a default timeout of 10 seconds will be used. Set the value to 0
             to turn off the timeout.

--- a/src/collector/rrdp/http.rs
+++ b/src/collector/rrdp/http.rs
@@ -52,6 +52,7 @@ impl HttpClient {
         builder = builder.redirect(
             redirect::Policy::custom(Self::redirect_policy)
         );
+        builder = builder.timeout(config.rrdp_read_timeout);
         if let Some(timeout) = config.rrdp_connect_timeout {
             builder = builder.connect_timeout(timeout);
         }


### PR DESCRIPTION
This PR adds a new `rrdp-read-timeout` config parameter which sets the timeout for all network operations related to RRDP. The default for this timeout is 10 seconds. As this is also used for the initial connect, this will make broken servers timeout much more quickly.

In addition, the PR changes the default for the `rrdp-timeout` value – which concerns the full exchange – to 600 seconds as we have seen some repositories time out the snapshot with the previous default of 300 seconds. We think it beneficiary to give them more time to finish the snapshot update rather than falling back to rsync and then trying again and failing again after five minutes for every validation run.

One question: Do we think 10 seconds is a good default for the `rrdp-read-timeout`? The default used by _reqwest_ is 30 seconds, but this seems to be really quite generous?