### PR TITLE
Make the socket received from systemd non-blocking

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -108,6 +108,7 @@ impl Process {
                             "Fatal: error switching systemd socket to \
                             nonblocking: {err}"
                         );
+                        return Err(Failed);
                     }
                     Ok(Some(res))
                 }


### PR DESCRIPTION
By default the socket passed from systemd is blocking and needs to be made non-blocking to work with Tokio.