### PR TITLE
Add SLURM v2 input filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.86.0, stable, beta]
+        rust: [1.87.0, stable, beta]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +180,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -226,6 +252,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -343,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +450,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -853,6 +900,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1312,7 +1369,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1354,11 +1411,11 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157a0b503ef5d3821bae79d2d4f44e1f5655eacdcc1b67623dd4403cd9ee302"
+version = "0.20.0-dev"
+source = "git+https://github.com/NLnetLabs/rpki-rs?branch=slurm-aspa-fields#4c2ebccbb965b1664218fb2a070d7efd68291a16"
 dependencies = [
  "arbitrary",
+ "aws-lc-rs",
  "base64",
  "bcder",
  "bytes",
@@ -1366,11 +1423,9 @@ dependencies = [
  "futures-util",
  "log",
  "quick-xml",
- "ring",
  "serde",
  "serde_json",
  "tokio",
- "untrusted",
  "uuid",
 ]
 
@@ -1435,7 +1490,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1938,6 +1993,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "routinator"
 version = "0.15.3-dev"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.87"
 resolver = "3"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "An RPKI relying party software."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ pin-project-lite = "0.2.4"
 rand            = "0.9.0"
 reqwest         = { version = "0.12.4", default-features = false, features = ["blocking", "rustls-tls", "gzip" ] }
 ring            = "0.17"
-rpki            = { version = "0.19.3", features = [ "repository", "rrdp", "rtr", "serde", "slurm" ] }
+rpki            = { features = [ "repository", "rrdp", "rtr", "serde", "slurm" ], git = "https://github.com/NLnetLabs/rpki-rs", branch = "slurm-aspa-fields" }
 rustls-pemfile  = "2.1.2"
 serde           = { version = "1.0.95", features = [ "derive" ] }
 serde_json      = "1.0.57"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,13 @@ Breaking changes
 
 New
 
+* Add SLURM v2 input filtering support
+
 Improvements
 
 Bug fixes
+
+* Fix field names to match the latest SLURM v2 draft
 
 Other changes
 

--- a/src/payload/validation.rs
+++ b/src/payload/validation.rs
@@ -752,7 +752,11 @@ impl<'a> SnapshotBuilder<'a> {
     fn process_aspa(&mut self, aspa: PubAspa, metrics: &mut AllVrpMetrics) {
         metrics.update(|m| m.aspas.valid += 1);
 
-        // SLURM filtering goes here ...
+        // Is the ASPA to be filtered locally?
+        if self.exceptions.drop_aspa(aspa.customer) {
+            metrics.update(|m| m.aspas.locally_filtered += 1);
+            return
+        }
 
         match self.aspas.entry(aspa.customer) {
             hash_map::Entry::Vacant(entry) => {
@@ -825,7 +829,26 @@ impl<'a> SnapshotBuilder<'a> {
             }
         }
 
-        // XXX ASPA assertions.
+        for (aspa, info) in self.exceptions.aspa_assertions() {
+            match self.aspas.entry(aspa.customer) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert((
+                        SmallAsnSet::from_iter(aspa.providers.iter()), 
+                        info.into()
+                    ));
+                    metrics.local.aspas.contributed += 1;
+                    metrics.snapshot.payload.aspas.contributed += 1;
+                },
+                hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().0 = entry.get().0.union(
+                        &SmallAsnSet::from_iter(aspa.providers.iter())
+                    ).collect();
+                    entry.get_mut().1.add_local(info);
+                    metrics.local.aspas.duplicate += 1;
+                    metrics.snapshot.payload.aspas.duplicate += 1;
+                },
+            }
+        }
     }
 
     fn into_snapshot(self, metrics: &mut Metrics) -> PayloadSnapshot {

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -5,8 +5,10 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use log::error;
-use rpki::rtr::payload::{RouteOrigin, RouterKey};
-use rpki::slurm::{BgpsecFilter, PrefixFilter, SlurmFile};
+use rpki::resources::Asn;
+use rpki::rtr::payload::{Aspa, RouteOrigin, RouterKey};
+use rpki::rtr::pdu::ProviderAsns;
+use rpki::slurm::{AspaFilter, BgpsecFilter, PrefixFilter, SlurmFile};
 use crate::config::Config;
 use crate::error::Failed;
 
@@ -17,9 +19,11 @@ use crate::error::Failed;
 pub struct LocalExceptions {
     origin_filters: Vec<PrefixFilter>,
     router_key_filters: Vec<BgpsecFilter>,
+    aspa_filters: Vec<AspaFilter>,
 
     origin_assertions: Vec<(RouteOrigin, Arc<ExceptionInfo>)>,
     router_key_assertions: Vec<(RouterKey, Arc<ExceptionInfo>)>,
+    aspa_assertions: Vec<(Aspa, Arc<ExceptionInfo>)>,
 }
 
 impl LocalExceptions {
@@ -121,6 +125,15 @@ impl LocalExceptions {
                 item
             })
         );
