### PR TITLE
Redesign repository log messages

### DIFF
--- a/src/collector/rrdp/base.rs
+++ b/src/collector/rrdp/base.rs
@@ -799,13 +799,13 @@ impl<'a> RepositoryUpdate<'a> {
             LoadResult::Current
         }
         else if let Some(date) = best_before {
-            self.log.info(format_args!(
+            self.log.warn(format_args!(
                 "Update failed and current copy is expired since {date}.",
             ));
             LoadResult::Stale
         }
         else {
-            self.log.info(format_args!(
+            self.log.warn(format_args!(
                 "Update failed and there is no current copy."
             ));
             LoadResult::Unavailable
@@ -1023,7 +1023,7 @@ impl<'a> RepositoryUpdate<'a> {
             }
         }
 
-        self.log.debug(format_args!("Delta update completed."));
+        self.log.info(format_args!("Delta update completed."));
         Ok(None)
     }
 

--- a/src/collector/rsync.rs
+++ b/src/collector/rsync.rs
@@ -723,7 +723,7 @@ impl RsyncCommand {
             }
 
             if len > 0 {
-                target.log(level, format_args!("{}",
+                target.log(log::Level::Info, level, format_args!("{}",
                     String::from_utf8_lossy(&line[..len])
                 ));
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -823,7 +823,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 let file = match str_from_ascii(item.file()) {
                     Ok(file) => file,
                     Err(_) => {
-                        self.log.warn(format_args!(
+                        self.log.error(format_args!(
                             "manifest {} contains illegal file name '{}'.",
                             self.cert.rpki_manifest(),
                             String::from_utf8_lossy(item.file())
@@ -842,7 +842,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 let content = match collector.load_object(&uri)? {
                     Some(content) => content,
                     None => {
-                        self.log.warn(format_args!(
+                        self.log.error(format_args!(
                             "{uri}: failed to load."
                         ));
                         return Err(store::UpdateError::Abort)
@@ -850,7 +850,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 };
 
                 if hash.verify(&content).is_err() {
-                    self.log.warn(format_args!(
+                    self.log.error(format_args!(
                         "{uri}: file has wrong manifest hash."
                     ));
                     return Err(store::UpdateError::Abort)
@@ -908,7 +908,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(manifest) => manifest,
             Err(_) => {
                 self.metrics.invalid_manifests += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "failed to decode manifest {}.",
                     self.cert.rpki_manifest()
                 ));
@@ -1057,12 +1057,12 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Some(some) if some.ends_with(".crl") => some.clone(),
             Some(some) => {
                 self.metrics.invalid_manifests += 1;
-                self.log.warn(format_args!("invalid CRL URI {}", some));
+                self.log.error(format_args!("invalid CRL URI {}", some));
                 return Ok(None)
             }
             None => {
                 self.metrics.invalid_manifests += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "missing CRL URI on manifest {}",
                     self.cert.rpki_manifest()
                 ));
@@ -1073,7 +1073,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Some(name) => name,
             None => {
                 self.metrics.invalid_manifests += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "CRL URI {crl_uri} outside repository directory."
                 ));
                 return Ok(None)
@@ -1099,7 +1099,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
                 let hash = ManifestHash::new(hash, manifest.file_hash_alg());
                 if hash.verify(&bytes).is_err() {
                     self.metrics.invalid_crls += 1;
-                    self.log.warn(format_args!(
+                    self.log.error(format_args!(
                         "file {crl_uri} has wrong hash."
                     ));
                     return Ok(None)
@@ -1111,7 +1111,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Some(some) => some,
             None => {
                 self.metrics.invalid_crls += 1;
-                self.log.warn(format_args!("CRL not listed on manifest."));
+                self.log.error(format_args!("CRL not listed on manifest."));
                 return Ok(None)
             }
         };
@@ -1121,7 +1121,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(crl) => crl,
             Err(_) => {
                 self.metrics.invalid_crls += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "CRL {crl_uri}: failed to decode."
                 ));
                 return Ok(None)
@@ -1258,7 +1258,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(manifest) => manifest,
             Err(_) => {
                 self.metrics.invalid_manifests += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "failed to decode manifest {}.",
                     self.cert.rpki_manifest(),
                 ));
@@ -1315,7 +1315,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Err(_) => {
                 self.metrics.invalid_manifests += 1;
                 self.metrics.invalid_crls += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "failed to decode CRL {crl_uri}."
                 ));
                 return Err(Failed)
@@ -1472,7 +1472,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(cert) => cert,
             Err(_) => {
                 manifest.metrics.invalid_certs += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "certificate {uri}: failed to decode."
                 ));
                 return Ok(())
@@ -1495,7 +1495,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
         ca_task: &mut Vec<CaTask<P::PubPoint>>,
     ) -> Result<(), Failed> {
         if self.cert.check_loop(&cert).is_err() {
-            self.log.warn(format_args!(
+            self.log.error(format_args!(
                 "CA certificate {uri}: certificate loop detected."
             ));
             manifest.metrics.invalid_certs += 1;
@@ -1507,7 +1507,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(cert) => cert,
             Err(err) => {
                 self.log.warn(format_args!(
-                    "CA certificagte {uri}: {err}."
+                    "CA certificate {uri}: {err}."
                 ));
                 manifest.metrics.invalid_certs += 1;
                 return Ok(())
@@ -1598,7 +1598,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(roa) => roa,
             Err(_) => {
                 manifest.metrics.invalid_roas += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "ROA {uri}: failed to decode."
                 ));
                 return Ok(())
@@ -1635,7 +1635,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(aspa) => aspa,
             Err(err) => {
                 manifest.metrics.invalid_aspas += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "ASPA {uri}: failed to decode."
                 ));
                 return Ok(())
@@ -1671,7 +1671,7 @@ impl<'a, P: ProcessRun> PubPoint<'a, P> {
             Ok(obj) => obj,
             Err(_) => {
                 manifest.metrics.invalid_gbrs += 1;
-                self.log.warn(format_args!(
+                self.log.error(format_args!(
                     "GBR {uri}: failed to decode."
                 ));
                 return Ok(())

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -480,9 +480,6 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
-                                if message.level > log::max_level() {
-                                    continue;
-                                }
                                 target.array_object(|target| {
                                     target.member_str(
                                         "level", message.level
@@ -550,9 +547,6 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
-                                if message.level > log::max_level() {
-                                    continue;
-                                }
                                 target.array_object(|target| {
                                     target.member_str(
                                         "level", message.level
@@ -572,9 +566,6 @@ async fn handle_api_status(
             for (uri, book) in &metrics.pub_point_logs {
                 target.member_array(uri, |target| {
                     for message in book {
-                        if message.level > log::max_level() {
-                            continue;
-                        }
                         target.array_object(|target| {
                             target.member_str("level", message.level);
                             target.member_str("message", &message.content);

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -480,6 +480,9 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
+                                if message.level >= log::max_level() {
+                                    continue;
+                                }
                                 target.array_object(|target| {
                                     target.member_str(
                                         "level", message.level
@@ -547,6 +550,9 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
+                                if message.level >= log::max_level() {
+                                    continue;
+                                }
                                 target.array_object(|target| {
                                     target.member_str(
                                         "level", message.level
@@ -566,6 +572,9 @@ async fn handle_api_status(
             for (uri, book) in &metrics.pub_point_logs {
                 target.member_array(uri, |target| {
                     for message in book {
+                        if message.level >= log::max_level() {
+                            continue;
+                        }
                         target.array_object(|target| {
                             target.member_str("level", message.level);
                             target.member_str("message", &message.content);

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -480,7 +480,7 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
-                                if message.level >= log::max_level() {
+                                if message.level > log::max_level() {
                                     continue;
                                 }
                                 target.array_object(|target| {
@@ -550,7 +550,7 @@ async fn handle_api_status(
                     if let Some(book) = &metrics.log_book {
                         target.member_array("issues", |target| {
                             for message in book {
-                                if message.level >= log::max_level() {
+                                if message.level > log::max_level() {
                                     continue;
                                 }
                                 target.array_object(|target| {
@@ -572,7 +572,7 @@ async fn handle_api_status(
             for (uri, book) in &metrics.pub_point_logs {
                 target.member_array(uri, |target| {
                     for message in book {
-                        if message.level >= log::max_level() {
+                        if message.level > log::max_level() {
                             continue;
                         }
                         target.array_object(|target| {

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -485,6 +485,10 @@ async fn handle_api_status(
                                         "level", message.level
                                     );
                                     target.member_str(
+                                        "repository_level", 
+                                        message.repository_level
+                                    );
+                                    target.member_str(
                                         "messages", &message.content
                                     );
                                 })
@@ -552,6 +556,10 @@ async fn handle_api_status(
                                         "level", message.level
                                     );
                                     target.member_str(
+                                        "repository_level", 
+                                        message.repository_level
+                                    );
+                                    target.member_str(
                                         "messages", &message.content
                                     );
                                 })
@@ -568,7 +576,11 @@ async fn handle_api_status(
                     for message in book {
                         target.array_object(|target| {
                             target.member_str("level", message.level);
-                            target.member_str("message", &message.content);
+                            target.member_str(
+                                "repository_level", 
+                                message.repository_level
+                            );
+                            target.member_str("messages", &message.content);
                         });
                     }
                 });

--- a/src/log.rs
+++ b/src/log.rs
@@ -101,9 +101,11 @@ impl LogBookWriter {
     }
 
     pub fn log(&mut self, level: log::Level, args: fmt::Arguments<'_>) {
-        self.log_record(
-            &log::Record::builder().level(level).args(args).build()
-        )
+        if level <= log::max_level() {
+            self.log_record(
+                &log::Record::builder().level(level).args(args).build()
+            )
+        }
     }
 
     pub fn trace(&mut self, args: fmt::Arguments<'_>) {

--- a/src/log.rs
+++ b/src/log.rs
@@ -33,7 +33,7 @@ impl LogMessage {
         Self {
             when: Utc::now(),
             level: record.level(),
-            repository_level: repository_level,
+            repository_level,
             content: record.args().to_string(),
         }
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -21,14 +21,19 @@ use crate::utils::sync::{Mutex, RwLock};
 pub struct LogMessage {
     pub when: DateTime<Utc>,
     pub level: log::Level,
+    pub repository_level: log::Level,
     pub content: String,
 }
 
 impl LogMessage {
-    fn from_record(record: &Record<'_>) -> Self {
+    fn from_record(
+        record: &Record<'_>, 
+        repository_level: log::Level
+    ) -> Self {
         Self {
             when: Utc::now(),
             level: record.level(),
+            repository_level: repository_level,
             content: record.args().to_string(),
         }
     }
@@ -100,36 +105,50 @@ impl LogBookWriter {
         self.book
     }
 
-    pub fn log(&mut self, level: log::Level, args: fmt::Arguments<'_>) {
+    pub fn log(
+        &mut self, 
+        level: log::Level, 
+        repository_level: log::Level,
+        args: fmt::Arguments<'_>
+    ) {
         if level <= log::max_level() {
             self.log_record(
-                &log::Record::builder().level(level).args(args).build()
+                &log::Record::builder().level(level).args(args).build(),
+                repository_level
             )
         }
     }
 
     pub fn trace(&mut self, args: fmt::Arguments<'_>) {
-        self.log(log::Level::Trace, args);
+        self.log(log::Level::Trace, log::Level::Trace, args);
     }
 
     pub fn debug(&mut self, args: fmt::Arguments<'_>) {
-        self.log(log::Level::Debug, args);
+        self.log(log::Level::Debug, log::Level::Debug, args);
     }
 
     pub fn info(&mut self, args: fmt::Arguments<'_>) {
-        self.log(log::Level::Info, args);
+        self.log(log::Level::Info, log::Level::Info, args);
     }
 
+    // The log level set to Info is intentional. We do not want to show a
+    // warning in the logging when it is the repository's fault
     pub fn warn(&mut self, args: fmt::Arguments<'_>) {
-        self.log(log::Level::Info, args);
+        self.log(log::Level::Info, log::Level::Warn, args);
     }
 
+    // The log level set to Info is intentional. We do not want to show an
+    // error in the logging when it is the repository's fault
     pub fn error(&mut self, args: fmt::Arguments<'_>) {
-        self.log(log::Level::Error, args);
+        self.log(log::Level::Info, log::Level::Error, args);
     }
 
     /// Writes a log record.
-    pub fn log_record(&mut self, record: &Record<'_>) {
+    pub fn log_record(
+        &mut self, 
+        record: &Record<'_>, 
+        repository_level: log::Level
+    ) {
         let logger = log::logger();
 
         // We use the level filter from the global log which should be set
@@ -137,7 +156,9 @@ impl LogBookWriter {
         if !logger.enabled(record.metadata()) {
             return
         }
-        self.book.messages.push(LogMessage::from_record(record));
+        self.book.messages.push(
+            LogMessage::from_record(record, repository_level)
+        );
         if let Some(prefix) = self.process_prefix.as_ref() {
             logger.log(
                 &log::Record::builder()

--- a/src/log.rs
+++ b/src/log.rs
@@ -111,7 +111,7 @@ impl LogBookWriter {
         repository_level: log::Level,
         args: fmt::Arguments<'_>
     ) {
-        if level <= log::max_level() {
+        if level <= log::max_level() || repository_level <= log::max_level() {
             self.log_record(
                 &log::Record::builder().level(level).args(args).build(),
                 repository_level


### PR DESCRIPTION
This PR does a few things:
- Only outputs log messages to the /status endpoint that meet the minimum log level
- Introduces a `repository_level` that indicates the log level from the publication point's perspective (so a broken manifest is an ERROR from the publication point's POV, but only an INFO from Routinator's POV)
- Makes pubPointIssues the same as the issues for rrdp and rsync in the /status endpoint