### PR TITLE
Fail initial run if TA certs are missing.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -556,8 +556,19 @@ impl<P: ProcessRun> Run<'_, P> {
                 }
             }
         }
-        warn!("No valid trust anchor for TAL {}", task.tal.info().name());
-        Ok(())
+        if self.initial {
+            info!(
+                "Initial quick validation failed: \
+                 no trust anchor for TAL {}.",
+                task.tal.info().name()
+            );
+            self.run_failed(RunFailed::retry());
+            Err(Failed)
+        }
+        else {
+            warn!("No valid trust anchor for TAL {}", task.tal.info().name());
+            Ok(())
+        }
     }
 
     /// Loads a trust anchor certificate with the given URI.


### PR DESCRIPTION
This PR cancels the optimistic initial run, thus falls back to a normal run without any data yet, if for any TAL there are no stored TA certificates.