+        self.aspa_filters.extend(
+            json.filters.aspa.unwrap_or_default()
+                    .into_iter().map(|mut item| {
+                if !keep_comments {
+                    item.comment = None
+                }
+                item
+            })
+        );
         self.origin_assertions.extend(
             json.assertions.prefix.into_iter().map(|item| {
                 (
@@ -149,6 +162,22 @@ impl LocalExceptions {
                 )
             })
         );
+        self.aspa_assertions.extend(
+            json.assertions.aspa.unwrap_or_default()
+                    .into_iter().map(|item| {
+                (
+                    Aspa::new(
+                        item.customer_asn, item.provider_asns
+                    ),
+                    info.cloned().unwrap_or_else(|| {
+                        Arc::new(ExceptionInfo {
+                            path: path.clone(),
+                            comment: item.comment,
+                        })
+                    })
+                )
+            })
+        );
     }
 
     pub fn drop_origin(&self, origin: RouteOrigin) -> bool {
@@ -158,6 +187,12 @@ impl LocalExceptions {
     pub fn drop_router_key(&self, key: &RouterKey) -> bool {
         self.router_key_filters.iter().any(|filter| {
             filter.drop_router_key(key)
+        })
+    }
+
+    pub fn drop_aspa(&self, customer: Asn) -> bool {
+        self.aspa_filters.iter().any(|filter| {
+            filter.drop_aspa(&Aspa::new(customer, ProviderAsns::empty()))
         })
     }
 
@@ -174,6 +209,14 @@ impl LocalExceptions {
     ) -> impl Iterator<Item = (RouterKey, Arc<ExceptionInfo>)> + '_ {
         self.router_key_assertions.iter().map(|(key, info)| {
             (key.clone(), info.clone())
+        })
+    }
+
+    pub fn aspa_assertions(
+        &self
+    ) -> impl Iterator<Item = (Aspa, Arc<ExceptionInfo>)> + '_ {
+        self.aspa_assertions.iter().map(|(aspa, info)| {
+            (aspa.clone(), info.clone())
         })
     }
 }

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use log::error;
 use rpki::resources::Asn;
 use rpki::rtr::payload::{Aspa, RouteOrigin, RouterKey};
-use rpki::rtr::pdu::ProviderAsns;
 use rpki::slurm::{AspaFilter, BgpsecFilter, PrefixFilter, SlurmFile};
 use crate::config::Config;
 use crate::error::Failed;
@@ -192,7 +191,7 @@ impl LocalExceptions {
 
     pub fn drop_aspa(&self, customer: Asn) -> bool {
         self.aspa_filters.iter().any(|filter| {
-            filter.drop_aspa(&Aspa::new(customer, ProviderAsns::empty()))
+            filter.drop_aspa(customer)
         })
     }
 


### PR DESCRIPTION
As mentioned in #1018, this PR adds SLURM v2 input. Routinator already supports SLURM v2 as output. Relies on https://github.com/NLnetLabs/rpki-rs/pull/380