### PR TITLE
Update nix to 0.31.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ uuid            = "1.1"
 
 
 [target.'cfg(unix)'.dependencies]
-nix             = { version = "0.30.1", features = ["fs", "mman", "net", "process", "socket", "user"] }
+nix             = { version = "0.31.3", features = ["fs", "mman", "net", "process", "socket", "user"] }
 syslog          = "7"
 
 [features]


### PR DESCRIPTION
This PR update the `nix` dependency to 0.31.3. It appears that none of the breaking changes affect us.

Fixes #1104.