### PR TITLE
Enable ASPA and BGPsec by default, set mode to strict

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,12 @@
 
 Breaking changes
 
+* ASPA and BGPsec are now enabled by default. The command line options 
+`--enable-aspa` and `--enable-bgpsec` have been replaced with `--disable-aspa`
+and `--disable-bgpsec`. 
+* Strict mode is now enabled by default. `--strict` has been replaced with
+`--disable-strict`.
+
 New
 
 Improvements

--- a/doc/manual/source/advanced-features.rst
+++ b/doc/manual/source/advanced-features.rst
@@ -23,9 +23,7 @@ one or more other ASes as its upstream providers. When validated, an ASPA's
 content can be used for detection and mitigation of route leaks.
 
 You can let Routinator process ASPA objects and include them in the published
-dataset, as well as the metrics, using the :option:`--enable-aspa` option
-or by setting ``enable-aspa`` to True in the :doc:`configuration
-file<configuration>`. ASPA information will be exposed via RTR, as well as
+dataset. ASPA information will be exposed via RTR, as well as
 in the :term:`json` and :term:`jsonext` output formats, e.g.:
 
 .. code-block:: json
@@ -96,9 +94,7 @@ RPKI. As there is currently very limited deployment, validating these objects
 with Routinator is not enabled by default.
 
 You can let Routinator process router keys and include them in the published
-dataset, as well as the metrics, using the :option:`--enable-bgpsec` option
-or by setting ``enable-bgpsec`` to True in the :doc:`configuration
-file<configuration>`. BGPsec information will be exposed via RTR, as well as
+dataset. BGPsec information will be exposed via RTR, as well as
 in the :term:`SLURM`, :term:`json` and :term:`jsonext` output formats, e.g.:
 
 .. code-block:: json

--- a/doc/manual/source/configuration.rst
+++ b/doc/manual/source/configuration.rst
@@ -105,8 +105,8 @@ own:
       dirty = false
       disable-rrdp = false
       disable-rsync = false
-      enable-aspa = false
-      enable-bgpsec = false
+      enable-aspa = true
+      enable-bgpsec = true
       exceptions = []
       expire = 7200
       history-size = 10
@@ -131,7 +131,7 @@ own:
       rtr-tcp-keepalive = 60
       rtr-tls-listen = []
       stale = "reject"
-      strict = false
+      strict = true
       syslog-facility = "daemon"
       systemd-listen = false
       unknown-objects = "warn"

--- a/doc/manual/source/manual-page.rst
+++ b/doc/manual/source/manual-page.rst
@@ -102,13 +102,11 @@ The available options are:
       should be filtered out of the output as well as origins that should be
       added.
 
-.. option:: --strict
+.. option:: --disable-strict
 
-      If this option is present, the repository will be validated in strict
+      If this option is present, the repository won't be validated in strict
       mode following the requirements laid out by the standard documents very
-      closely. With the current RPKI repository, using this option will lead
-      to a rather large amount of invalid route origins and should therefore
-      not be used in practice.
+      closely. 
 
       See `RELAXED DECODING`_ below for more information.
 
@@ -345,15 +343,15 @@ The available options are:
       The maximum number of CAs a given CA may be away from a trust anchor
       certificate before it is rejected. The default value is 32.
 
-.. option:: --enable-bgpsec
+.. option:: --disable-bgpsec
 
-      If this option is present, BGPsec router keys will be processed
-      during validation and included in the produced data set.
+      If this option is present, BGPsec router keys will not be processed
+      during validation and not included in the produced data set.
 
-.. option:: --enable-aspa
+.. option:: --disable-aspa
 
-      If this option is present, ASPA assertions will be processed
-      during validation and included in the produced data set.
+      If this option is present, ASPA assertions will not be processed
+      during validation and not included in the produced data set.
 
 .. option:: --dirty
 
@@ -1067,7 +1065,7 @@ All values can be overridden via the command line options.
 
       strict
             A boolean specifying whether strict validation should be
-            employed. If missing, strict validation will not be used.
+            employed. If missing or true, strict validation will be used.
 
       stale
             A string specifying the policy for dealing with stale objects.
@@ -1236,14 +1234,14 @@ All values can be overridden via the command line options.
 
       enable-bgpsec
             A boolean value specifying whether BGPsec router keys should be
-            included in the published dataset. If false or missing, no router
-            keys will be included.
+            included in the published dataset. If false, no router
+            keys will be included. Enabled by default.
 
 
       enable-aspa
             A boolean value specifying whether ASPA assertions should be
-            included in the published dataset. If false or missing, no ASPA
-            assertions will be included.
+            included in the published dataset. If false, no ASPA
+            assertions will be included. Enabled by default.
 
       dirty
             A boolean value which, if true, specifies that unused files and
@@ -1603,11 +1601,11 @@ the formatting of the objects published in the RPKI repository. However,
 because RPKI reuses existing technology, real-world applications produce
 objects that do not follow these strict requirements.
 
