### PR TITLE
Fix --rrdp-tcp-keepalive to actually be an option.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,10 +12,13 @@ Bug fixes
 
 * Set an RTR listener socket received via systemd to non-blocking. This
   fixes a panic in Tokio. ([#1081] by [@MaxHearnden])
+* Fixed the `--rrdp-tcp-keepalive` to be a command line option rather than
+  a command line argument. ([1085])
 
 Other changes
 
 [#1081]: https://github.com/NLnetLabs/routinator/pull/1081
+[#1085]: https://github.com/NLnetLabs/routinator/pull/1085
 [@MaxHearnden]: https://github.com/MaxHearnden
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1890,7 +1890,7 @@ struct GlobalArgs {
     rrdp_connect_timeout: Option<u64>,
 
     /// TCP keepalive duration for RRDP connections (0 for none)
-    #[arg(value_name = "SECONDS")]
+    #[arg(long, value_name = "SECONDS")]
     rrdp_tcp_keepalive: Option<u64>,
 
     /// Local address for outgoing RRDP connections


### PR DESCRIPTION
This PR fixes command line processing and makes `--rrdp-tcp-keepalive` an option (as intended) rather than an argument. Not sure how that would even have worked with subcommands.