### PR TITLE
Don’t exit on socket accept errors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,11 @@ Bug fixes
   fixes a panic in Tokio. ([#1081] by [@MaxHearnden])
 * Fixed the `--rrdp-tcp-keepalive` to be a command line option rather than
   a command line argument. ([1085])
+* Changed how transient errors when accepting incoming HTTP and RTR
+  connections are handled: instead of exiting, a warning is printed and
+  the error is ignored. ([#1099])
+
+  This issue was assigned [CVE-2026-49232].
 
 Other changes
 
@@ -28,6 +33,7 @@ Other changes
 [#1081]: https://github.com/NLnetLabs/routinator/pull/1081
 [#1085]: https://github.com/NLnetLabs/routinator/pull/1085
 [@MaxHearnden]: https://github.com/MaxHearnden
+[CVE-2026-49232]: https://nlnetlabs.nl/downloads/routinator/CVE-2026-49232.txt
 
 
 

--- a/src/http/listener.rs
+++ b/src/http/listener.rs
@@ -6,12 +6,13 @@ use std::net::{SocketAddr, TcpListener as StdListener};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use futures::pin_mut;
 use futures::future::{pending, select_all};
 use hyper::service::service_fn;
 use hyper::Method;
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use log::error;
+use log::{error, warn};
 use rpki::rtr::server::NotifySender;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpListener;
@@ -125,8 +126,9 @@ async fn single_http_listener(
         let stream = match listener.accept().await {
             Ok(some) => some,
             Err(err) => {
-                error!("Fatal error in HTTP server {addr}: {err}");
-                break;
+                warn!("Accept error in HTTP server {addr}: {err}");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
             }
         };
         let service_state = state.clone();

--- a/src/rtr.rs
+++ b/src/rtr.rs
@@ -9,11 +9,13 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use futures::{pin_mut, Stream};
 use futures::future::{pending, select_all};
-use log::error;
+use log::{error, warn};
+use pin_project_lite::pin_project;
 use rpki::rtr::server::{NotifySender, Server, Socket};
 use rpki::rtr::state::State;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::time::Sleep;
 use tokio_rustls::TlsAcceptor;
 use crate::config::Config;
 use crate::error::ExitError;
@@ -118,7 +120,8 @@ async fn single_rtr_listener(
     };
     let tls = tls.map(TlsAcceptor::from);
     let listener = RtrListener {
-        tcp: listener, tls, keepalive, server_metrics
+        tcp: listener, backoff: None,
+        tls, keepalive, server_metrics, addr: addr.clone(),
     };
     if let Err(err) = Server::new(
         listener, sender, origins.clone()
@@ -130,12 +133,16 @@ async fn single_rtr_listener(
 
 //------------ RtrListener --------------------------------------------------
 
-/// A wrapper around an TCP listener that produces RTR streams.
-struct RtrListener {
-    tcp: TcpListener,
-    tls: Option<TlsAcceptor>,
-    keepalive: Option<Duration>,
-    server_metrics: Arc<RtrServerMetrics>,
+pin_project! {
+    /// A wrapper around an TCP listener that produces RTR streams.
+    struct RtrListener {
+        tcp: TcpListener,
+        backoff: Option<Pin<Box<Sleep>>>,
+        tls: Option<TlsAcceptor>,
+        keepalive: Option<Duration>,
+        server_metrics: Arc<RtrServerMetrics>,
+        addr: String,
+    }
 }
 
 impl Stream for RtrListener {
@@ -145,18 +152,31 @@ impl Stream for RtrListener {
         self: Pin<&mut Self>,
         ctx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.tcp.poll_accept(ctx) {
+        let this = self.project();
+        if let Some(backoff) = this.backoff.as_mut() {
+            if matches!(backoff.as_mut().poll(ctx), Poll::Pending) {
+                return Poll::Pending;
+            }
+            *this.backoff = None;
+        }
+        match this.tcp.poll_accept(ctx) {
             Poll::Ready(Ok((sock, addr))) => {
                 match RtrStream::new(
                     sock, addr,
-                    self.tls.as_ref(), self.keepalive,
-                    &self.server_metrics,
+                    this.tls.as_ref(), *this.keepalive,
+                    this.server_metrics,
                 ) {
                     Ok(stream) => Poll::Ready(Some(Ok(stream))),
                     Err(_) => Poll::Pending,
                 }
             }
-            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
+            Poll::Ready(Err(err)) => {
+                warn!("Accept error in RTR server {}: {}", this.addr, err);
+                *this.backoff = Some(Box::pin(
+                    tokio::time::sleep(Duration::from_millis(100))
+                ));
+                Poll::Pending
+            }
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
This PR changes the logic for dealing with errors returned from accepting a new connection in HTTP and RTR listeners from causing Routinator to exit to warn and ignore.

The issue fixed by this PR was assigned CVE-2026-49232.