-As a consequence, a significant portion of the RPKI repository is actually
-invalid if the rules are followed. We therefore introduce two decoding modes:
+As a consequence, a significant portion of the RPKI repository used to be
+invalid if the rules are followed. We therefore introduced two decoding modes:
 strict and relaxed. Strict mode rejects any object that does not pass all
 checks laid out by the relevant RFCs. Relaxed mode ignores a number of these
-checks.
+checks. Nowadays nearly all objects follow the strict requirements.
 
 This memo documents the violations we encountered and are dealing with in
 relaxed decoding mode.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2781,7 +2781,7 @@ mod test {
             config.extra_tals_dir.unwrap().to_str().unwrap(), "/test/taldir"
         );
         assert!(config.exceptions.is_empty());
-        assert!(!config.strict);
+        assert!(config.strict);
         assert_eq!(
             config.validation_threads,
             Config::default_validation_threads()
@@ -2818,7 +2818,7 @@ mod test {
     fn basic_args() {
         let config = process_basic_args(&[
             "routinator", "-r", "/repository",
-            "-x", "/x1", "--exceptions", "x2", "--strict",
+            "-x", "/x1", "--exceptions", "x2",
             "--validation-threads", "2000",
             "--syslog", "--syslog-facility", "auth"
         ]);

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ use crate::error::Failed;
 //------------ Defaults for Some Values --------------------------------------
 
 /// Are we doing strict validation by default?
-const DEFAULT_STRICT: bool = false;
+const DEFAULT_STRICT: bool = true;
 
 /// The default timeout for running rsync commands in seconds.
 const DEFAULT_RSYNC_TIMEOUT: Duration = Duration::from_secs(300);
@@ -483,8 +483,8 @@ impl Config {
         }
 
         // strict
-        if args.strict {
-            self.strict = true
+        if args.disable_strict {
+            self.strict = false
         }
 
         // stale
@@ -635,13 +635,13 @@ impl Config {
         }
 
         // enable_bgpsec
-        if args.enable_bgpsec {
-            self.enable_bgpsec = true
+        if args.disable_bgpsec {
+            self.enable_bgpsec = false
         }
 
         // enable_aspa
-        if args.enable_aspa {
-            self.enable_aspa = true
+        if args.disable_aspa {
+            self.enable_aspa = false
         }
 
         // dirty_repository
@@ -917,7 +917,7 @@ impl Config {
             exceptions: {
                 file.take_path_array("exceptions")?.unwrap_or_default()
             },
-            strict: file.take_bool("strict")?.unwrap_or(false),
+            strict: file.take_bool("strict")?.unwrap_or(true),
             stale: {
                 file.take_from_str("stale")?.unwrap_or(DEFAULT_STALE_POLICY)
             },
@@ -1009,9 +1009,9 @@ impl Config {
                 file.take_usize("max-ca-depth")?
                     .unwrap_or(DEFAULT_MAX_CA_DEPTH)
             },
-            enable_bgpsec: file.take_bool("enable-bgpsec")?.unwrap_or(false),
+            enable_bgpsec: file.take_bool("enable-bgpsec")?.unwrap_or(true),
 
-            enable_aspa: file.take_bool("enable-aspa")?.unwrap_or(false),
+            enable_aspa: file.take_bool("enable-aspa")?.unwrap_or(true),
 
             dirty_repository: file.take_bool("dirty")?.unwrap_or(false),
             validation_threads: {
@@ -1226,8 +1226,8 @@ impl Config {
             rrdp_user_agent: DEFAULT_RRDP_USER_AGENT.to_string(),
             max_object_size: Some(DEFAULT_MAX_OBJECT_SIZE),
             max_ca_depth: DEFAULT_MAX_CA_DEPTH,
-            enable_bgpsec: false,
-            enable_aspa: false,
+            enable_bgpsec: true,
+            enable_aspa: true,
             dirty_repository: DEFAULT_DIRTY_REPOSITORY,
             validation_threads: Config::default_validation_threads(),
             refresh: Duration::from_secs(DEFAULT_REFRESH),
@@ -1807,7 +1807,7 @@ struct GlobalArgs {
 
     /// Parse RPKI data in strict mode
     #[arg(long)]
-    strict: bool,
+    disable_strict: bool,
 
     /// The policy for handling stale objects
     #[arg(long, value_name = "POLICY")]
@@ -1915,11 +1915,11 @@ struct GlobalArgs {
 
     /// Include BGPsec router keys in the data set
     #[arg(long)]
-    enable_bgpsec: bool,
+    disable_bgpsec: bool,
 
     /// Include ASPA in the data set
     #[arg(long)]
-    enable_aspa: bool,
+    disable_aspa: bool,
 
     /// Do not clean up repository directory after validation
     #[arg(long)]


### PR DESCRIPTION
This PR changes the default ASPA and BGPsec configuration to enabled. It also changed the command line interface from `--enable-aspa` to `--disable-aspa`. It also sets `strict` by default.